### PR TITLE
fix: ssc create: the `--attrs` now supports multiple attributes with multiple values

### DIFF
--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/attribute/cli/mixin/SSCAttributeUpdateMixin.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/attribute/cli/mixin/SSCAttributeUpdateMixin.java
@@ -18,7 +18,7 @@ import lombok.Getter;
 import picocli.CommandLine.Option;
 
 public class SSCAttributeUpdateMixin {
-    private static final String PARAM_LABEL = "[CATEGORY:]ATTR=VALUE[,VALUE...]";
+    private static final String PARAM_LABEL = "CATEGORY:ATTR=[VAL1;VAL2],ATTR=VAL3...";
     public static abstract class AbstractSSCAppVersionAttributeUpdateMixin {
         public abstract Map<String,String> getAttributes();
 

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/attribute/cli/mixin/SSCAttributeUpdateMixin.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/attribute/cli/mixin/SSCAttributeUpdateMixin.java
@@ -18,7 +18,7 @@ import lombok.Getter;
 import picocli.CommandLine.Option;
 
 public class SSCAttributeUpdateMixin {
-    private static final String PARAM_LABEL = "CATEGORY:ATTR=[VAL1;VAL2],ATTR=VAL3...";
+    private static final String PARAM_LABEL = "ATTR=VALUE";
     public static abstract class AbstractSSCAppVersionAttributeUpdateMixin {
         public abstract Map<String,String> getAttributes();
 

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/attribute/helper/SSCAttributeUpdateBuilder.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/attribute/helper/SSCAttributeUpdateBuilder.java
@@ -222,7 +222,7 @@ public final class SSCAttributeUpdateBuilder {
     }
 
     private static ArrayNode getOptionValues(SSCAttributeDefinitionHelper helper, SSCAttributeDefinitionDescriptor descriptor, String value) {
-        return Stream.of(value.split(","))
+        return Stream.of(value.split("[\\[\\];]"))
                 .filter(StringUtils::isNotBlank)
                 .map(v->helper.getOptionGuid(descriptor.getGuid(), v))
                 .map(SSCAttributeUpdateBuilder::createAttrValueNode)

--- a/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/i18n/SSCMessages.properties
+++ b/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/i18n/SSCMessages.properties
@@ -324,7 +324,11 @@ fcli.ssc.artifact.upload.file = File to upload.
 fcli.ssc.attribute.usage.header = Manage SSC application version attributes & definitions.
 fcli.ssc.attribute.list.usage.header = List application version attributes.
 fcli.ssc.attribute.update.usage.header = Update application version attributes. 
-fcli.ssc.attribute.update.option = Set values for one or more attributes. This option accepts a comma-separated list of attribute value assignments.
+fcli.ssc.attribute.update.option = Example: ATTR1=[VAL1;VAL2],CATEGORY:ATTR2=VAL3 \
+  \nSet values for one or more attributes. This option accepts a comma-separated list of KEY=VALUE assignments. \
+  \nEach KEY accepts either the Attribute's GUID or its Name with the optional Category (InfoClassification or "BUSINESS:Data Classification" or "Data Classification") \
+  \nEach VALUE accepts a semicolon-separated list of Attribute's Values, encapsulated in brackets (optional for single value) \
+  
 fcli.ssc.attribute.get-definition.usage.header = Get attribute definition details.
 fcli.ssc.attribute.list-definitions.usage.header = List attribute definitions.
 fcli.ssc.attribute-definition.resolver.nameOrId = Attribute definition name or id.


### PR DESCRIPTION
fix: ssc create: the `--attrs` now supports multiple attributes with multiple values

Previously, the following inputs would fail`--attrs "Interfaces=Batch Processing Console,GUI,Development Phase=Active Development"` or even `--attrs "Interfaces=Batch Processing Console,GUI"`, because at both level, the expected separator is `,`. Now, the Attribute separator is still `,`, and the value separator becomes `;`, with `[ ]` surrounding the values (optional with single value), allowing it to work.

Example: `--attrs "Interfaces=[Batch Processing Console;GUI],Development Phase=Active Development,Application Type=Application"`