### PR TITLE
Updated FoD `wait-for` implementation

### DIFF
--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/rest/FoDUrls.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/rest/FoDUrls.java
@@ -56,4 +56,5 @@ public class FoDUrls {
     public static final String DAST_AUTOMATED_SCANS = ApiBase + "/releases/{relId}/dast-automated-scans";
     public static final String REPORTS = ApiBase + "/reports";
     public static final String REPORT = ApiBase + "/reports/{reportId}";
+    public static final String SCAN_POLLING_SUMMARY = ApiBase + "/releases/{relId}/scans/{scanId}/polling-summary";
 }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/cli/cmd/AbstractFoDScanWaitForCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/cli/cmd/AbstractFoDScanWaitForCommand.java
@@ -13,25 +13,30 @@
 
 package com.fortify.cli.fod._common.scan.cli.cmd;
 
-import java.util.Set;
-
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fortify.cli.common.cli.util.CommandGroup;
+import com.fortify.cli.common.output.transform.IRecordTransformer;
 import com.fortify.cli.common.rest.cli.cmd.AbstractWaitForCommand;
 import com.fortify.cli.common.rest.wait.WaitHelper.WaitHelperBuilder;
+import com.fortify.cli.fod._common.cli.mixin.FoDDelimiterMixin;
 import com.fortify.cli.fod._common.scan.cli.mixin.FoDScanResolverMixin;
+import com.fortify.cli.fod._common.scan.helper.FoDScanHelper;
 import com.fortify.cli.fod._common.scan.helper.FoDScanStatus;
 import com.fortify.cli.fod._common.scan.helper.FoDScanStatus.FoDScanStatusIterable;
 import com.fortify.cli.fod._common.scan.helper.FoDScanType;
 import com.fortify.cli.fod._common.session.cli.mixin.FoDUnirestInstanceSupplierMixin;
-
 import kong.unirest.UnirestInstance;
 import lombok.Getter;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 
