### PR TITLE
Add query string embed=scan to get artifact

### DIFF
--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/artifact/cli/cmd/SSCArtifactGetCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/artifact/cli/cmd/SSCArtifactGetCommand.java
@@ -31,7 +31,7 @@ public class SSCArtifactGetCommand extends AbstractSSCArtifactOutputCommand impl
     
     @Override
     public HttpRequest<?> getBaseRequest() {
-        return getUnirestInstance().get(SSCUrls.ARTIFACT(artifactId));
+        return getUnirestInstance().get(SSCUrls.ARTIFACT(artifactId)).queryString("embed","scans");
     }
     
     @Override


### PR DESCRIPTION
The `fcli ssc artifact get` command has been updated to address #637 .

Example output looks like the following, where the new data added is in the `_embed` attribute:
```
PS C:\Users\mike\IdeaProjects\fcli> java -jar fcli-core/fcli-app/build/libs/fcli.jar ssc artifact get 28
---
id: 28
artifactType: FPR
status: PROCESS_COMPLETE
allowDelete: true
allowPurge: false
allowApprove: false
inModifyingStatus: false
uploadDate: 2024-11-08T12:38:27.434+00:00
approvalComment: null
approvalDate: null
approvalUsername: null
auditUpdated: true
messages: ""
messageCount: 0
purged: false
fileName: 710fab6321d14adb9c81e93db7cdbb14.fpr
fileSize: 2174853
fileURL: null
originalFileName: Logistics_2.5_2024-11-08.fpr
uploadIP: null
userName: admin
versionNumber: null
otherStatus: NOT_EXIST
runtimeStatus: NONE
scaStatus: PROCESSED
webInspectStatus: NONE
lastScanDate: 2009-11-24T16:49:10.000+00:00
scanErrorsCount: 0
indexed: true
projectVersionId: 6
_embed:
  scans:
  - id: 16
    guid: 3140d521-b46d-41c9-b1a4-f93c9ec59cf0
    uploadDate: 2009-11-24T16:49:10.000+00:00
    type: SCA
    certification: INVALID
    hostname: rocket.local
    engineVersion: 5.7.0.0025
    artifactId: 28
    noOfFiles: 98
    totalLOC: 4509
    execLOC: 1438
    elapsedTime: 01:49
    fortifyAnnotationsLOC: 0
    buildId: splc
_href: https://localhost/api/v1/artifacts/28
scanTypes: SCA

```