### PR TITLE
FoD: Add ability to automatically set required attributes when creating an application

### DIFF
--- a/fcli-fod/src/main/java/com/fortify/cli/fod/entity/app/attr/cli/helper/FoDPickListDescriptor.java
+++ b/fcli-fod/src/main/java/com/fortify/cli/fod/entity/app/attr/cli/helper/FoDPickListDescriptor.java
@@ -25,26 +25,14 @@
 package com.fortify.cli.fod.entity.app.attr.cli.helper;
 
 import com.fortify.cli.common.json.JsonNodeHolder;
-
 import io.micronaut.core.annotation.ReflectiveAccess;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-import java.util.ArrayList;
-import java.util.Map;
-
 @ReflectiveAccess
 @Data
 @EqualsAndHashCode(callSuper = true)
-public class FoDAttributeDescriptor extends JsonNodeHolder {
+public class FoDPickListDescriptor extends JsonNodeHolder {
     private Integer id;
     private String name;
-    private Integer attributeTypeId;
-    private String attributeType;
-    private Integer attributeDataTypeId;
-    private String attributeDataType;
-    private Boolean isRequired;
-    private Boolean isRestricted;
-    private ArrayList<FoDPickListDescriptor> picklistValues;
-    private String value;
 }

--- a/fcli-fod/src/main/java/com/fortify/cli/fod/entity/app/cli/cmd/FoDAppCreateAppCommand.java
+++ b/fcli-fod/src/main/java/com/fortify/cli/fod/entity/app/cli/cmd/FoDAppCreateAppCommand.java
@@ -68,6 +68,8 @@ public abstract class FoDAppCreateAppCommand extends AbstractFoDJsonNodeOutputCo
     protected String owner;
     @Option(names = {"--user-groups", "--groups"}, required = false, split=",")
     protected ArrayList<String> userGroups;
+    @Option(names={"--auto-required-attrs"}, required = false)
+    protected boolean autoRequiredAttrs = false;
 
     @Mixin
     protected FoDCriticalityTypeOptions.RequiredOption criticalityType;
@@ -94,7 +96,7 @@ public abstract class FoDAppCreateAppCommand extends AbstractFoDJsonNodeOutputCo
                 .setOwnerId(userDescriptor.getUserId())
                 .setApplicationType(FoDAppTypeOptions.FoDAppType.Web.getName())
                 .setHasMicroservices(false)
-                .setAttributes(FoDAttributeHelper.getAttributesNode(unirest, appAttrs.getAttributes()))
+                .setAttributes(FoDAttributeHelper.getAttributesNode(unirest, appAttrs.getAttributes(), autoRequiredAttrs))
                 .setUserGroupIds(FoDUserGroupHelper.getUserGroupsNode(unirest, userGroups));
 
         return FoDAppHelper.createApp(unirest, appCreateRequest).asJsonNode();

--- a/fcli-fod/src/main/java/com/fortify/cli/fod/entity/app/cli/cmd/FoDAppCreateMicroserviceAppCommand.java
+++ b/fcli-fod/src/main/java/com/fortify/cli/fod/entity/app/cli/cmd/FoDAppCreateMicroserviceAppCommand.java
@@ -67,9 +67,10 @@ public class FoDAppCreateMicroserviceAppCommand extends FoDAppCreateAppCommand {
                 .setOwnerId(userDescriptor.getUserId())
                 .setApplicationType(FoDAppTypeOptions.FoDAppType.Microservice.getName())
                 .setHasMicroservices(true)
+                .setAutoReqdAttrs(autoRequiredAttrs)
                 .setMicroservices(FoDAppHelper.getMicroservicesNode(microservices))
                 .setReleaseMicroserviceName(releaseMicroservice)
-                .setAttributes(FoDAttributeHelper.getAttributesNode(unirest, appAttrs.getAttributes()))
+                .setAttributes(FoDAttributeHelper.getAttributesNode(unirest, appAttrs.getAttributes(), autoRequiredAttrs))
                 .setUserGroupIds(FoDUserGroupHelper.getUserGroupsNode(unirest, userGroups));
 
         return FoDAppHelper.createApp(unirest, appCreateRequest).asJsonNode();

--- a/fcli-fod/src/main/java/com/fortify/cli/fod/entity/app/cli/cmd/FoDAppCreateMobileAppCommand.java
+++ b/fcli-fod/src/main/java/com/fortify/cli/fod/entity/app/cli/cmd/FoDAppCreateMobileAppCommand.java
@@ -60,7 +60,8 @@ public class FoDAppCreateMobileAppCommand extends FoDAppCreateAppCommand {
                 .setOwnerId(userDescriptor.getUserId())
                 .setApplicationType(FoDAppTypeOptions.FoDAppType.Mobile.getName())
                 .setHasMicroservices(false)
-                .setAttributes(FoDAttributeHelper.getAttributesNode(unirest, appAttrs.getAttributes()))
+                .setAutoReqdAttrs(autoRequiredAttrs)
+                .setAttributes(FoDAttributeHelper.getAttributesNode(unirest, appAttrs.getAttributes(), autoRequiredAttrs))
                 .setUserGroupIds(FoDUserGroupHelper.getUserGroupsNode(unirest, userGroups));
 
         return FoDAppHelper.createApp(unirest, appCreateRequest).asJsonNode();

--- a/fcli-fod/src/main/java/com/fortify/cli/fod/entity/app/cli/cmd/FoDAppCreateWebAppCommand.java
+++ b/fcli-fod/src/main/java/com/fortify/cli/fod/entity/app/cli/cmd/FoDAppCreateWebAppCommand.java
@@ -60,7 +60,8 @@ public class FoDAppCreateWebAppCommand extends FoDAppCreateAppCommand {
                 .setOwnerId(userDescriptor.getUserId())
                 .setApplicationType(FoDAppTypeOptions.FoDAppType.Web.getName())
                 .setHasMicroservices(false)
-                .setAttributes(FoDAttributeHelper.getAttributesNode(unirest, appAttrs.getAttributes()))
+                .setAutoReqdAttrs(autoRequiredAttrs)
+                .setAttributes(FoDAttributeHelper.getAttributesNode(unirest, appAttrs.getAttributes(), autoRequiredAttrs))
                 .setUserGroupIds(FoDUserGroupHelper.getUserGroupsNode(unirest, userGroups));
 
         return FoDAppHelper.createApp(unirest, appCreateRequest).asJsonNode();

--- a/fcli-fod/src/main/java/com/fortify/cli/fod/entity/app/helper/FoDAppCreateRequest.java
+++ b/fcli-fod/src/main/java/com/fortify/cli/fod/entity/app/helper/FoDAppCreateRequest.java
@@ -50,6 +50,7 @@ public class FoDAppCreateRequest {
     private String releaseMicroserviceName;
     private JsonNode attributes;
     private JsonNode userGroupIds;
+    private Boolean autoRequiredAttrs;
 
     public FoDAppCreateRequest setApplicationName(String name) {
         this.applicationName = name;
@@ -122,6 +123,11 @@ public class FoDAppCreateRequest {
 
     public FoDAppCreateRequest setUserGroupIds(JsonNode ids) {
         this.userGroupIds = ids;
+        return this;
+    }
+
+    public FoDAppCreateRequest setAutoReqdAttrs(Boolean autoRequiredAttrs) {
+        this.autoRequiredAttrs = autoRequiredAttrs;
         return this;
     }
 

--- a/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
+++ b/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
@@ -3,7 +3,9 @@ fcli.fod.usage.header = Commands for interacting with Fortify on Demand (FoD).
 
 # Mixins
 ApplicationMixin = Application id or name.
-ApplicationReleaseMixin = Application release id or <application>:<release> name.
+ApplicationReleaseMixin = If creating a new application this should be the application and release name in the \
+  format <application>:<release>. If specifying an existing release you can provide either the \
+  release id, e.g. 1234 or the combined <application>:<release> name.
 ApplicationMicroserviceMixin = Application microservice id or <application>:<microservice> name.
 ScanMixin = Scan id(s).
 AnalysisStatusMixin = Scan analysis status. Valid values: ${COMPLETION-CANDIDATES}.
@@ -45,7 +47,7 @@ fcli.fod.app.usage.header = Commands for interacting with applications on Fortif
 
 # For the "fod app create-web-app" command
 fcli.fod.app.create-web-app.usage.header = Create a new web application (with a release) on Fortify on Demand (FoD). \
-  Please note some attributes might be mandatory depending on the configuration of your tenant. Please check from the \
+  Please note some attributes might be mandatory depending on the configuration of your tenant. Please check the \
   Fortify on Demand web portal first.
 fcli.fod.app.create-web-app.application-name = The name of the application to create.
 fcli.fod.app.create-web-app.release-name = The name of the release to create for the application.
@@ -58,10 +60,11 @@ fcli.fod.app.create-web-app.criticality = The business criticality of the applic
 fcli.fod.app.create-web-app.status = The SDLC lifecycle status of the release. Valid values: ${COMPLETION-CANDIDATES}
 fcli.fod.app.create-web-app.attr = Attribute id or name and its value to set on the application.
 fcli.fod.app.create-web-app.skip-if-exists = Check to see if application already exists before creating.
+fcli.fod.app.create-web-app.auto-required-attrs = Automatically set a default value for required attributes.
 
 # For the "fod app create-mobile-app" command
 fcli.fod.app.create-mobile-app.usage.header = Create a new mobile application (with a release) on Fortify on Demand (FoD). \
-  Please note some attributes might be mandatory depending on the configuration of your tenant. Please check from the \
+  Please note some attributes might be mandatory depending on the configuration of your tenant. Please check the \
   Fortify on Demand web portal first.
 fcli.fod.app.create-mobile-app.application-name = ${fcli.fod.app.create-web-app.application-name}
 fcli.fod.app.create-mobile-app.release-name = ${fcli.fod.app.create-web-app.release-name}
@@ -74,10 +77,11 @@ fcli.fod.app.create-mobile-app.criticality = ${fcli.fod.app.create-web-app.criti
 fcli.fod.app.create-mobile-app.status = ${fcli.fod.app.create-web-app.status}
 fcli.fod.app.create-mobile-app.attr = ${fcli.fod.app.create-web-app.attr}
 fcli.fod.app.create-mobile-app.skip-if-exists = ${fcli.fod.app.create-web-app.skip-if-exists}
+fcli.fod.app.create-mobile-app.auto-required-attrs = ${fcli.fod.app.create-web-app.auto-required-attrs}
 
 # For the "fod app create-microservice-app" command
 fcli.fod.app.create-microservice-app.usage.header = Create a new microservices application (with a release) on Fortify on Demand (FoD). \
-  Please note some attributes might be mandatory depending on the configuration of your tenant. Please check from the \
+  Please note some attributes might be mandatory depending on the configuration of your tenant. Please check the \
   Fortify on Demand web portal first.
 fcli.fod.app.create-microservice-app.missing-microservice = Missing option: if 'Microservice' type is specified then one or more 'microservice' options need to specified.
 fcli.fod.app.create-microservice-app.invalid-microservice = Invalid option: the 'release-microservice' option specified was not found in the 'microservice' options.
@@ -94,6 +98,7 @@ fcli.fod.app.create-microservice-app.criticality = ${fcli.fod.app.create-web-app
 fcli.fod.app.create-microservice-app.status = ${fcli.fod.app.create-web-app.status}
 fcli.fod.app.create-microservice-app.attr = ${fcli.fod.app.create-web-app.attr}
 fcli.fod.app.create-microservice-app.skip-if-exists = ${fcli.fod.app.create-web-app.skip-if-exists}
+fcli.fod.app.create-microservice-app.auto-required-attrs = ${fcli.fod.app.create-web-app.auto-required-attrs}
 
 # For the "fod app delete" command
 fcli.fod.app.delete.usage.header = Delete an application from Fortify on Demand (FoD).


### PR DESCRIPTION
For each of `fcli fod app create-XXX` commands added the option `--auto-required-attrs` to automatically set required attribute values (closes #311). This brings it into alignment with SSC application version commands.