### PR TITLE
FoD entitlement fix

### DIFF
--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/cli/cmd/AbstractFoDScanStartCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/cli/cmd/AbstractFoDScanStartCommand.java
@@ -24,11 +24,15 @@ import com.fortify.cli.fod.release.helper.FoDReleaseDescriptor;
 
 import kong.unirest.UnirestInstance;
 import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
 
 @CommandGroup("*-scan-start")
 public abstract class AbstractFoDScanStartCommand extends AbstractFoDJsonNodeOutputCommand implements IActionCommandResultSupplier {
     @Mixin private FoDDelimiterMixin delimiterMixin; // Is automatically injected in resolver mixins
     @Mixin private FoDReleaseByQualifiedNameOrIdResolverMixin.RequiredOption releaseResolver;
+
+    @Option(names = {"--validate-entitlement"})
+    public final Boolean validateEntitlement = false;
 
     @Override
     public final JsonNode getJsonNode(UnirestInstance unirest) {

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/cli/cmd/FoDSastScanStartCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/cli/cmd/FoDSastScanStartCommand.java
@@ -75,9 +75,11 @@ public class FoDSastScanStartCommand extends AbstractFoDScanStartCommand {
     private void validateScanSetup(UnirestInstance unirest, String relId) {
         // get current setup and check if its valid
         FoDScanConfigSastDescriptor currentSetup = FoDScanSastHelper.getSetupDescriptor(unirest, relId);
-        if (currentSetup.getEntitlementId() == null || currentSetup.getEntitlementId() <= 0) {
-            throw new FcliSimpleException("The static scan configuration for release with id '" + relId +
-                    "' has not been setup correctly - 'Entitlement' is missing or empty.");
+        if (validateEntitlement) {
+            if (currentSetup.getEntitlementId() == null || currentSetup.getEntitlementId() <= 0) {
+                throw new FcliSimpleException("The static scan configuration for release with id '" + relId +
+                        "' has not been setup correctly - 'Entitlement' is missing or empty.");
+            }
         }
         if (StringUtils.isBlank(currentSetup.getTechnologyStack())) {
             throw new FcliSimpleException("The static scan configuration for release with id '" + relId +

--- a/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
+++ b/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
@@ -505,6 +505,7 @@ fcli.fod.sast-scan.start.entitlement-id = The Id of the entitlement to use for t
 fcli.fod.sast-scan.start.purchase-entitlement = Purchase an entitlement if one is not currently allocated or available.
 fcli.fod.sast-scan.start.notes = Scan notes.
 fcli.fod.sast-scan.start.file = Absolute path of the ScanCentral package (.Zip) file to upload.
+fcli.fod.sast-scan.start.validate-entitlement = Validate if an entitlement has been set and is still valid.
 fcli.fod.sast-scan.setup.usage.header = (PREVIEW) Configure SAST scan details for the release.
 fcli.fod.sast-scan.setup.usage.description.0 = This command is not fully implemented and is intended for preview only. \
   Command name, options and behavior may change at any time, even between patch or minor releases, potentially affecting \
@@ -581,6 +582,7 @@ fcli.fod.dast-scan.start.usage.description.0 = This command is intended for DAST
   which this command is being used.
 fcli.fod.dast-scan.start.usage.description.1 = The scan will need to have been previously setup using the FoD UI or one of the \
   'fod dast-scan setup-xxx' commands.
+fcli.fod.dast-scan.start.validate-entitlement = Validate if an entitlement has been set and is still valid.
 fcli.fod.dast-scan.start-legacy.usage.header = (LEGACY) Start a new DAST scan.
 fcli.fod.dast-scan.start-legacy.usage.description.0 = This command is not fully implemented and is intended for legacy DAST scanning (not DAST Automated). \
   It can only be used for starting a configured Dynamic scan and does not support file uploads (i.e. API definitions \
@@ -604,6 +606,7 @@ fcli.fod.dast-scan.start-legacy.notes = ${fcli.fod.sast-scan.start.notes}
 fcli.fod.dast-scan.start-legacy.file = ${fcli.fod.sast-scan.start.file}
 fcli.fod.dast-scan.start-legacy.chunk-size = ${fcli.fod.scan.chunk-size}
 fcli.fod.dast-scan.start-legacy.timezone = The timezone to use for starting the scan - default is UTC. Use 'fod rest lookup TimeZones' to see the values.
+fcli.fod.dast-scan.start-legacy.validate-entitlement = Validate if an entitlement has been set and is still valid.
 fcli.fod.dast-scan.import.usage.header = Import existing DAST scan results (from an FPR file).
 fcli.fod.dast-scan.import.usage.description = As FoD doesn't return a scan id for imported scans, the output of this command cannot be used with commands that expect a scan id, like the wait-for command.
 fcli.fod.dast-scan.import.file = FPR file containing existing DAST scan results to be imported.
@@ -755,6 +758,7 @@ fcli.fod.mast-scan.start.file = Absolute path of the mobile application file to 
 fcli.fod.mast-scan.start.framework = The Mobile Framework to use. Valid values: ${COMPLETION-CANDIDATES}.
 fcli.fod.mast-scan.start.platform = The Mobile Platform to use. Valid values: ${COMPLETION-CANDIDATES}.
 fcli.fod.mast-scan.start.timezone = The timezone to use for starting the scan - default is UTC. Use 'fod rest lookup TimeZones' to see the values.
+fcli.fod.mast-scan.start.validate-entitlement = Validate if an entitlement has been set and is still valid.
 fcli.fod.mast-scan.setup.usage.header = (PREVIEW) Configure MAST scan details for the release.
 fcli.fod.mast-scan.setup.usage.description.0 = This command is not fully implemented and is intended for preview only. \
   Command name, options and behavior may change at any time, even between patch or minor releases, potentially affecting \
@@ -819,6 +823,7 @@ fcli.fod.oss-scan.start.usage.description = This command is not fully implemente
   any workflows in which this command is being used.
 fcli.fod.oss-scan.start.file = ${fcli.fod.sast-scan.start.file}
 fcli.fod.oss-scan.start.chunk-size = ${fcli.fod.scan.chunk-size}
+fcli.fod.oss-scan.start.validate-entitlement = Validate if an entitlement has been set and is still valid.
 fcli.fod.oss-scan.wait-for.usage.header = Wait for one or more OSS scans to reach or exit specified scan statuses.
 fcli.fod.oss-scan.wait-for.usage.description.0 = ${fcli.fod.scan.wait-for.usage.description.0}
 fcli.fod.oss-scan.wait-for.usage.description.1 = ${fcli.fod.scan.wait-for.usage.description.1}


### PR DESCRIPTION
This is the fix for (#682) - the behaviour for SAST scans is now to NOT validate entitlement by default as this has caused some issues with entitlements that customers have been given.