### PR TITLE
fix: `fcli fod issue list`: Add `--include` option to allow for retrieving `fixed` and/or `suppressed` issues

### DIFF
--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/issue/cli/cmd/FoDIssueListCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/issue/cli/cmd/FoDIssueListCommand.java
@@ -20,6 +20,7 @@ import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDBaseRequestOutputCo
 import com.fortify.cli.fod._common.rest.query.FoDFiltersParamGenerator;
 import com.fortify.cli.fod._common.rest.query.cli.mixin.FoDFiltersParamMixin;
 import com.fortify.cli.fod.issue.cli.mixin.FoDIssueEmbedMixin;
+import com.fortify.cli.fod.issue.cli.mixin.FoDIssueIncludeMixin;
 import com.fortify.cli.fod.release.cli.mixin.FoDReleaseByQualifiedNameOrIdResolverMixin;
 
 import kong.unirest.HttpRequest;
@@ -35,6 +36,7 @@ public class FoDIssueListCommand extends AbstractFoDBaseRequestOutputCommand imp
     @Mixin private FoDReleaseByQualifiedNameOrIdResolverMixin.RequiredOption releaseResolver;
     @Mixin private FoDFiltersParamMixin filterParamMixin;
     @Mixin private FoDIssueEmbedMixin embedMixin;
+    @Mixin private FoDIssueIncludeMixin includeMixin;
     @Getter private IServerSideQueryParamValueGenerator serverSideQueryParamGenerator = new FoDFiltersParamGenerator();
     //        .add("id","applicationId")
     //        .add("name","applicationName")

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/issue/cli/mixin/FoDIssueIncludeMixin.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/issue/cli/mixin/FoDIssueIncludeMixin.java
@@ -1,0 +1,28 @@
+package com.fortify.cli.fod.issue.cli.mixin;
+
+import com.fortify.cli.common.rest.unirest.IHttpRequestUpdater;
+import kong.unirest.HttpRequest;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import picocli.CommandLine;
+import java.util.List;
+
+public class FoDIssueIncludeMixin implements IHttpRequestUpdater {
+    @CommandLine.Option(names = {"--include", "-i"}, split = ",", descriptionKey = "fcli.fod.issue.list.includeIssue") // use similar attributes as other multi-value options in fcli
+    private List<FoDIssueInclude> includes;
+
+    public HttpRequest<?> updateRequest(HttpRequest<?> request) {
+        for ( var include : includes) {
+            request = request.queryString(include.getRequestParameterName(), "true");
+        }
+        return request;
+    }
+
+    @RequiredArgsConstructor
+    public static enum FoDIssueInclude {
+        fixed("includeFixed"), suppressed("includeSuppressed");
+
+        @Getter
+        private final String requestParameterName;
+    }
+}

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/issue/cli/mixin/FoDIssueIncludeMixin.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/issue/cli/mixin/FoDIssueIncludeMixin.java
@@ -8,7 +8,7 @@ import picocli.CommandLine;
 import java.util.List;
 
 public class FoDIssueIncludeMixin implements IHttpRequestUpdater {
-    @CommandLine.Option(names = {"--include", "-i"}, split = ",", descriptionKey = "fcli.fod.issue.list.includeIssue") // use similar attributes as other multi-value options in fcli
+    @CommandLine.Option(names = {"--include", "-i"}, split = ",", descriptionKey = "fcli.fod.issue.list.includeIssue")
     private List<FoDIssueInclude> includes;
 
     public HttpRequest<?> updateRequest(HttpRequest<?> request) {

--- a/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
+++ b/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
@@ -755,8 +755,9 @@ fcli.fod.issue.embed = Embed extra issue data. Due to FoD rate limits, this may 
   Using the --output option, this extra data can be included in the output. Using the --query option, \
   this extra data can be queried upon. To get an understanding of the structure and contents of the \
   embedded data, use the --output json or --output yaml options.
-fcli.fod.issue.list.includeIssue = By default, list will not display fixed or suppressed issues. \
-  Supply a comma separated list of attributes. Possible values are (fixed, suppressed).
+fcli.fod.issue.list.includeIssue = By default, fixed or suppressed issues will not be included. \
+  This option accepts 'fixed', 'suppressed' or 'fixed,suppressed' to include such issues in the \
+  output.
 
 # fcli fod report
 fcli.fod.report.usage.header = Manage FoD reports.

--- a/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
+++ b/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
@@ -755,6 +755,8 @@ fcli.fod.issue.embed = Embed extra issue data. Due to FoD rate limits, this may 
   Using the --output option, this extra data can be included in the output. Using the --query option, \
   this extra data can be queried upon. To get an understanding of the structure and contents of the \
   embedded data, use the --output json or --output yaml options.
+fcli.fod.issue.list.includeIssue = By default, list will not display fixed or suppressed issues. \
+  Supply a comma separated list of attributes. Possible values are (fixed, suppressed).
 
 # fcli fod report
 fcli.fod.report.usage.header = Manage FoD reports.


### PR DESCRIPTION
`fcli fod issue ls` didn't have an obvious/easy to have fixed and suppressed issues included in the output. 
This PR adds two options `--include-suppressed` and `--include-fixed`.
I've done some light testing of `--include-suppressed`, including testing with existing options like `--embed`, `-o`, and `-q` and everything appears to be working.

I have not done any testing with `--include-fixed` as I don't have a release with any fixed issues. Though the code for this option is almost exactly the same as `--include-suppressed`, so I expect for this to be okay.

This will address #545.