### PR TITLE
Updated `mast-scan setup` and `mast-scan start` to take advantage of updated API

### DIFF
--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/mobile/FoDScanMobileHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/mobile/FoDScanMobileHelper.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fortify.cli.common.exception.FcliSimpleException;
 import com.fortify.cli.common.json.JsonHelper;
-import com.fortify.cli.common.progress.helper.IProgressWriterI18n;
 import com.fortify.cli.fod._common.rest.FoDUrls;
 import com.fortify.cli.fod._common.rest.helper.FoDFileTransferHelper;
 import com.fortify.cli.fod._common.scan.helper.FoDScanDescriptor;
@@ -37,7 +36,7 @@ public class FoDScanMobileHelper extends FoDScanHelper {
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     // TODO Split into multiple methods
-    public static final FoDScanDescriptor startScan(UnirestInstance unirest, IProgressWriterI18n progressWriter, FoDReleaseDescriptor releaseDescriptor, FoDScanMobileStartRequest req,
+    public static final FoDScanDescriptor startScan(UnirestInstance unirest, FoDReleaseDescriptor releaseDescriptor, FoDScanMobileStartRequest req,
                                                     File scanFile) {
         var relId = releaseDescriptor.getReleaseId();
         HttpRequest<?> request = unirest.post(FoDUrls.MOBILE_SCANS_START).routeParam("relId", relId)
@@ -47,7 +46,6 @@ public class FoDScanMobileHelper extends FoDScanHelper {
                 .queryString("platformType", req.getPlatformType())
                 .queryString("timeZone", req.getTimeZone())
                 .queryString("entitlementFrequencyType", req.getEntitlementFrequencyType());
-
         if (req.getEntitlementId() != null && req.getEntitlementId() > 0) {
             request = request.queryString("entitlementId", req.getEntitlementId());
         }
@@ -55,7 +53,7 @@ public class FoDScanMobileHelper extends FoDScanHelper {
         JsonNode response = FoDFileTransferHelper.uploadChunked(unirest, request, scanFile);
         FoDStartScanResponse startScanResponse = JsonHelper.treeToValue(response, FoDStartScanResponse.class);
         if (startScanResponse == null || startScanResponse.getScanId() <= 0) {
-            throw new FcliSimpleException("Unable to retrieve scan id from response when starting Static scan.");
+            throw new FcliSimpleException("Unable to retrieve scan id from response when starting Mobile scan.");
         }
         JsonNode node = objectMapper.createObjectNode()
             .put("scanId", startScanResponse.getScanId())
@@ -67,4 +65,5 @@ public class FoDScanMobileHelper extends FoDScanHelper {
             .put("microserviceName", releaseDescriptor.getMicroserviceName());
         return JsonHelper.treeToValue(node, FoDScanDescriptor.class);
     }
+
 }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/mobile/FoDScanMobileStartRequest.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/mobile/FoDScanMobileStartRequest.java
@@ -18,31 +18,28 @@ import com.formkiq.graalvm.annotations.Reflectable;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.With;
 
 @Reflectable @NoArgsConstructor @AllArgsConstructor
-@Getter @ToString @Builder
+@Data @Builder(toBuilder=true) @With
 public class FoDScanMobileStartRequest {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "MM/dd/yyyy HH:mm")
-
     private String startDate;
     private Integer assessmentTypeId;
     private Integer entitlementId;
     private String entitlementFrequencyType;
-
     private String timeZone;
-
     private String frameworkType;
     private String platformType;
     private Boolean isRemediationScan;
+    // the following are legacy options we no longer used
     //private Boolean isBundledAssessment;
     //private Integer parentAssessmentTypeId;
     //private Boolean applyPreviousScanSettings;
     private String scanMethodType;
     private String scanTool;
     private String scanToolVersion;
-
     private String notes;
 }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/mast_scan/helper/FoDScanConfigMobileDescriptor.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/mast_scan/helper/FoDScanConfigMobileDescriptor.java
@@ -26,9 +26,8 @@ public class FoDScanConfigMobileDescriptor extends JsonNodeHolder {
     private Integer releaseId;
     private Integer assessmentTypeId;
     private Integer entitlementId;
-    private String entitlementDescription;
     private String entitlementFrequencyType;
-    private Integer entitlementFrequencyTypeId;
-    private Integer technologyStackId;
-    private String technologyStack;
+    private String frameworkType;
+    private String auditPreferenceType;
+    private String timeZone;
 }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/mast_scan/helper/FoDScanConfigMobileHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/mast_scan/helper/FoDScanConfigMobileHelper.java
@@ -13,11 +13,13 @@
 
 package com.fortify.cli.fod.mast_scan.helper;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fortify.cli.common.json.JsonHelper;
 import com.fortify.cli.fod._common.rest.FoDUrls;
 import com.fortify.cli.fod.release.helper.FoDReleaseDescriptor;
 
+import kong.unirest.GetRequest;
 import kong.unirest.UnirestInstance;
 
 public class FoDScanConfigMobileHelper {
@@ -37,4 +39,15 @@ public class FoDScanConfigMobileHelper {
                 .asString().getBody();
         return getSetupDescriptor(unirest, releaseId);
     }
+
+    public static final FoDScanConfigMobileDescriptor getSetupDescriptorWithAppRel(UnirestInstance unirest, FoDReleaseDescriptor releaseDescriptor) {
+        GetRequest request = unirest.get(FoDUrls.MOBILE_SCANS + "/scan-setup")
+                .routeParam("relId", releaseDescriptor.getReleaseId());
+        JsonNode setup = request.asObject(ObjectNode.class).getBody()
+                .put("applicationName", releaseDescriptor.getApplicationName())
+                .put("releaseName", releaseDescriptor.getReleaseName())
+                .put("microserviceName", releaseDescriptor.getMicroserviceName());
+        return JsonHelper.treeToValue(setup, FoDScanConfigMobileDescriptor.class);
+    }
+
 }

--- a/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
+++ b/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
@@ -740,11 +740,12 @@ fcli.fod.mast-scan.wait-for.until = ${fcli.fod.scan.wait-for.until}
 fcli.fod.mast-scan.wait-for.while = ${fcli.fod.scan.wait-for.while}
 fcli.fod.mast-scan.wait-for.any-state = ${fcli.fod.scan.wait-for.any-state}
 fcli.fod.mast-scan.start.usage.header = Start a new MAST scan.
-fcli.fod.mast-scan.start.usage.description.0 = To correctly start a scan you will need to provide the name of the \
+fcli.fod.mast-scan.start.usage.description.0 = This command currently supports scanning of 'Mobile Assessment' type only.
+fcli.fod.mast-scan.start.usage.description.1 = To correctly start a scan you will need to provide the name of the \
   assessment type using the '--assessment-type=xxx' option. This will usually be "Mobile Assessment" but since assessment \
   types can potentially be configured differently for each tenant, you can find the correct name using the 'fod release lsat' \
   command for the release.
-fcli.fod.mast-scan.start.usage.description.1 = If you know the Id of an entitlement that you want to use then you \
+fcli.fod.mast-scan.start.usage.description.2 = If you know the Id of an entitlement that you want to use then you \
   can supply it to the '--entitlement-id=xxx' option. If not, you can supply both '--assessment-type' and \
   '--entitlement-frequency' options and the command will try to find an appropriate entitlement.
 fcli.fod.mast-scan.start.usage.description.2 = The scan will need to have been previously setup using the FoD UI or the \
@@ -755,14 +756,12 @@ fcli.fod.mast-scan.start.entitlement-id = ${fcli.fod.sast-scan.start.entitlement
 fcli.fod.mast-scan.start.entitlement-frequency = The Entitlement Frequency to use. Valid values: ${COMPLETION-CANDIDATES}.
 fcli.fod.mast-scan.start.notes = ${fcli.fod.sast-scan.start.notes}
 fcli.fod.mast-scan.start.file = Absolute path of the mobile application file to upload, for example .apk or .ipa file. See FoD documentation for supported file types and packaging instructions.
-fcli.fod.mast-scan.start.framework = The Mobile Framework to use. Valid values: ${COMPLETION-CANDIDATES}.
-fcli.fod.mast-scan.start.platform = The Mobile Platform to use. Valid values: ${COMPLETION-CANDIDATES}.
-fcli.fod.mast-scan.start.timezone = The timezone to use for starting the scan - default is UTC. Use 'fod rest lookup TimeZones' to see the values.
+fcli.fod.mast-scan.start.framework = The Mobile Framework to use. Valid values: ${COMPLETION-CANDIDATES}. Default value: ${DEFAULT-VALUE}.
+fcli.fod.mast-scan.start.platform = The Mobile Platform to use. Valid values: ${COMPLETION-CANDIDATES}. Default value: ${DEFAULT-VALUE}.
+fcli.fod.mast-scan.start.timezone = The timezone to use for starting the scan. Use 'fod rest lookup TimeZones' to see the values. Default value: ${DEFAULT-VALUE}.
 fcli.fod.mast-scan.start.validate-entitlement = Validate if an entitlement has been set and is still valid.
-fcli.fod.mast-scan.setup.usage.header = (PREVIEW) Configure MAST scan details for the release.
-fcli.fod.mast-scan.setup.usage.description.0 = This command is not fully implemented and is intended for preview only. \
-  Command name, options and behavior may change at any time, even between patch or minor releases, potentially affecting \
-  any workflows in which this command is being used.
+fcli.fod.mast-scan.setup.usage.header = Configure MAST scan details for the release.
+fcli.fod.mast-scan.start.usage.description.0 = This command currently supports scanning of 'Mobile Assessment' type only.
 fcli.fod.mast-scan.setup.usage.description.1 = To correctly setup a scan you will need to provide the name of the \
   assessment type using the '--assessment-type=xxx' option. Since assessment types can potentially be configured \
   differently for each tenant, you can find the correct name using the 'fod release lsat' command.
@@ -772,11 +771,11 @@ fcli.fod.mast-scan.setup.usage.description.2 = If you know the Id of an entitlem
 fcli.fod.mast-scan.setup.entitlement-frequency = The Entitlement Frequency to use. Valid values: ${COMPLETION-CANDIDATES}.
 fcli.fod.mast-scan.setup.entitlement-id = Entitlement Id to use. If not specified Frequency and Assessment Type will be used to find one.
 fcli.fod.mast-scan.setup.validate-entitlement = Check if the entitlement assigned is still valid, e.g. it has not expired.
-fcli.fod.mast-scan.setup.assessment-type = The type of Static assessment to carry out. Use 'fod release lsat' to find valid values.
-fcli.fod.mast-scan.setup.framework = The Mobile Framework to use. Valid values: ${COMPLETION-CANDIDATES}.
-fcli.fod.mast-scan.setup.platform = The Mobile Platform to use. Valid values: ${COMPLETION-CANDIDATES}.
-fcli.fod.mast-scan.setup.timezone = The timezone to use for starting the scan - default is UTC. Use 'fod rest lookup TimeZones' to see the values.
-fcli.fod.mast-scan.setup.audit-preference = Audit preference, e.g. Manual or None. Default value: None.
+fcli.fod.mast-scan.setup.assessment-type = The type of Mobile assessment to carry out. Use 'fod release lsat' to find valid values.
+fcli.fod.mast-scan.setup.framework = The Mobile Framework to use. Valid values: ${COMPLETION-CANDIDATES}. Default value: ${DEFAULT-VALUE}.
+fcli.fod.mast-scan.setup.platform = The Mobile Platform to use. Valid values: ${COMPLETION-CANDIDATES}. Default value: ${DEFAULT-VALUE}.
+fcli.fod.mast-scan.setup.timezone = The timezone to use for starting the scan. Use 'fod rest lookup TimeZones' to see the values. Default value: ${DEFAULT-VALUE}.
+fcli.fod.mast-scan.setup.audit-preference = Audit preference, e.g. Manual or Automated. Note: Automated is only applicable to Mobile Assessments. Default value: ${DEFAULT-VALUE}.
 fcli.fod.mast-scan.setup.skip-if-exists = Skip setup if a scan has already been set up. If not specified, any existing scan \
   setup will be replaced based on the given setup options.
 fcli.fod.mast-scan.import.usage.header = Import existing MAST scan results (from an FPR file).


### PR DESCRIPTION
The commands have been updated and made more self contained/consistent with the behaviour of other commands. 

The `/mobile-scan/setup` endpoint currently only returns a limited set of data (the following fields):

```
---
assessmentTypeId: 271
entitlementId: 13738
entitlementFrequencyType: 0
frameworkType: Android
auditPreferenceType: None
timeZone: UTC
state: Configured
```

so some arguments (mainly regarding entitlement) and are still required on the `mast-scan start` command.

The default (and recommended) use-case is for a "Automated" "Subscription" scan - so options have been defaulted to this and the descriptions updated.