### PR TITLE
Updated `fcli fod xxx-scan wait-for` documentation for release and scan id preference

### DIFF
--- a/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
+++ b/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
@@ -417,10 +417,10 @@ fcli.fod.scan.wait-for.usage.description.0 = Although this command offers a lot 
   is detected, an exception will be thrown.
 fcli.fod.scan.wait-for.usage.description.1 = %nThe following states are currently known by fcli:
 fcli.fod.scan.wait-for.usage.description.2 = ${fcli.fod.scan.states:-See fcli help output}
-fcli.fod.scan.wait-for.usage.description.3 = %nPlease note it is recommended to pass '<release-id>:<scan-id>' items \
-  to this command rather than just '<scan-id>' items. If '<scan-id>' only is passed then its status might not be available and a \
-  a '404 - Not Found' error produced. It is recommended to pass a fcli variable to do this as it will automatically resolve \
-  to using <release-id>:<scan-id>. For example, to start a SAST scan and wait for it complete use: %n \
+fcli.fod.scan.wait-for.usage.description.3 = %nPlease note it is recommended to pass the scan id's as '<release-id>:<scan-id>' \
+  rather than just '<scan-id>'. If only '<scan-id>' is passed then its status might not be available yet, causing FoD to return \
+  a '404 - Not Found' error . It is recommended to pass a fcli variable to do this as it will automatically resolve \
+  to using <release-id>:<scan-id>. For example, to start a SAST scan and wait for it to complete, use: %n \
   %n    fcli fod sast-scan start ... --store scan \
   %n    fcli fod sast-scan wait-for ::scan::
 fcli.fod.scan.wait-for.until = Wait until either any or all scans match. If neither --until or --while are specified, default is to wait until all scans match.

--- a/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
+++ b/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
@@ -28,7 +28,7 @@ fcli.fod.app.app-name-or-id = Application id or name. Note that numeric values a
 fcli.fod.app.app-type = Application type. Valid values: ${COMPLETION-CANDIDATES}
 fcli.fod.app.release.microservice-and-release-name = Initial release to be created on the application, in the format <microservice>:<release> for a microservices application, or just <release> for non-microservices applications.
 fcli.fod.scan.scan-id = Scan id.
-fcli.fod.scan.scan-ids = Scan id(s).
+fcli.fod.scan.scan-ids = Whitespace separated list of <release-id>:<scan-id> or <scan-id> items.
 fcli.fod.scan.entitlement-frequency = The entitlement frequency type to use. Valid values: ${COMPLETION-CANDIDATES}.
 fcli.fod.scan.analysis-status = Scan analysis status. Valid values: ${COMPLETION-CANDIDATES}.
 fcli.fod.scan.scan-type = Scan type. Valid values: ${COMPLETION-CANDIDATES}.
@@ -417,6 +417,12 @@ fcli.fod.scan.wait-for.usage.description.0 = Although this command offers a lot 
   is detected, an exception will be thrown.
 fcli.fod.scan.wait-for.usage.description.1 = %nThe following states are currently known by fcli:
 fcli.fod.scan.wait-for.usage.description.2 = ${fcli.fod.scan.states:-See fcli help output}
+fcli.fod.scan.wait-for.usage.description.3 = %nPlease note it is recommended to pass '<release-id>:<scan-id>' items \
+  to this command rather than just '<scan-id>' items. If '<scan-id>' only is passed then its status might not be available and a \
+  a '404 - Not Found' error produced. It is recommended to pass a fcli variable to do this as it will automatically resolve \
+  to using <release-id>:<scan-id>. For example, to start a SAST scan and wait for it complete use: %n \
+  %n    fcli fod sast-scan start ... --store scan \
+  %n    fcli fod sast-scan wait-for ::scan::
 fcli.fod.scan.wait-for.until = Wait until either any or all scans match. If neither --until or --while are specified, default is to wait until all scans match.
 fcli.fod.scan.wait-for.while = Wait while either any or all scans match.
 fcli.fod.scan.wait-for.any-state = One or more scan states against which to match the given scans.
@@ -446,6 +452,7 @@ fcli.fod.sast-scan.wait-for.usage.header = Wait for one or more SAST scans to re
 fcli.fod.sast-scan.wait-for.usage.description.0 = ${fcli.fod.scan.wait-for.usage.description.0}
 fcli.fod.sast-scan.wait-for.usage.description.1 = ${fcli.fod.scan.wait-for.usage.description.1}
 fcli.fod.sast-scan.wait-for.usage.description.2 = ${fcli.fod.scan.states:-See fcli help output}
+fcli.fod.sast-scan.wait-for.usage.description.3 = ${fcli.fod.scan.wait-for.usage.description.3}
 fcli.fod.sast-scan.wait-for.until = ${fcli.fod.scan.wait-for.until}
 fcli.fod.sast-scan.wait-for.while = ${fcli.fod.scan.wait-for.while}
 fcli.fod.sast-scan.wait-for.any-state = ${fcli.fod.scan.wait-for.any-state}
@@ -521,6 +528,7 @@ fcli.fod.dast-scan.wait-for.usage.header = (PREVIEW) Wait for one or more DAST s
 fcli.fod.dast-scan.wait-for.usage.description.0 = ${fcli.fod.scan.wait-for.usage.description.0}
 fcli.fod.dast-scan.wait-for.usage.description.1 = ${fcli.fod.scan.wait-for.usage.description.1}
 fcli.fod.dast-scan.wait-for.usage.description.2 = ${fcli.fod.scan.states:-See fcli help output}