-@CommandGroup("*-scan")
-public abstract class AbstractFoDScanWaitForCommand extends AbstractWaitForCommand {
+import java.util.Arrays;
+import java.util.Set;
+
+@CommandGroup("*-scan-wait-for")
+public abstract class AbstractFoDScanWaitForCommand extends AbstractWaitForCommand implements IRecordTransformer {
     @Getter @Mixin private FoDUnirestInstanceSupplierMixin unirestInstanceSupplier;
+    @Mixin private FoDDelimiterMixin delimiterMixin; // Is automatically injected in resolver mixins
     @Mixin private FoDScanResolverMixin.PositionalParameterMulti scansResolver;
     @Option(names={"-s", "--any-state"}, required=true, split=",", defaultValue="Completed", completionCandidates = FoDScanStatusIterable.class)
     private Set<String> states;
@@ -40,6 +45,7 @@ public abstract class AbstractFoDScanWaitForCommand extends AbstractWaitForComma
     protected final WaitHelperBuilder configure(UnirestInstance unirest, WaitHelperBuilder builder) {
         return builder
                 .recordsSupplier(scansResolver::getScanDescriptorJsonNodes)
+                .recordTransformer(this::transformRecord)
                 .currentStateProperty("analysisStatusType")
                 .knownStates(FoDScanStatus.getKnownStateNames())
                 .failureStates(FoDScanStatus.getFailureStateNames())
@@ -48,5 +54,10 @@ public abstract class AbstractFoDScanWaitForCommand extends AbstractWaitForComma
     
     // TODO Verify that all given scan id's are of given scan type
     protected abstract FoDScanType getScanType();
+
+    @Override
+    public JsonNode transformRecord(JsonNode record) {
+        return FoDScanHelper.renameFields(record, getScanType());
+    }
 
 }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/FoDScanPollingDescriptor.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/FoDScanPollingDescriptor.java
@@ -13,35 +13,30 @@
 
 package com.fortify.cli.fod._common.scan.helper;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.formkiq.graalvm.annotations.Reflectable;
 import com.fortify.cli.common.json.JsonNodeHolder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
-
 @Reflectable @NoArgsConstructor
 @Data @EqualsAndHashCode(callSuper = true)
-public class FoDScanDescriptor extends JsonNodeHolder {
-    private String scanId;
-    private String scanType;
-    private String applicationName;
-    private String releaseName;
-    private String applicationId;
-    private String releaseId;
-    private String microserviceName;
-    private String status;
-
-    @JsonIgnore
-    public String getReleaseAndScanId() {
-        return String.format("%s:%s", releaseId, scanId);
-    }
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyy-MM-dd'T'hh:mm:ss")
-    private Date startedDateTime;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyy-MM-dd'T'hh:mm:ss")
-    private Date completedDateTime;
+public class FoDScanPollingDescriptor extends JsonNodeHolder {
+    private String ScanId;
+    private String OpenSourceScanId;
+    private String TenantId;
+    private String AnalysisStatusId;
+    private String OpenSourceStatusId;
+    private String AnalysisStatusTypeValue;
+    private String AnalysisStatusReasonId;
+    private String AnalysisStatusReason;
+    private String AnalysisStatusReasonNotes;
+    private String IssueCountCritical;
+    private String IssueCountHigh;
+    private String IssueCountMedium;
+    private String IssueCountLow;
+    private String PassFailStatus;
+    private String PassFailReasonType;
+    private String PauseDetails;
+    private String ScanType;
 }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/dast/FoDScanDastAutomatedHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/dast/FoDScanDastAutomatedHelper.java
@@ -51,6 +51,7 @@ public class FoDScanDastAutomatedHelper extends FoDScanHelper {
         JsonNode node = objectMapper.createObjectNode()
                 .put("scanId", startScanResponse.getScanId())
                 .put("scanType", FoDScanType.Dynamic.name())
+                .put("releaseAndScanId",  String.format("%s:%s", releaseDescriptor.getReleaseId(), startScanResponse.getScanId()))
                 .put("analysisStatusType", "Pending")
                 .put("applicationName", releaseDescriptor.getApplicationName())
                 .put("releaseName", releaseDescriptor.getReleaseName())

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/dast/FoDScanDastLegacyHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/dast/FoDScanDastLegacyHelper.java
@@ -53,6 +53,7 @@ public class FoDScanDastLegacyHelper extends FoDScanHelper {
         JsonNode node = objectMapper.createObjectNode()
                 .put("scanId", startScanResponse.getScanId())
                 .put("scanType", FoDScanType.Dynamic.name())
+                .put("releaseAndScanId",  String.format("%s:%s", releaseDescriptor.getReleaseId(), startScanResponse.getScanId()))
                 .put("analysisStatusType", "Pending")
                 .put("applicationName", releaseDescriptor.getApplicationName())
                 .put("releaseName", releaseDescriptor.getReleaseName())

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/mobile/FoDScanMobileHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/mobile/FoDScanMobileHelper.java
@@ -58,6 +58,7 @@ public class FoDScanMobileHelper extends FoDScanHelper {
         JsonNode node = objectMapper.createObjectNode()
             .put("scanId", startScanResponse.getScanId())
             .put("scanType", FoDScanType.Mobile.name())
+            .put("releaseAndScanId",  String.format("%s:%s", releaseDescriptor.getReleaseId(), startScanResponse.getScanId()))
             .put("analysisStatusType", "Pending")
             .put("applicationName", releaseDescriptor.getApplicationName())
             .put("releaseName", releaseDescriptor.getReleaseName())

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/oss/FoDScanOssHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/oss/FoDScanOssHelper.java
@@ -53,6 +53,7 @@ public class FoDScanOssHelper extends FoDScanHelper {
         JsonNode node = objectMapper.createObjectNode()
                 .put("scanId", startScanResponse.getScanId())
                 .put("scanType", FoDScanType.OpenSource.name())
+                .put("releaseAndScanId",  String.format("%s:%s", releaseDescriptor.getReleaseId(), startScanResponse.getScanId()))
                 .put("analysisStatusType", "Pending")
                 .put("applicationName", releaseDescriptor.getApplicationName())
                 .put("releaseName", releaseDescriptor.getReleaseName())

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/sast/FoDScanSastHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/sast/FoDScanSastHelper.java
@@ -88,6 +88,7 @@ public class FoDScanSastHelper extends FoDScanHelper {
         JsonNode node = objectMapper.createObjectNode()
                 .put("scanId", startScanResponse.getScanId())
                 .put("scanType", FoDScanType.Static.name())
+                .put("releaseAndScanId",  String.format("%s:%s", releaseDescriptor.getReleaseId(), startScanResponse.getScanId()))
                 .put("analysisStatusType", "Pending")
                 .put("applicationName", releaseDescriptor.getApplicationName())
                 .put("releaseName", releaseDescriptor.getReleaseName())

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/FoDDastScanCommands.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/FoDDastScanCommands.java
@@ -37,6 +37,6 @@ import picocli.CommandLine;
                 FoDDastScanFileUploadCommand.class
         }
 )
-@DefaultVariablePropertyName("scanId")
+@DefaultVariablePropertyName("releaseAndScanId")
 public class FoDDastScanCommands extends AbstractContainerCommand {
 }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/mast_scan/cli/cmd/FoDMastScanCommands.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/mast_scan/cli/cmd/FoDMastScanCommands.java
@@ -32,6 +32,6 @@ import picocli.CommandLine;
                 FoDMastScanWaitForCommand.class,
         }
 )
-@DefaultVariablePropertyName("scanId")
+@DefaultVariablePropertyName("releaseAndScanId")
 public class FoDMastScanCommands extends AbstractContainerCommand {
 }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/oss_scan/cli/cmd/FoDOssScanCommands.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/oss_scan/cli/cmd/FoDOssScanCommands.java
@@ -32,6 +32,6 @@ import picocli.CommandLine;
                 FoDOssScanWaitForCommand.class,
         }
 )
-@DefaultVariablePropertyName("scanId")
+@DefaultVariablePropertyName("releaseAndScanId")
 public class FoDOssScanCommands extends AbstractContainerCommand {
 }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/cli/cmd/FoDSastScanCommands.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/cli/cmd/FoDSastScanCommands.java
@@ -32,6 +32,6 @@ import picocli.CommandLine;
                 FoDSastScanWaitForCommand.class,
         }
 )
