### PR TITLE
chore: `ssc av create --from` now supports copy of `IssueTemplate,VersionAttributes,UserAccess`

### DIFF
--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/helper/SSCAppVersionUserUpdateBuilder.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/helper/SSCAppVersionUserUpdateBuilder.java
@@ -12,9 +12,7 @@
  *******************************************************************************/
 package com.fortify.cli.ssc.access_control.helper;
 
-import java.util.Arrays;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.*;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -23,6 +21,11 @@ import com.fortify.cli.common.json.JsonHelper;
 import com.fortify.cli.ssc._common.rest.SSCUrls;
 import com.fortify.cli.ssc.access_control.helper.SSCUserSpecPredicate.MatchMode;
 
+import com.fortify.cli.ssc.appversion.helper.SSCAppVersionCopyType;
+import com.fortify.cli.ssc.appversion.helper.SSCAppVersionCreateCopyFromBuilder;
+import com.fortify.cli.ssc.appversion.helper.SSCAppVersionDescriptor;
+import com.fortify.cli.ssc.appversion.helper.SSCAppVersionHelper;
+import com.fortify.cli.ssc.attribute.helper.SSCAttributeUpdateBuilder;
 import kong.unirest.HttpRequest;
 import kong.unirest.UnirestInstance;
 import lombok.Data;
