### PR TITLE
copy-state new cmd and new options for av create

### DIFF
--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/cli/cmd/SSCAppVersionCommands.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/cli/cmd/SSCAppVersionCommands.java
@@ -23,6 +23,7 @@ import picocli.CommandLine.Command;
         subcommands = {
             SSCAppVersionCreateCommand.class,
             SSCAppVersionDeleteCommand.class,
+            SSCAppVersionCopyStateCommand.class,
             SSCAppVersionDownloadStateCommand.class,
             SSCAppVersionGetCommand.class,
             SSCAppVersionListCommand.class,

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/cli/cmd/SSCAppVersionCopyStateCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/cli/cmd/SSCAppVersionCopyStateCommand.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright 2021, 2023 Open Text.
+ *
+ * The only warranties for products and services of Open Text 
+ * and its affiliates and licensors ("Open Text") are as may 
+ * be set forth in the express warranty statements accompanying 
+ * such products and services. Nothing herein should be construed 
+ * as constituting an additional warranty. Open Text shall not be 
+ * liable for technical or editorial errors or omissions contained 
+ * herein. The information contained herein is subject to change 
+ * without notice.
+ *******************************************************************************/
+package com.fortify.cli.ssc.appversion.cli.cmd;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fortify.cli.common.output.cli.cmd.IJsonNodeSupplier;
+import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
+import com.fortify.cli.common.output.transform.IActionCommandResultSupplier;
+import com.fortify.cli.common.output.transform.IRecordTransformer;
+import com.fortify.cli.common.rest.unirest.UnexpectedHttpResponseException;
+import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCJsonNodeOutputCommand;
+import com.fortify.cli.ssc._common.rest.SSCUrls;
+import com.fortify.cli.ssc.appversion.cli.mixin.SSCAppAndVersionNameResolverMixin;
+import com.fortify.cli.ssc.appversion.cli.mixin.SSCFromAppVersionResolverMixin;
+import com.fortify.cli.ssc.appversion.helper.SSCAppVersionDescriptor;
+import com.fortify.cli.ssc.appversion.helper.SSCAppVersionHelper;
+import kong.unirest.UnirestInstance;
+import lombok.Getter;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+
+import java.util.HashMap;
+
+@Command(name = "copy-state")
+public class SSCAppVersionCopyStateCommand extends AbstractSSCJsonNodeOutputCommand implements IJsonNodeSupplier, IRecordTransformer, IActionCommandResultSupplier {
+    @Getter
+    @Mixin
+    private OutputHelperMixins.TableNoQuery outputHelper;
+    @Mixin
+    private SSCAppAndVersionNameResolverMixin.PositionalParameter sscAppAndVersionNameResolver;
+    @Mixin
+    private SSCFromAppVersionResolverMixin.RequiredOption fromAppVersionResolver;
+
+    @Override
+    public JsonNode getJsonNode(UnirestInstance unirest) {
+        ObjectMapper mapper = new ObjectMapper();
+        SSCAppVersionDescriptor targetAppVersionDescriptor = SSCAppVersionHelper.getRequiredAppVersion(unirest, sscAppAndVersionNameResolver.getAppAndVersionName(), sscAppAndVersionNameResolver.getDelimiter());
+        SSCAppVersionDescriptor sourceAppVersionDescriptor = fromAppVersionResolver.getAppVersionDescriptor(unirest, sscAppAndVersionNameResolver.getDelimiter());
+
+        return mapper.valueToTree(copyState(unirest, sourceAppVersionDescriptor, targetAppVersionDescriptor));
+
+    }
+
+    @Override
+    public JsonNode transformRecord(JsonNode record) {
+        return SSCAppVersionHelper.renameFields(record);
+    }
+
+    @Override
+    public String getActionCommandResult() {
+        return "COPY_REQUESTED";
+    }
+
+    @Override
+    public boolean isSingular() {
+        return true;
+    }
+
+    private static final HashMap<String, String> copyState(UnirestInstance unirest, SSCAppVersionDescriptor sourceAppVersion, SSCAppVersionDescriptor targetAppVersion) {
+        HashMap<String, String> appVersionIds = new HashMap<String, String>();
+        appVersionIds.put("previousProjectVersionId", sourceAppVersion.getVersionId());
+        appVersionIds.put("projectVersionId", targetAppVersion.getVersionId());
+        String action = "COPY_REQUESTED";
+        try {
+            JsonNode response = unirest.post(SSCUrls.PROJECT_VERSIONS_ACTION_COPY_CURRENT_STATE)
+                    .body(appVersionIds)
+                    .asObject(JsonNode.class).getBody();
+            if (response.has("responseCode")) {
+                if (response.get("responseCode").intValue() != 200) {
+                    action = "UNKNOWN";
+                }
+            }
+        } catch (UnexpectedHttpResponseException e) {
+            action = "COPY_FAILED";
+        }
+
+        appVersionIds.put(IActionCommandResultSupplier.actionFieldName, action);
+        return appVersionIds;
+    }
+
+}

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/cli/mixin/SSCFromAppVersionResolverMixin.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/cli/mixin/SSCFromAppVersionResolverMixin.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright 2021, 2023 Open Text.
+ *
+ * The only warranties for products and services of Open Text 
+ * and its affiliates and licensors ("Open Text") are as may 
+ * be set forth in the express warranty statements accompanying 
+ * such products and services. Nothing herein should be construed 
+ * as constituting an additional warranty. Open Text shall not be 
+ * liable for technical or editorial errors or omissions contained 
+ * herein. The information contained herein is subject to change 
+ * without notice.
+ *******************************************************************************/
+package com.fortify.cli.ssc.appversion.cli.mixin;
+
+import com.fortify.cli.common.cli.util.EnvSuffix;
+import com.fortify.cli.ssc.appversion.helper.SSCAppVersionDescriptor;
+import com.fortify.cli.ssc.appversion.helper.SSCAppVersionHelper;
+import kong.unirest.UnirestInstance;
+import lombok.Getter;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+public class SSCFromAppVersionResolverMixin {
+    public static abstract class AbstractSSCAppVersionResolverMixin {
+        public abstract String getAppVersionNameOrId();
+
+        public SSCAppVersionDescriptor getAppVersionDescriptor(UnirestInstance unirest,String delimiter, String... fields){
+            return SSCAppVersionHelper.getRequiredAppVersion(unirest, getAppVersionNameOrId(), delimiter, fields);
+        }
+
+        public String getAppVersionId(UnirestInstance unirest) {
+            return getAppVersionId(unirest, ":");
+        }
+
+        public String getAppVersionId(UnirestInstance unirest, String delimiter) {
+            return getAppVersionDescriptor(unirest, delimiter).getVersionId();
+        }
+    }
+
+
+    public static class RequiredOption extends AbstractSSCAppVersionResolverMixin {
+        @Option(names = {"--from"}, required = false, descriptionKey = "fcli.ssc.appversion.resolver.from.nameOrId")
+        @Getter private String appVersionNameOrId;
+
+    }
+}

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/helper/SSCAppVersionCreateCopyStateBuilder.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/helper/SSCAppVersionCreateCopyStateBuilder.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright 2021, 2023 Open Text.
+ *
+ * The only warranties for products and services of Open Text 
+ * and its affiliates and licensors ("Open Text") are as may 
+ * be set forth in the express warranty statements accompanying 
+ * such products and services. Nothing herein should be construed 
+ * as constituting an additional warranty. Open Text shall not be 
+ * liable for technical or editorial errors or omissions contained 
+ * herein. The information contained herein is subject to change 
+ * without notice.
+ *******************************************************************************/
+package com.fortify.cli.ssc.appversion.helper;
+
+import com.fortify.cli.ssc._common.rest.SSCUrls;
+import kong.unirest.HttpRequest;
+import kong.unirest.UnirestInstance;
+
+import java.util.HashMap;
+
+public final class SSCAppVersionCreateCopyStateBuilder {
+    private final UnirestInstance unirest;
+
+    private String previousProjectVersionId;
+
+    public SSCAppVersionCreateCopyStateBuilder(UnirestInstance unirest) {
+        this.unirest = unirest;
+    }
+
+
+    public final HttpRequest<?> buildRequest(String projectVersionId) {
+        HashMap<String, String> body = new HashMap<String, String>();
+        body.put("previousProjectVersionId", this.previousProjectVersionId);
+        body.put("projectVersionId", projectVersionId);
+        return unirest
+                .post(SSCUrls.PROJECT_VERSIONS_ACTION_COPY_CURRENT_STATE)
+                .body(body);
+    }
+
+    public final SSCAppVersionCreateCopyStateBuilder set(String previousProjectVersionId) {
+        this.previousProjectVersionId = previousProjectVersionId;
+        return this;
+    }
+}

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/helper/SSCAppVersionCreateFromBuilder.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/helper/SSCAppVersionCreateFromBuilder.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright 2021, 2023 Open Text.
+ *
+ * The only warranties for products and services of Open Text 
+ * and its affiliates and licensors ("Open Text") are as may 
+ * be set forth in the express warranty statements accompanying 
+ * such products and services. Nothing herein should be construed 
+ * as constituting an additional warranty. Open Text shall not be 
+ * liable for technical or editorial errors or omissions contained 
+ * herein. The information contained herein is subject to change 
+ * without notice.
+ *******************************************************************************/
+package com.fortify.cli.ssc.appversion.helper;
+
+import com.fortify.cli.ssc._common.rest.SSCUrls;
+import com.fortify.cli.ssc.access_control.helper.SSCAppVersionUserUpdateBuilder;
+import kong.unirest.HttpRequest;
+import kong.unirest.UnirestInstance;
+
+import java.util.HashMap;
+
+public final class SSCAppVersionCreateFromBuilder {
+    private final UnirestInstance unirest;
+
+    private String previousProjectVersionId;
+
+    public SSCAppVersionCreateFromBuilder(UnirestInstance unirest) {
+        this.unirest = unirest;
+    }
+
+
+    public final HttpRequest<?> buildRequest(String projectVersionId) {
+        HashMap<String, String> body = new HashMap<String, String>();
+        body.put("previousProjectVersionId", this.previousProjectVersionId);
+        body.put("projectVersionId", projectVersionId);
+        body.put("copyAnalysisProcessingRules", "true");
+        body.put("copyBugTrackerConfiguration", "true");
+        body.put("copyCustomTags", "true");
+        return unirest
+                .post(SSCUrls.PROJECT_VERSIONS_ACTION_COPY_FROM_PARTIAL)
+                .body(body);
+    }
+
+    public final SSCAppVersionCreateFromBuilder set(String previousProjectVersionId) {
+        this.previousProjectVersionId = previousProjectVersionId;
+        return this;
+    }
+}

--- a/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/i18n/SSCMessages.properties
+++ b/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/i18n/SSCMessages.properties
@@ -228,7 +228,11 @@ fcli.ssc.appversion.create.active = Specify whether application version should b
   or not (false).
 fcli.ssc.appversion.create.skip-if-exists = Skip application version creation if an application version with \
   the specified name already exists.
+fcli.ssc.appversion.create.copy-state = Copy application state (Attributes, CustomTages and BugTracker settings). Requires --from
 fcli.ssc.appversion.delete.usage.header = Delete an application version.
+fcli.ssc.appversion.copy-state.usage.header = Copy application version state.
+fcli.ssc.appversion.copy-state.usage.description = Copy application version state from another application version
+fcli.ssc.appversion.copy-state.output.table.options = previousProjectVersionId,projectVersionId
 fcli.ssc.appversion.download-state.usage.header = Download application version state.
 fcli.ssc.appversion.download-state.usage.description = Download application version state artifact. See 'fcli ssc artifact download' for downloading individual artifacts.
 fcli.ssc.appversion.download-state.file = Optional output file path.
@@ -265,6 +269,7 @@ fcli.ssc.appversion.update.name = Update application version name.
 fcli.ssc.appversion.update.description = Update application version description.
 fcli.ssc.appversion.resolver.name = Application and version name.
 fcli.ssc.appversion.resolver.nameOrId = Application version id or <application>:<version> name.
+fcli.ssc.appversion.resolver.from.nameOrId = Copy FROM application version: id or <application>:<version> name.
   
 # fcli ssc artifact
 fcli.ssc.artifact.usage.header = Manage SSC artifacts.


### PR DESCRIPTION
Copy vulns from one AV to another:
feat: new cmd: ssc appversion copy-state <app>:<version> --from <app>:<version>

Added support for copy AV attributes, CustomTags, BugTracker (--from) and vulns (--copy-state)
feat: new cmd options : ssc appversion create <app>:<version> --from <app>:<version> --copy-state