### PR TITLE
Added `--include` to `ssc av list`

### DIFF
--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/cli/cmd/SSCAppVersionListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/cli/cmd/SSCAppVersionListCommand.java
@@ -22,8 +22,8 @@ import com.fortify.cli.ssc._common.rest.query.SSCQParamGenerator;
 import com.fortify.cli.ssc._common.rest.query.SSCQParamValueGenerators;
 import com.fortify.cli.ssc._common.rest.query.cli.mixin.SSCQParamMixin;
 import com.fortify.cli.ssc.appversion.cli.mixin.SSCAppVersionBulkEmbedMixin;
+import com.fortify.cli.ssc.appversion.cli.mixin.SSCAppVersionIncludeMixin;
 import com.fortify.cli.ssc.appversion.helper.SSCAppVersionHelper;
-
 import kong.unirest.HttpRequest;
 import kong.unirest.UnirestInstance;
 import lombok.Getter;
@@ -40,7 +40,8 @@ public class SSCAppVersionListCommand extends AbstractSSCBaseRequestOutputComman
                 .add("application.id", "project.id", SSCQParamValueGenerators::plain)
                 .add("name", SSCQParamValueGenerators::wrapInQuotes);
     @Mixin private SSCAppVersionBulkEmbedMixin bulkEmbedMixin;
-    
+    @Mixin private SSCAppVersionIncludeMixin includeMixin;
+
     @Override
     public HttpRequest<?> getBaseRequest(UnirestInstance unirest) {
         return unirest.get("/api/v1/projectVersions?limit=100");

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/cli/mixin/SSCAppVersionIncludeMixin.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/cli/mixin/SSCAppVersionIncludeMixin.java
@@ -11,8 +11,8 @@ import java.util.Set;
 
 public class SSCAppVersionIncludeMixin implements IHttpRequestUpdater {
     @DisableTest(TestType.MULTI_OPT_PLURAL_NAME)
-    @Option(names = {"--include", "-i"}, split = ",", descriptionKey = "fcli.ssc.appversion.list.include", paramLabel="<status>")
-    private Set<SSCIssueInclude> includes;
+    @Option(names = {"--include", "-i"}, split = ",", descriptionKey = "fcli.ssc.appversion.list.include", paramLabel="<includeOption>")
+    private Set<SSCAppVersionInclude> includes;
 
     public HttpRequest<?> updateRequest(HttpRequest<?> request) {
         if ( includes!=null ) {
@@ -27,7 +27,7 @@ public class SSCAppVersionIncludeMixin implements IHttpRequestUpdater {
     }
 
     @RequiredArgsConstructor
-    public static enum SSCIssueInclude {
+    public static enum SSCAppVersionInclude {
         inactive("includeInactive"),
         onlyWithMyIssues("myAssignedIssues"),
         onlyNotEmpty("onlyIfHasIssues");

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/cli/mixin/SSCAppVersionIncludeMixin.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/cli/mixin/SSCAppVersionIncludeMixin.java
@@ -1,0 +1,38 @@
+package com.fortify.cli.ssc.appversion.cli.mixin;
+
+import com.fortify.cli.common.rest.unirest.IHttpRequestUpdater;
+import com.fortify.cli.common.util.DisableTest;
+import com.fortify.cli.common.util.DisableTest.TestType;
+import kong.unirest.HttpRequest;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import picocli.CommandLine.Option;
+import java.util.Set;
+
+public class SSCAppVersionIncludeMixin implements IHttpRequestUpdater {
+    @DisableTest(TestType.MULTI_OPT_PLURAL_NAME)
+    @Option(names = {"--include", "-i"}, split = ",", descriptionKey = "fcli.ssc.appversion.list.include", paramLabel="<status>")
+    private Set<SSCIssueInclude> includes;
+
+    public HttpRequest<?> updateRequest(HttpRequest<?> request) {
+        if ( includes!=null ) {
+            for ( var include : includes) {
+                var queryParameterName = include.getRequestParameterName();
+                if ( queryParameterName!=null ) {
+                    request = request.queryString(queryParameterName, "true");
+                }
+            }
+        }
+        return request;
+    }
+
+    @RequiredArgsConstructor
+    public static enum SSCIssueInclude {
+        inactive("includeInactive"),
+        onlyWithMyIssues("myAssignedIssues"),
+        onlyNotEmpty("onlyIfHasIssues");
+
+        @Getter
+        private final String requestParameterName;
+    }
+}

--- a/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/i18n/SSCMessages.properties
+++ b/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/i18n/SSCMessages.properties
@@ -342,6 +342,10 @@ fcli.ssc.appversion.list.embed = Embed extra application version data. Allowed v
   Using the --output option, this extra data can be included in the output. Using the --query option, \
   this extra data can be queried upon. To get an understanding of the structure and contents of the \
   embedded data, use the --output json or --output yaml options. 
+fcli.ssc.appversion.list.include = This option accepts a comma-separated of include arguments. One available argument \
+  allows you to include deactivated (inactive) App Versions. It is also possible to only retrieve App Versions where \
+  you have issues assigned to your user account (onlyWithMyIssues), or only App Versions that have issues populated in \
+  them (onlyNotEmpty). Allowed values: ${COMPLETION-CANDIDATES}.
 fcli.ssc.appversion.purge-artifacts.usage.header = Purge application version artifacts.
 fcli.ssc.appversion.purge-artifacts.usage.description = Purge all application version artifacts older than the specified date. See 'fcli ssc artifact purge' for purging individual artifacts. 
 fcli.ssc.appversion.purge-artifacts.older-than = Purge artifacts older than the specified value, \


### PR DESCRIPTION
Created to address #556 .

I've added an `include` option to `ssc av ls`. 
I'm not very confident that I've chosen the best names for the arguments that can be supplied to the `--include` option.