@@ -93,6 +96,21 @@ public final class SSCAppVersionUserUpdateBuilder {
         this.allowMultipleMatchesForRemove |= allowMultipleMatches;
         if ( authEntitySpecs!=null && authEntitySpecs.length>0 ) {
         	authEntitySpecsToRemove.addAll(Arrays.asList(authEntitySpecs));
+        }
+        return this;
+    }
+
+    public SSCAppVersionUserUpdateBuilder getUsersFrom(SSCAppVersionCreateCopyFromBuilder copyFromBuilder) {
+        if(copyFromBuilder.isCopyTypeRequested(SSCAppVersionCopyType.UserAccess)) {
+            Set<String> users = new LinkedHashSet<>();
+            SSCAppVersionDescriptor fromDescriptor = copyFromBuilder.getPreviousProjectVersionDescriptor();
+            JsonNode fromUsers = SSCAppVersionHelper.getUsers(unirest, fromDescriptor);
+
+            for (JsonNode fromUser : fromUsers) {
+                users.add(fromUser.get("id").toString());
+            }
+
+            return add(false, users.toArray(new String[0]));
         }
         return this;
     }

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/helper/SSCAppVersionCopyType.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/helper/SSCAppVersionCopyType.java
@@ -20,9 +20,12 @@ import java.util.stream.Stream;
  */
 public enum SSCAppVersionCopyType {
     AnalysisProcessingRules("copyAnalysisProcessingRules"),
+    VersionAttributes("copyVersionAttributes"),
     BugTrackerConfiguration("copyBugTrackerConfiguration"),
     CustomTags("copyCustomTags"),
-    State("copyState");
+    IssueTemplate("copyIssueTemplate"),
+    State("copyState"),
+    UserAccess("copyUserAccessSettings");
 
     private final String sscValue;
 

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/helper/SSCAppVersionCreateCopyFromBuilder.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/helper/SSCAppVersionCreateCopyFromBuilder.java
@@ -21,18 +21,16 @@ import kong.unirest.UnirestInstance;
 
 public final class SSCAppVersionCreateCopyFromBuilder {
     private final UnirestInstance unirest;
-
     private ObjectNode copyFromPartialOptions = JsonHelper.getObjectMapper().createObjectNode();
     private ObjectNode copyStateOptions = JsonHelper.getObjectMapper().createObjectNode();
-    private SSCAppVersionDescriptor previousProjectVersion;
-
+    private SSCAppVersionDescriptor previousProjectVersionDescriptor;
     private boolean copyRequested = false;
-
-    private boolean copyState = false;
 
     public SSCAppVersionCreateCopyFromBuilder(UnirestInstance unirest) {
         this.unirest = unirest;
     }
+
+    public SSCAppVersionDescriptor getPreviousProjectVersionDescriptor() { return this.previousProjectVersionDescriptor; }
 
     public final HttpRequest<?> buildCopyFromPartialRequest(String projectVersionId) {
         if(!copyRequested){
@@ -47,7 +45,7 @@ public final class SSCAppVersionCreateCopyFromBuilder {
 
 
     public final HttpRequest<?> buildCopyStateRequest(String projectVersionId) {
-        if(!copyState || !copyRequested){
+        if( !isCopyTypeRequested(SSCAppVersionCopyType.State) || !copyRequested){
             return null;
         }
 
@@ -63,7 +61,7 @@ public final class SSCAppVersionCreateCopyFromBuilder {
     }
 
     public final SSCAppVersionCreateCopyFromBuilder setCopyFrom(SSCAppVersionDescriptor previousProjectVersionDescriptor) {
-        this.previousProjectVersion = previousProjectVersionDescriptor;
+        this.previousProjectVersionDescriptor = previousProjectVersionDescriptor;
         this.copyFromPartialOptions.put("previousProjectVersionId", previousProjectVersionDescriptor.getVersionId());
         this.copyStateOptions.put("previousProjectVersionId", previousProjectVersionDescriptor.getIntVersionId());
         return this;
@@ -74,11 +72,7 @@ public final class SSCAppVersionCreateCopyFromBuilder {
             copyOptions = SSCAppVersionCopyType.values();
         }
         for (SSCAppVersionCopyType option : copyOptions) {
-            if(option.getSscValue() == "copyState") {
-                this.copyState = true;
-            } else {
-                this.copyFromPartialOptions.put(option.getSscValue(), "true");
-            }
+            this.copyFromPartialOptions.put(option.getSscValue(), "true");
         }
 
         return this;
@@ -90,7 +84,7 @@ public final class SSCAppVersionCreateCopyFromBuilder {
         return this;
     }
 
-    public boolean copyStateEnabled() {
-        return this.copyState;
+    public final boolean isCopyTypeRequested(SSCAppVersionCopyType type){
+        return this.copyFromPartialOptions.has(type.getSscValue());
     }
 }

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/helper/SSCAppVersionDescriptor.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/helper/SSCAppVersionDescriptor.java
@@ -31,7 +31,8 @@ public class SSCAppVersionDescriptor extends JsonNodeHolder {
     @JsonProperty("id") private String versionId;
     @JsonProperty("name") private String versionName;
     private boolean refreshRequired;
-    
+    private String issueTemplateId;
+
     @JsonProperty("project")
     public void unpackProject(Map<String, String> project) {
         applicationId = project.get("id");

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/helper/SSCAppVersionHelper.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/helper/SSCAppVersionHelper.java
@@ -26,6 +26,9 @@ import kong.unirest.UnirestInstance;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 public class SSCAppVersionHelper {
     public static final JsonNode renameFields(JsonNode record) {
         return new RenameFieldsTransformer(new String[] {"project:application"}).transform(record);
@@ -86,7 +89,31 @@ public class SSCAppVersionHelper {
             return SSCJobHelper.getJobDescriptor(unirest, response.get("data").get("data").get("id").textValue());
         }
     }
-    
+
+    public static final JsonNode getAttributes(UnirestInstance unirest, String appVersionNameOrId, String delimiter) {
+        return getAttributes(unirest, getOptionalAppVersion(unirest, appVersionNameOrId, delimiter));
+    }
+
+    public static final JsonNode getAttributes(UnirestInstance unirest, SSCAppVersionDescriptor descriptor) {
+        Map<String,String> attributes = new LinkedHashMap<>();
+
+        JsonNode response = unirest.get(SSCUrls.PROJECT_VERSION_ATTRIBUTES(descriptor.getVersionId()))
+                .asObject(ObjectNode.class)
+                .getBody();
+
+        return response.get("data");
+    }
+
+    public static final JsonNode getUsers(UnirestInstance unirest, SSCAppVersionDescriptor descriptor) {
+        Map<String,String> attributes = new LinkedHashMap<>();
+
+        JsonNode response = unirest.get(SSCUrls.PROJECT_VERSION_AUTH_ENTITIES(descriptor.getVersionId()))
+                .asObject(ObjectNode.class)
+                .getBody();
+
+        return response.get("data");
+    }
+
     @Data
     @Reflectable @AllArgsConstructor
     private static final class SSCAppVersionRefreshRequest {

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/attribute/cli/mixin/SSCAttributeUpdateMixin.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/attribute/cli/mixin/SSCAttributeUpdateMixin.java
@@ -25,12 +25,12 @@ public class SSCAttributeUpdateMixin {
     }
     
     public static class OptionalAttrOption extends AbstractSSCAppVersionAttributeUpdateMixin {
-        @Option(names = {"--attrs", "--attributes"}, required = false, split = ",", paramLabel = PARAM_LABEL, descriptionKey = "fcli.ssc.attribute.update.option")
+        @Option(names = {"--attrs", "--attributes"}, required = false, split = ";", paramLabel = PARAM_LABEL, descriptionKey = "fcli.ssc.attribute.update.option")
         @Getter private Map<String,String> attributes;
     }
     
     public static class RequiredAttrOption extends AbstractSSCAppVersionAttributeUpdateMixin {
-        @Option(names = {"--attrs", "--attributes"}, required = true, split = ",", paramLabel = PARAM_LABEL, descriptionKey = "fcli.ssc.attribute.update.option")
+        @Option(names = {"--attrs", "--attributes"}, required = true, split = ";", paramLabel = PARAM_LABEL, descriptionKey = "fcli.ssc.attribute.update.option")
         @Getter private Map<String,String> attributes;
     }
 }

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/attribute/cli/mixin/SSCAttributeUpdateMixin.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/attribute/cli/mixin/SSCAttributeUpdateMixin.java
@@ -25,12 +25,12 @@ public class SSCAttributeUpdateMixin {
     }
     
     public static class OptionalAttrOption extends AbstractSSCAppVersionAttributeUpdateMixin {
-        @Option(names = {"--attrs", "--attributes"}, required = false, split = ";", paramLabel = PARAM_LABEL, descriptionKey = "fcli.ssc.attribute.update.option")
+        @Option(names = {"--attrs", "--attributes"}, required = false, split = ",", paramLabel = PARAM_LABEL, descriptionKey = "fcli.ssc.attribute.update.option")
         @Getter private Map<String,String> attributes;
     }
     
     public static class RequiredAttrOption extends AbstractSSCAppVersionAttributeUpdateMixin {
-        @Option(names = {"--attrs", "--attributes"}, required = true, split = ";", paramLabel = PARAM_LABEL, descriptionKey = "fcli.ssc.attribute.update.option")
+        @Option(names = {"--attrs", "--attributes"}, required = true, split = ",", paramLabel = PARAM_LABEL, descriptionKey = "fcli.ssc.attribute.update.option")
         @Getter private Map<String,String> attributes;
     }
 }

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/attribute/helper/SSCAttributeUpdateBuilder.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/attribute/helper/SSCAttributeUpdateBuilder.java
@@ -26,6 +26,10 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fortify.cli.common.json.JsonHelper;
 import com.fortify.cli.common.util.StringUtils;
+import com.fortify.cli.ssc.appversion.helper.SSCAppVersionCopyType;
+import com.fortify.cli.ssc.appversion.helper.SSCAppVersionCreateCopyFromBuilder;
+import com.fortify.cli.ssc.appversion.helper.SSCAppVersionDescriptor;
+import com.fortify.cli.ssc.appversion.helper.SSCAppVersionHelper;
 import com.fortify.cli.ssc.attribute.domain.SSCAttributeDefinitionType;
 
 import kong.unirest.HttpRequest;
@@ -55,12 +59,31 @@ public final class SSCAttributeUpdateBuilder {
         }
         return resetPreparedRequest();
     }
-    
+
     public SSCAttributeUpdateBuilder addRequiredAttrs(boolean addRequiredAttrs) {
         this.addRequiredAttributes = addRequiredAttrs;
         return resetPreparedRequest();
     }
-    
+
+    public SSCAttributeUpdateBuilder getAttrsFrom(SSCAppVersionCreateCopyFromBuilder copyFromBuilder) {
+        if(copyFromBuilder.isCopyTypeRequested(SSCAppVersionCopyType.VersionAttributes)) {
+            Map<String,String> attributes = new LinkedHashMap<>();
+            SSCAppVersionDescriptor fromDescriptor = copyFromBuilder.getPreviousProjectVersionDescriptor();
+            JsonNode fromAttributes = SSCAppVersionHelper.getAttributes(unirest, fromDescriptor);
+
+            for (JsonNode attr : fromAttributes) {
+                String values = "";
+                for (JsonNode value: attr.get("values")) {
+                    values += value.get("guid").textValue() + ",";
+                }
+                attributes.put(attr.get("attributeDefinitionId").toString(), values);
+            }
+
+            return this.add(attributes);
+        }
+        return resetPreparedRequest();
+    }
+
     public SSCAttributeUpdateBuilder checkRequiredAttrs(boolean checkRequiredAttrs) {
         this.checkRequiredAttributes = checkRequiredAttrs;
         return resetPreparedRequest();

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/issue/cli/mixin/SSCIssueTemplateResolverMixin.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/issue/cli/mixin/SSCIssueTemplateResolverMixin.java
@@ -37,6 +37,10 @@ public class SSCIssueTemplateResolverMixin {
             SSCIssueTemplateDescriptor descriptor = getIssueTemplateDescriptor(unirest);
             return descriptor!=null ? descriptor : SSCIssueTemplateHelper.getDefaultIssueTemplateDescriptor(unirest);
         }
+
+        public SSCIssueTemplateDescriptor getDefaultIssueTemplateDescriptor(UnirestInstance unirest) {
+            return SSCIssueTemplateHelper.getDefaultIssueTemplateDescriptor(unirest);
+        }
     }
     
     public static class OptionalOption extends AbstractSSCIssueTemplateResolverMixin {


### PR DESCRIPTION
chore: `ssc av create --from` now supports copy of `IssueTemplate,VersionAttributes,UserAccess`

By default, the `--copy-from` feature will copy everything from the source app, now including (with the priority): 
- `IssueTemplate` (user input > copy-from > system default) 
- `VersionAttribute` (user input > copy-from > auto-required-attrs) 
- `UserAccess` (user input > copy-from)