### PR TITLE
fix: `fod action run setup-release` 

### DIFF
--- a/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/actions/zip/setup-release.yaml
+++ b/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/actions/zip/setup-release.yaml
@@ -113,6 +113,16 @@ cli.options:
     names: --oss
     description: "See `fcli fod sast-scan setup`" 
     type: boolean  
+  technology-stack:      
+    group: sast_setup_opts
+    required: false
+    names: --technology-stack
+    description: "See `fcli fod sast-scan setup`"
+  language-level:    
+    group: sast_setup_opts
+    required: false
+    names: --language-level
+    description: "See `fcli fod sast-scan setup`" 
   
 steps:
   - log.progress: "Creating FoD application & release if non-existing" 


### PR DESCRIPTION
Added specification of `--technology-stack` and `--language-level` in case AutoDetect fails.