+fcli.fod.dast-scan.wait-for.usage.description.3 = ${fcli.fod.scan.wait-for.usage.description.3}
 fcli.fod.dast-scan.wait-for.until = ${fcli.fod.scan.wait-for.until}
 fcli.fod.dast-scan.wait-for.while = ${fcli.fod.scan.wait-for.while}
 fcli.fod.dast-scan.wait-for.any-state = ${fcli.fod.scan.wait-for.any-state}
@@ -680,6 +688,7 @@ fcli.fod.mast-scan.wait-for.usage.header = Wait for one or more MAST scans to re
 fcli.fod.mast-scan.wait-for.usage.description.0 = ${fcli.fod.scan.wait-for.usage.description.0}
 fcli.fod.mast-scan.wait-for.usage.description.1 = ${fcli.fod.scan.wait-for.usage.description.1}
 fcli.fod.mast-scan.wait-for.usage.description.2 = ${fcli.fod.scan.states:-See fcli help output}
+fcli.fod.mast-scan.wait-for.usage.description.3 = ${fcli.fod.scan.wait-for.usage.description.3}
 fcli.fod.mast-scan.wait-for.until = ${fcli.fod.scan.wait-for.until}
 fcli.fod.mast-scan.wait-for.while = ${fcli.fod.scan.wait-for.while}
 fcli.fod.mast-scan.wait-for.any-state = ${fcli.fod.scan.wait-for.any-state}
@@ -754,6 +763,7 @@ fcli.fod.oss-scan.wait-for.usage.header = Wait for one or more OSS scans to reac
 fcli.fod.oss-scan.wait-for.usage.description.0 = ${fcli.fod.scan.wait-for.usage.description.0}
 fcli.fod.oss-scan.wait-for.usage.description.1 = ${fcli.fod.scan.wait-for.usage.description.1}
 fcli.fod.oss-scan.wait-for.usage.description.2 = ${fcli.fod.scan.states:-See fcli help output}
+fcli.fod.oss-scan.wait-for.usage.description.3 = ${fcli.fod.scan.wait-for.usage.description.3}
 fcli.fod.oss-scan.wait-for.until = ${fcli.fod.scan.wait-for.until}
 fcli.fod.oss-scan.wait-for.while = ${fcli.fod.scan.wait-for.while}
 fcli.fod.oss-scan.wait-for.any-state = ${fcli.fod.scan.wait-for.any-state}

--- a/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
+++ b/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
@@ -419,7 +419,7 @@ fcli.fod.scan.wait-for.usage.description.1 = %nThe following states are currentl
 fcli.fod.scan.wait-for.usage.description.2 = ${fcli.fod.scan.states:-See fcli help output}
 fcli.fod.scan.wait-for.usage.description.3 = %nPlease note it is recommended to pass the scan id's as '<release-id>:<scan-id>' \
   rather than just '<scan-id>'. If only '<scan-id>' is passed then its status might not be available yet, causing FoD to return \
-  a '404 - Not Found' error . It is recommended to pass a fcli variable to do this as it will automatically resolve \
+  a '404 - Not Found' error. It is recommended to pass a fcli variable to do this as it will automatically resolve \
   to using <release-id>:<scan-id>. For example, to start a SAST scan and wait for it to complete, use: %n \
   %n    fcli fod sast-scan start ... --store scan \
   %n    fcli fod sast-scan wait-for ::scan::


### PR DESCRIPTION
Updated documentation so it now looks like the following:

```
Wait for one or more SAST scans to reach or exit specified scan statuses.

Usage: fcli fod sast-scan wait-for [--delim=<delimiter>] [-i=<intervalPeriod>]
                                   [--on-failure-state=<onFailureState>]
                                   [--on-timeout=<onTimeout>]
                                   [--on-unknown-state=<onUnknownState>]
                                   [--on-unknown-state-requested=<onUnknownState
                                   Requested>] [--progress=<type>]
                                   [-t=<timeoutPeriod>] [-s=<states>[,
                                   <states>...]]... [[-h]
                                   [--env-prefix=<envPrefix>]
                                   [--log-file=<logFile>]
                                   [--log-level=<logLevel>]] [[-o=format
                                   [=<options>]] [--store=variableName
                                   [=<propertyNames>]]
                                   [--to-file=<outputFile>]]
                                   [-u=any-match|all-match |
                                   -w=any-match|all-match]
                                   [[--session=<sessionName>]] scan-id's...

Although this command offers a lot of options to cover many different use
cases, you can simply pass a scan id (possibly stored using --store on one of
the 'scan start-*' commands) to wait for scan completion. If any error state or
unknown state is detected, an exception will be thrown.

The following states are currently known by fcli:
Not_Started, In_Progress, Completed, Canceled, Waiting, Scheduled, Queued

Please note it is recommended to pass '<release-id>:<scan-id>' items to this
command rather than just '<scan-id>' items. If '<scan-id>' only is passed then
its status might not be available and a a '404 - Not Found' error produced. It
is recommended to pass a fcli variable to do this as it will automatically
resolve to using <release-id>:<scan-id>. For example, to start a SAST scan and
wait for it complete use:

    fcli fod sast-scan start ... --store scan
    fcli fod sast-scan wait-for ::scan::

Command parameters:
      scan-id's...           Whitespace separated list of <release-id>:
                               <scan-id> or <scan-id> items.

Command options:
```