### PR TITLE
Fixes for `fod action run release-summary`

### DIFF
--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/json/JSONDateTimeConverter.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/json/JSONDateTimeConverter.java
@@ -56,7 +56,7 @@ public final class JSONDateTimeConverter implements Converter<String,Date> {
 	}
 
 	public static final DateTimeFormatter createDefaultDateTimeFormatter() {
-		return DateTimeFormatter.ofPattern("yyyy-MM-dd[['T'][' ']HH:mm:ss[.SSS][.SS]][ZZZZ][Z][XXX][XX][X]");
+		return DateTimeFormatter.ofPattern("yyyy-MM-dd[['T'][' ']HH:mm:ss[.SSS][.SS][.S]][ZZZZ][Z][XXX][XX][X]");
 	}
 	
 	@Override

--- a/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/actions/zip/release-summary.yaml
+++ b/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/actions/zip/release-summary.yaml
@@ -65,16 +65,16 @@ steps:
               value: ${issues_raw.totalCount}
           - set:
             - name: ossCritical
-              value: ${issues_raw.filters.?[#this.fieldName == 'severity'][0].fieldFilterValues.?[#this.value == "Critical"][0]?.count?:0}       
+              value: ${issues_raw.filters.?[#this.fieldName == 'severity'][0].fieldFilterValues.^[#this.value == "Critical"]?.count?:0}       
           - set:
             - name: ossHigh
-              value: ${issues_raw.filters.?[#this.fieldName == 'severity'][0].fieldFilterValues.?[#this.value == "High"][0]?.count?:0}   
+              value: ${issues_raw.filters.?[#this.fieldName == 'severity'][0].fieldFilterValues.^[#this.value == "High"]?.count?:0}   
           - set:
             - name: ossMedium
-              value: ${issues_raw.filters.?[#this.fieldName == 'severity'][0].fieldFilterValues.?[#this.value == "Medium"][0]?.count?:0}   
+              value: ${issues_raw.filters.?[#this.fieldName == 'severity'][0].fieldFilterValues.^[#this.value == "Medium"]?.count?:0}   
           - set:
             - name: ossLow
-              value: ${issues_raw.filters.?[#this.fieldName == 'severity'][0].fieldFilterValues.?[#this.value == "Low"][0]?.count?:0}                      
+              value: ${issues_raw.filters.?[#this.fieldName == 'severity'][0].fieldFilterValues.^[#this.value == "Low"]?.count?:0}                      
   # replace up to here
 
   - write:


### PR DESCRIPTION
Updated `release-summary` action to work with FoD concatenated seconds format and when there are zero issues for a severity level.