### PR TITLE
Updated windows workflow for compressed native binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Compress and basic test of (compressed) native fcli
       run: |
         mkdir .\native-image\win\compressed
-        .\upx\upx-3.96-win64\upx.exe -o .\native-image\win\compressed\fcli.exe .\native-image\win\fcli.exe
+        .\upx-3.96-win64\upx.exe -o .\native-image\win\compressed\fcli.exe .\native-image\win\fcli.exe
         .\native-image\win\compressed\fcli.exe --help 
         .\native-image\win\compressed\fcli.exe fod --help
 


### PR DESCRIPTION
Updated windows workflow for compressed native binary. You may wish to not keep the uncompressed version, but everything else to download UPX, extract it, and then compress fcli.exe, is all there.