### PR TITLE
feat: Add ability to configure fcli trust store through environment variables

### DIFF
--- a/fcli-core/fcli-app/src/main/java/com/fortify/cli/app/runner/util/FortifyCLIStaticInitializer.java
+++ b/fcli-core/fcli-app/src/main/java/com/fortify/cli/app/runner/util/FortifyCLIStaticInitializer.java
@@ -88,22 +88,61 @@ public final class FortifyCLIStaticInitializer {
     }
     
     private void initializeTrustStore() {
+        String trustStorePropertyKey = "javax.net.ssl.trustStore";
+        String trustStoreTypePropertyKey = "javax.net.ssl.trustStoreType";
+        String trustStorePasswordPropertyKey = "javax.net.ssl.trustStorePassword";
+
         // First clear existing configuration
-        System.clearProperty("javax.net.ssl.trustStore");
-        System.clearProperty("avax.net.ssl.trustStorePassword");
+        System.clearProperty(trustStorePropertyKey);
+        System.clearProperty(trustStoreTypePropertyKey);
+        System.clearProperty(trustStorePasswordPropertyKey);
         TrustStoreConfigDescriptor descriptor = TrustStoreConfigHelper.getTrustStoreConfig();
-        if ( descriptor!=null && StringUtils.isNotBlank(descriptor.getPath()) ) {
-            Path absolutePath = Path.of(descriptor.getPath()).toAbsolutePath();
-            if ( !Files.exists(absolutePath) ) {
-                log.warn("WARN: Trust store cannot be found: "+absolutePath);
-            }
-            System.setProperty("javax.net.ssl.trustStore", descriptor.getPath());
-            if ( StringUtils.isNotBlank(descriptor.getType()) ) {
-                System.setProperty("javax.net.ssl.trustStoreType", descriptor.getType());
-            }
-            if ( StringUtils.isNotBlank(descriptor.getPassword()) ) {
-                System.setProperty("javax.net.ssl.trustStorePassword", descriptor.getPassword());
-            }
+        if (descriptor != null && StringUtils.isNotBlank(descriptor.getPath())) {
+            initializeTrustStoreFromConfig(descriptor, trustStorePropertyKey, trustStoreTypePropertyKey,
+                    trustStorePasswordPropertyKey);
+        } else {
+            initializeTrustStoreFromEnv(trustStorePropertyKey, trustStoreTypePropertyKey,
+                    trustStorePasswordPropertyKey);
+        }
+    }
+
+    private void initializeTrustStoreFromEnv(String trustStorePropertyKey, String trustStoreTypePropertyKey,
+            String trustStorePasswordPropertyKey) {
+        String trustStorePath = System.getenv("FCLI_TRUSTSTORE");
+        if (null != trustStorePath && Files.exists(Path.of(trustStorePath))) {
+            System.setProperty(trustStorePropertyKey, trustStorePath);
+            String fileName = Paths.get(trustStorePath).getFileName().toString();
+            int lastIndexOf = fileName.lastIndexOf(".");
+            String trustStoreType = "jks";
+            if (lastIndexOf > 0) {
+                String fileExtension = fileName.substring(lastIndexOf + 1);
+                if (fileExtension.equals("jks") || fileExtension.equals("p12") || fileExtension.equals("pfs"))
+                    trustStoreType = fileExtension;
+            } else if (null != System.getenv("FCLI_TRUSTSTORE_TYPE"))
+                trustStoreType = System.getenv("FCLI_TRUSTSTORE_TYPE");
+            System.setProperty(trustStoreTypePropertyKey, trustStoreType);
+
+            String trustStorePwd = "changeit";
+            if (null != System.getenv("FCLI_TRUSTSTORE_PWD"))
+                trustStorePwd = System.getenv("FCLI_TRUSTSTORE_PWD");
+            System.setProperty(trustStorePasswordPropertyKey, trustStorePwd);
+        } else {
+                log.warn("WARN: Either Trust store not defined or cannot be found at: " + trustStorePath);
+        }
+    }
+
+    private void initializeTrustStoreFromConfig(TrustStoreConfigDescriptor descriptor, String trustStorePropertyKey,
+            String trustStoreTypePropertyKey, String trustStorePasswordPropertyKey) {
+        Path absolutePath = Path.of(descriptor.getPath()).toAbsolutePath();
+        if (!Files.exists(absolutePath)) {
+            log.warn("WARN: Trust store cannot be found: " + absolutePath);
+        }
+        System.setProperty(trustStorePropertyKey, descriptor.getPath());
+        if (StringUtils.isNotBlank(descriptor.getType())) {
+            System.setProperty(trustStoreTypePropertyKey, descriptor.getType());
+        }
+        if (StringUtils.isNotBlank(descriptor.getPassword())) {
+            System.setProperty(trustStorePasswordPropertyKey, descriptor.getPassword());
         }
     }
     

--- a/fcli-core/fcli-app/src/main/java/com/fortify/cli/app/runner/util/FortifyCLIStaticInitializer.java
+++ b/fcli-core/fcli-app/src/main/java/com/fortify/cli/app/runner/util/FortifyCLIStaticInitializer.java
@@ -14,6 +14,7 @@ package com.fortify.cli.app.runner.util;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Locale;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -96,6 +97,7 @@ public final class FortifyCLIStaticInitializer {
         System.clearProperty(trustStorePropertyKey);
         System.clearProperty(trustStoreTypePropertyKey);
         System.clearProperty(trustStorePasswordPropertyKey);
+        
         TrustStoreConfigDescriptor descriptor = TrustStoreConfigHelper.getTrustStoreConfig();
         if (descriptor != null && StringUtils.isNotBlank(descriptor.getPath())) {
             initializeTrustStoreFromConfig(descriptor, trustStorePropertyKey, trustStoreTypePropertyKey,
@@ -104,6 +106,7 @@ public final class FortifyCLIStaticInitializer {
             initializeTrustStoreFromEnv(trustStorePropertyKey, trustStoreTypePropertyKey,
                     trustStorePasswordPropertyKey);
         }
+        log.debug("INFO: Trust store file: " + System.getProperty(trustStorePropertyKey, "NONE"));
     }
 
     private void initializeTrustStoreFromEnv(String trustStorePropertyKey, String trustStoreTypePropertyKey,
@@ -111,23 +114,24 @@ public final class FortifyCLIStaticInitializer {
         String trustStorePath = System.getenv("FCLI_TRUSTSTORE");
         if (null != trustStorePath && Files.exists(Path.of(trustStorePath))) {
             System.setProperty(trustStorePropertyKey, trustStorePath);
-            String fileName = Paths.get(trustStorePath).getFileName().toString();
-            int lastIndexOf = fileName.lastIndexOf(".");
+            
             String trustStoreType = "jks";
-            if (lastIndexOf > 0) {
-                String fileExtension = fileName.substring(lastIndexOf + 1);
-                if (fileExtension.equals("jks") || fileExtension.equals("p12") || fileExtension.equals("pfs"))
-                    trustStoreType = fileExtension;
-            } else if (null != System.getenv("FCLI_TRUSTSTORE_TYPE"))
+            if (null != System.getenv("FCLI_TRUSTSTORE_TYPE")) {
                 trustStoreType = System.getenv("FCLI_TRUSTSTORE_TYPE");
+            } else {
+                String fileName = Paths.get(trustStorePath).getFileName().toString();
+                String fileExtension = StringUtils.substringAfterLast(fileName, ".");
+                if (fileExtension.equals("jks") || fileExtension.equals("p12") || fileExtension.equals("pfx")) {
+                    trustStoreType = fileExtension;
+                }
+            }
             System.setProperty(trustStoreTypePropertyKey, trustStoreType);
 
             String trustStorePwd = "changeit";
-            if (null != System.getenv("FCLI_TRUSTSTORE_PWD"))
+            if (null != System.getenv("FCLI_TRUSTSTORE_PWD")) {
                 trustStorePwd = System.getenv("FCLI_TRUSTSTORE_PWD");
+            }
             System.setProperty(trustStorePasswordPropertyKey, trustStorePwd);
-        } else {
-                log.warn("WARN: Either Trust store not defined or cannot be found at: " + trustStorePath);
         }
     }
 


### PR DESCRIPTION
When the FCLI Trust Store configurations are unavailable, they can be read from the Environment Variables.

FCLI_TRUSTSTORE: to fetch the path of the trust store
FCLI_TRUSTSTORE_TYPE: to fetch the type of the trust store (ideally auto-detect is available based on the trust store file extension)
FCLI_TRUSTSTORE_PWD: to fetch the password of the trust store, and if not present, the default password `changeit` can be used