### PR TITLE
feat: fcli sc-sast session login: Allow for overriding SC SAST Controller URL (resolves #611)

### DIFF
--- a/fcli-core/fcli-sc-sast/src/main/java/com/fortify/cli/sc_sast/_common/session/cli/mixin/SCSastUrlConfigOptions.java
+++ b/fcli-core/fcli-sc-sast/src/main/java/com/fortify/cli/sc_sast/_common/session/cli/mixin/SCSastUrlConfigOptions.java
@@ -20,9 +20,18 @@ import picocli.CommandLine.Option;
 
 public class SCSastUrlConfigOptions extends ConnectionConfigOptions implements IUrlConfig {
     @Option(names = {"--ssc-url"}, required = true, order=1)
-    @Getter private String url;
+    @Getter private String ssc_url;
+    
+    @Option(names = {"--ctrl-url", "-curl"}, required = false)
+    @Getter private String controllerUrl;
     
     public boolean hasUrlConfig() {
-        return url!=null;
+        return (ssc_url!=null) || (controllerUrl != null);
     }
+
+	@Override
+	public String getUrl() {
+		return ssc_url;
+	}
+	
 }

--- a/fcli-core/fcli-sc-sast/src/main/java/com/fortify/cli/sc_sast/_common/session/helper/SCSastSessionDescriptor.java
+++ b/fcli-core/fcli-sc-sast/src/main/java/com/fortify/cli/sc_sast/_common/session/helper/SCSastSessionDescriptor.java
@@ -30,6 +30,7 @@ import com.fortify.cli.common.session.helper.SessionSummary;
 import com.fortify.cli.common.util.DateTimePeriodHelper;
 import com.fortify.cli.common.util.DateTimePeriodHelper.Period;
 import com.fortify.cli.common.util.StringUtils;
+import com.fortify.cli.sc_sast._common.session.cli.mixin.SCSastUrlConfigOptions;
 import com.fortify.cli.ssc._common.session.helper.ISSCCredentialsConfig;
 import com.fortify.cli.ssc._common.session.helper.ISSCUserCredentialsConfig;
 import com.fortify.cli.ssc.access_control.helper.SSCTokenCreateRequest;
@@ -63,7 +64,19 @@ public class SCSastSessionDescriptor extends AbstractSessionDescriptor {
         this.scSastClientAuthToken = scSastClientAuthToken;
         this.cachedSscTokenResponse = getOrGenerateToken(sscUrlConfig, credentialsConfig);
         char[] activeToken = getActiveSSCToken();
-        this.scSastUrlConfig = activeToken==null ? null : buildScSastUrlConfig(sscUrlConfig, scSastUrlConfig, activeToken);
+        
+		if (sscUrlConfig instanceof SCSastUrlConfigOptions sastCtrlUrl) {
+			String controllerUrl = sastCtrlUrl.getControllerUrl();
+			
+			if (controllerUrl!=null) {
+				UrlConfig.UrlConfigBuilder builder = UrlConfig.builderFrom(sscUrlConfig, scSastUrlConfig);
+				builder.url(controllerUrl);
+				this.scSastUrlConfig = builder.build();
+			} else {
+				this.scSastUrlConfig = activeToken == null ? null
+						: buildScSastUrlConfig(sscUrlConfig, scSastUrlConfig, activeToken);
+			}
+		}
     }
 
     @JsonIgnore

--- a/fcli-core/fcli-sc-sast/src/main/resources/com/fortify/cli/sc_sast/i18n/SCSastMessages.properties
+++ b/fcli-core/fcli-sc-sast/src/main/resources/com/fortify/cli/sc_sast/i18n/SCSastMessages.properties
@@ -74,6 +74,7 @@ fcli.sc-sast.session.login.ssc-url.0 = SSC URL.
 fcli.sc-sast.session.login.ssc-url.1 = Environment variables:%n \
   ${fcli.env.default.prefix}_SSC_URL: Shared with SSC/SC DAST%n \
   ${fcli.env.default.prefix}_SC_SAST_SSC_URL: Only SC SAST commands
+fcli.sc-sast.session.login.ctrl-url.0 = Scan Central Controller URL.\By default the Controller URL shall be fetched from the SSC configuration, however with the use of this option, the user defined controller URL overrides the one fetched from SSC Configuration 
   
 # fcli sc-sast session logout
 fcli.sc-sast.session.logout.usage.header = Terminate ScanCentral SAST session.


### PR DESCRIPTION
Added support in FCLI to accept an optional argument --ctrl-url which accepts the controller URL and in such cases the user input overrides the controller URL fetched from the SSC configurations.

Example Command:
sc-sast session login --ssc-url="http********************************" --ctrl-url "http**************************" -u********* -p***** -c********!