### PR TITLE
chore: Remove unnecessary `finally` block to prevent premature issue stream cancellation

### DIFF
--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/grpc/AviatorGrpcClient.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/grpc/AviatorGrpcClient.java
@@ -308,10 +308,6 @@ public class AviatorGrpcClient implements AutoCloseable {
                         throw new AviatorTechnicalException("Error during request processing execution", e);
                     }
                     LOG.warn("Exception caught after stream completion during processing execution", e);
-                } finally {
-                    if (!resultFuture.isDone()) {
-                        resultFuture.completeExceptionally(new AviatorTechnicalException("Request processing task ended unexpectedly"));
-                    }
                 }
             });
 


### PR DESCRIPTION
This fix removes a redundant finally block that was causing the issue stream to cancel prematurely, ensuring proper stream handling.