-@DefaultVariablePropertyName("scanId")
+@DefaultVariablePropertyName("releaseAndScanId")
 public class FoDSastScanCommands extends AbstractContainerCommand {
 }

--- a/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
+++ b/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
@@ -825,6 +825,7 @@ fcli.fod.*-scan-config.output.table.options = applicationName,microserviceName,r
 fcli.fod.*-scan-setup.output.table.options = scanType,setupType,fileId,filename,applicationName,microserviceName,releaseName,entitlementId
 fcli.fod.*-scan-start.output.table.options = scanId,scanType,analysisStatusType,applicationName,microserviceName,releaseName
 fcli.fod.*-scan-upload-file.output.table.options = fileId,fileType,filename,applicationName,microserviceName,releaseName
+fcli.fod.*-scan-wait-for.output.table.options = scanId,analysisStatusType,scanType
 fcli.fod.session.output.table.options = name,type,url,created,expires,expired
 fcli.fod.rest.lookup.output.table.options = group,text,value
 fcli.fod.report.output.table.options = reportId,reportName,reportStatusType,reportType


### PR DESCRIPTION
Updated `wait-for` commands to use internal `/polling-summary` API. This required changes to support release qualified scanIds, for example:

```
fcli fod sast-scan wait-for 12345  // still supported
fcli fod sast-scan wait-for 88888:12345 // now supported releaseId:scanId format
```

Also now storing `releaseId:scanId` in start scan variables and defaulted to this:

```
>fcli util var contents curScan -o json
{
  "scanId" : 10697688,
  "scanType" : "Dynamic",
  "releaseAndScanId" : "1173597:10697688",
  "analysisStatusType" : "Pending",
  "applicationName" : "FortifyDemoApp [KAL]",
  "releaseName" : "1.0.1",
  "microserviceName" : "",
  "__action__" : "STARTED"
}
```