### PR TITLE
feat: `fcli sc-sast session login`: Allow for overriding SC SAST Controller URL (resolves #611)

### DIFF
--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/rest/unirest/config/UrlConfig.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/rest/unirest/config/UrlConfig.java
@@ -35,6 +35,9 @@ public class UrlConfig implements IUrlConfig {
     }
     
     public static final UrlConfigBuilder builderFrom(IUrlConfig other) {
+        if (null != other) {
+            return builderFrom(other).url(other.getUrl());
+        }
         return builderFrom(other);
     }
     

--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/rest/unirest/config/UrlConfig.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/rest/unirest/config/UrlConfig.java
@@ -35,15 +35,7 @@ public class UrlConfig implements IUrlConfig {
     }
     
     public static final UrlConfigBuilder builderFrom(IUrlConfig other) {
-        UrlConfigBuilder builder = UrlConfig.builder();
-        if ( other!=null ) {
-            builder = builder
-                .url(other.getUrl())
-                .insecureModeEnabled(other.isInsecureModeEnabled())
-                .connectTimeoutInMillis(other.getConnectTimeoutInMillis())
-                .socketTimeoutInMillis(other.getSocketTimeoutInMillis());
-        }
-        return builder;
+        return builderFrom(other);
     }
     
     public static final UrlConfigBuilder builderFrom(IUrlConfig other, IUrlConfig overrides) {
@@ -53,6 +45,17 @@ public class UrlConfig implements IUrlConfig {
             override(overrides.getInsecureModeEnabled(), builder::insecureModeEnabled);
             builder.connectTimeoutInMillis(overrides.getConnectTimeoutInMillis())
                 .socketTimeoutInMillis(overrides.getSocketTimeoutInMillis());
+        }
+        return builder;
+    }
+    
+    public static final UrlConfigBuilder builderFrom(IConnectionConfig other) {
+        UrlConfigBuilder builder = UrlConfig.builder();
+        if ( other!=null ) {
+            builder = builder
+                .insecureModeEnabled(other.isInsecureModeEnabled())
+                .connectTimeoutInMillis(other.getConnectTimeoutInMillis())
+                .socketTimeoutInMillis(other.getSocketTimeoutInMillis());
         }
         return builder;
     }

--- a/fcli-core/fcli-sc-sast/src/main/java/com/fortify/cli/sc_sast/_common/session/cli/cmd/SCSastSessionLoginCommand.java
+++ b/fcli-core/fcli-sc-sast/src/main/java/com/fortify/cli/sc_sast/_common/session/cli/cmd/SCSastSessionLoginCommand.java
@@ -41,9 +41,9 @@ public class SCSastSessionLoginCommand extends AbstractSessionLoginCommand<SCSas
     
     @Override
     protected SCSastSessionDescriptor login(String sessionName) {
-        ISCSastAndSSCUrlConfig urlConfig = sessionLoginOptions.getUrlConfigOptions();
+        ISCSastAndSSCUrlConfig scSastAndSscUrlConfig = sessionLoginOptions.getScSastAndSscUrlConfigOptions();
         ISSCCredentialsConfig credentialsConfig = sessionLoginOptions.getCredentialOptions();
-        return new SCSastSessionDescriptor(urlConfig, credentialsConfig, sessionLoginOptions.getClientAuthToken());
+        return new SCSastSessionDescriptor(scSastAndSscUrlConfig, credentialsConfig, sessionLoginOptions.getClientAuthToken());
     }
     
     @Override

--- a/fcli-core/fcli-sc-sast/src/main/java/com/fortify/cli/sc_sast/_common/session/cli/cmd/SCSastSessionLoginCommand.java
+++ b/fcli-core/fcli-sc-sast/src/main/java/com/fortify/cli/sc_sast/_common/session/cli/cmd/SCSastSessionLoginCommand.java
@@ -15,10 +15,10 @@ package com.fortify.cli.sc_sast._common.session.cli.cmd;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.rest.unirest.GenericUnirestFactory;
 import com.fortify.cli.common.rest.unirest.UnexpectedHttpResponseException;
-import com.fortify.cli.common.rest.unirest.config.IUrlConfig;
 import com.fortify.cli.common.session.cli.cmd.AbstractSessionLoginCommand;
 import com.fortify.cli.sc_sast._common.rest.helper.SCSastUnirestHelper;
 import com.fortify.cli.sc_sast._common.session.cli.mixin.SCSastSessionLoginOptions;
+import com.fortify.cli.sc_sast._common.session.helper.ISCSastAndSSCUrlConfig;
 import com.fortify.cli.sc_sast._common.session.helper.SCSastSessionDescriptor;
 import com.fortify.cli.sc_sast._common.session.helper.SCSastSessionHelper;
 import com.fortify.cli.ssc._common.session.helper.ISSCCredentialsConfig;
@@ -41,7 +41,7 @@ public class SCSastSessionLoginCommand extends AbstractSessionLoginCommand<SCSas
     
     @Override
     protected SCSastSessionDescriptor login(String sessionName) {
-        IUrlConfig urlConfig = sessionLoginOptions.getUrlConfigOptions();
+        ISCSastAndSSCUrlConfig urlConfig = sessionLoginOptions.getUrlConfigOptions();
         ISSCCredentialsConfig credentialsConfig = sessionLoginOptions.getCredentialOptions();
         return new SCSastSessionDescriptor(urlConfig, credentialsConfig, sessionLoginOptions.getClientAuthToken());
     }

--- a/fcli-core/fcli-sc-sast/src/main/java/com/fortify/cli/sc_sast/_common/session/cli/mixin/SCSastAndSSCUrlConfigOptions.java
+++ b/fcli-core/fcli-sc-sast/src/main/java/com/fortify/cli/sc_sast/_common/session/cli/mixin/SCSastAndSSCUrlConfigOptions.java
@@ -24,8 +24,4 @@ public class SCSastAndSSCUrlConfigOptions extends ConnectionConfigOptions implem
     
     @Option(names = {"--ctrl-url", "-curl"}, required = false, order=1)
     @Getter private String controllerUrl;
-//    
-//    public boolean hasUrlConfig() {
-//        return controllerUrl!=null;
-//    }
 }

