### PR TITLE
feat:Add --active argument to fcli ssc appversion update, in order to allow activating/deactivating existing applications versions using fcli (resolves #625)

### DIFF
--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/cli/cmd/SSCAppVersionUpdateCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/cli/cmd/SSCAppVersionUpdateCommand.java
@@ -53,6 +53,8 @@ public class SSCAppVersionUpdateCommand extends AbstractSSCJsonNodeOutputCommand
     private String name;
     @Option(names={"--description","-d"}, required = false)
     private String description;
+    @Option(names={"--active"}, required = false, defaultValue=Option.NULL_VALUE, arity="1")
+    private Boolean active;
     
     @Override
     public JsonNode getJsonNode(UnirestInstance unirest) {
@@ -100,6 +102,10 @@ public class SSCAppVersionUpdateCommand extends AbstractSSCJsonNodeOutputCommand
         boolean hasUpdate = optionalUpdate(updateData, "name", getUnqualifiedVersionName(name, descriptor));
         hasUpdate |= optionalUpdate(updateData, "description", description);
         hasUpdate |= optionalUpdate(updateData, issueTemplateResolver.getIssueTemplateDescriptor(unirest));
+        if (null != active) {
+            updateData.put("active", active);
+            hasUpdate |= true;
+        }
         return hasUpdate 
                 ? unirest.put(SSCUrls.PROJECT_VERSION(descriptor.getVersionId())).body(updateData)
                 : null;

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/helper/SSCAppVersionHelper.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/helper/SSCAppVersionHelper.java
@@ -60,7 +60,7 @@ public class SSCAppVersionHelper {
     }
 
     private static GetRequest getBaseRequest(UnirestInstance unirest, String... fields) {
-        GetRequest request = unirest.get("/api/v1/projectVersions?limit=2");
+        GetRequest request = unirest.get("/api/v1/projectVersions?includeInactive=true&limit=2");
         if ( fields!=null && fields.length>0 ) {
             request.queryString("fields", String.join(",", fields));
         }

--- a/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/i18n/SSCMessages.properties
+++ b/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/i18n/SSCMessages.properties
@@ -369,6 +369,8 @@ fcli.ssc.appversion.update.usage.description = This command allows for updating 
   or --rm-users option may not be applied if the fcli session was created using a CIToken.
 fcli.ssc.appversion.update.name = Update application version name.
 fcli.ssc.appversion.update.description = Update application version description.
+fcli.ssc.appversion.update.active = Specify whether application version should be activated (true) \
+  or not (false).
 fcli.ssc.appversion.resolver.name = Application and version name.
 fcli.ssc.appversion.resolver.nameOrId = Application version id or <application>:<version> name.
 fcli.ssc.appversion.resolver.copy-from.nameOrId = Copy FROM application version: \nid or <application>:<version> name.


### PR DESCRIPTION
Supporting an optional argument **--active** to Activate or Deactivate the application version in SSC.