--- a/fcli-core/fcli-sc-sast/src/main/java/com/fortify/cli/sc_sast/_common/session/cli/mixin/SCSastAndSSCUrlConfigOptions.java
+++ b/fcli-core/fcli-sc-sast/src/main/java/com/fortify/cli/sc_sast/_common/session/cli/mixin/SCSastAndSSCUrlConfigOptions.java
@@ -13,16 +13,19 @@
 package com.fortify.cli.sc_sast._common.session.cli.mixin;
 
 import com.fortify.cli.common.rest.cli.mixin.ConnectionConfigOptions;
-import com.fortify.cli.common.rest.unirest.config.IUrlConfig;
+import com.fortify.cli.sc_sast._common.session.helper.ISCSastAndSSCUrlConfig;
 
 import lombok.Getter;
 import picocli.CommandLine.Option;
 
-public class SCSastUrlConfigOptions extends ConnectionConfigOptions implements IUrlConfig {
+public class SCSastAndSSCUrlConfigOptions extends ConnectionConfigOptions implements ISCSastAndSSCUrlConfig {
     @Option(names = {"--ssc-url"}, required = true, order=1)
-    @Getter private String url;
+    @Getter private String sscUrl;
     
-    public boolean hasUrlConfig() {
-        return url!=null;
-    }
+    @Option(names = {"--ctrl-url", "-curl"}, required = false, order=1)
+    @Getter private String controllerUrl;
+//    
+//    public boolean hasUrlConfig() {
+//        return controllerUrl!=null;
+//    }
 }

--- a/fcli-core/fcli-sc-sast/src/main/java/com/fortify/cli/sc_sast/_common/session/cli/mixin/SCSastSessionLoginOptions.java
+++ b/fcli-core/fcli-sc-sast/src/main/java/com/fortify/cli/sc_sast/_common/session/cli/mixin/SCSastSessionLoginOptions.java
@@ -21,7 +21,7 @@ import picocli.CommandLine.Option;
 
 public class SCSastSessionLoginOptions {
     @ArgGroup(exclusive = false, multiplicity = "1", order = 1)
-    @Getter private SCSastUrlConfigOptions urlConfigOptions = new SCSastUrlConfigOptions();
+    @Getter private SCSastAndSSCUrlConfigOptions urlConfigOptions = new SCSastAndSSCUrlConfigOptions();
     
     @Option(names = {"--client-auth-token", "-c"}, required = true, interactive = true, arity = "0..1", echo = false) 
     @Getter private char[] clientAuthToken;

--- a/fcli-core/fcli-sc-sast/src/main/java/com/fortify/cli/sc_sast/_common/session/cli/mixin/SCSastSessionLoginOptions.java
+++ b/fcli-core/fcli-sc-sast/src/main/java/com/fortify/cli/sc_sast/_common/session/cli/mixin/SCSastSessionLoginOptions.java
@@ -21,7 +21,7 @@ import picocli.CommandLine.Option;
 
 public class SCSastSessionLoginOptions {
     @ArgGroup(exclusive = false, multiplicity = "1", order = 1)
-    @Getter private SCSastAndSSCUrlConfigOptions urlConfigOptions = new SCSastAndSSCUrlConfigOptions();
+    @Getter private SCSastAndSSCUrlConfigOptions scSastAndSscUrlConfigOptions = new SCSastAndSSCUrlConfigOptions();
     
     @Option(names = {"--client-auth-token", "-c"}, required = true, interactive = true, arity = "0..1", echo = false) 
     @Getter private char[] clientAuthToken;

--- a/fcli-core/fcli-sc-sast/src/main/java/com/fortify/cli/sc_sast/_common/session/helper/ISCSastAndSSCUrlConfig.java
+++ b/fcli-core/fcli-sc-sast/src/main/java/com/fortify/cli/sc_sast/_common/session/helper/ISCSastAndSSCUrlConfig.java
@@ -8,9 +8,7 @@ import com.fortify.cli.common.rest.unirest.config.IConnectionConfig;
 /**
  * Interface for the functions to get the SSC URL and the Controller URL
  */
-public interface ISCSastAndSSCUrlConfig extends IConnectionConfig{
-    
+public interface ISCSastAndSSCUrlConfig extends IConnectionConfig {
     String getSscUrl();
-    
     String getControllerUrl();
 }

--- a/fcli-core/fcli-sc-sast/src/main/java/com/fortify/cli/sc_sast/_common/session/helper/ISCSastAndSSCUrlConfig.java
+++ b/fcli-core/fcli-sc-sast/src/main/java/com/fortify/cli/sc_sast/_common/session/helper/ISCSastAndSSCUrlConfig.java
@@ -1,0 +1,16 @@
+/**
+ * 
+ */
+package com.fortify.cli.sc_sast._common.session.helper;
+
+import com.fortify.cli.common.rest.unirest.config.IConnectionConfig;
+
+/**
+ * Interface for the functions to get the SSC URL and the Controller URL
+ */
+public interface ISCSastAndSSCUrlConfig extends IConnectionConfig{
+    
+    String getSscUrl();
+    
+    String getControllerUrl();
+}

--- a/fcli-core/fcli-sc-sast/src/main/resources/com/fortify/cli/sc_sast/i18n/SCSastMessages.properties
+++ b/fcli-core/fcli-sc-sast/src/main/resources/com/fortify/cli/sc_sast/i18n/SCSastMessages.properties
@@ -74,6 +74,7 @@ fcli.sc-sast.session.login.ssc-url.0 = SSC URL.
 fcli.sc-sast.session.login.ssc-url.1 = Environment variables:%n \
   ${fcli.env.default.prefix}_SSC_URL: Shared with SSC/SC DAST%n \
   ${fcli.env.default.prefix}_SC_SAST_SSC_URL: Only SC SAST commands
+fcli.sc-sast.session.login.ctrl-url = Scan Central Controller URL.%n\By default the Controller URL shall be fetched from the SSC configuration, however with the use of this option, the user defined controller URL overrides the one fetched from SSC Configuration.
   
 # fcli sc-sast session logout
 fcli.sc-sast.session.logout.usage.header = Terminate ScanCentral SAST session.

--- a/fcli-core/fcli-sc-sast/src/main/resources/com/fortify/cli/sc_sast/i18n/SCSastMessages.properties
+++ b/fcli-core/fcli-sc-sast/src/main/resources/com/fortify/cli/sc_sast/i18n/SCSastMessages.properties
@@ -74,7 +74,7 @@ fcli.sc-sast.session.login.ssc-url.0 = SSC URL.
 fcli.sc-sast.session.login.ssc-url.1 = Environment variables:%n \
   ${fcli.env.default.prefix}_SSC_URL: Shared with SSC/SC DAST%n \
   ${fcli.env.default.prefix}_SC_SAST_SSC_URL: Only SC SAST commands
-fcli.sc-sast.session.login.ctrl-url = Scan Central Controller URL.%n\By default the Controller URL shall be fetched from the SSC configuration, however with the use of this option, the user defined controller URL overrides the one fetched from SSC Configuration.
+fcli.sc-sast.session.login.ctrl-url = Override ScanCentral SAST Controller URL. If not specified, the controller URL as configured in SSC will be used.
   
 # fcli sc-sast session logout
 fcli.sc-sast.session.logout.usage.header = Terminate ScanCentral SAST session.


### PR DESCRIPTION
Added support in FCLI to accept an optional argument **--ctrl-url** which accepts the controller URL and in such cases the user input overrides the controller URL fetched from the SSC configurations.

### Example Command:
_sc-sast session login --ssc-url="http**********************" --ctrl-url "http************************" -u******* -p***** -c*******_

### Scenarios Tested:

1. **SSC URL**: http**************** has enabled SC SAST and the Controller URL is http*************. FCLI detected the controller URL automatically without having the **--ctrl-url** argument. The SC SAST session login was successful.
2. **SSC URL**: http****************** has disabled SC SAST and FCLI could not read the SSC Configuration for the Controller URL, throws an error. The SC SAST session login fails.
3. **SSC URL**: http************************* has disabled SC SAST. An Optional Argument for the Controller URL **--ctrl-url** was mentioned as http*******************. The SC SAST session login was successful as FCLI did not attempt to read the controller URL from the SSC Configurations.