### PR TITLE
FoD: allow assessment type Id or Name and tidy up

### DIFF
--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/FoDDastLegacyScanStartCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/FoDDastLegacyScanStartCommand.java
@@ -131,9 +131,12 @@ public class FoDDastLegacyScanStartCommand extends AbstractFoDScanStartCommand {
             }
             LOG.info("Configuring release to use entitlement " + entitlementIdToUse);
 
-            // check if the entitlement is still valid
-            FoDReleaseAssessmentTypeHelper.validateEntitlement(relId, atd.get());
-            LOG.info("The entitlement " + entitlementIdToUse + " is valid.");
+            // check if the entitlement can still be used
+            if (FoDReleaseAssessmentTypeHelper.validateEntitlementCanBeUsed(relId, atd.get())) {
+                LOG.info("The entitlement '" + entitlementIdToUse + "' is still valid.");
+            } else {
+                LOG.info("The entitlement '" + entitlementIdToUse + "' is no longer valid.");
+            }
 
             String startDateStr = (startDate == null || startDate.isEmpty())
                     ? LocalDateTime.now().format(dtf)

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/mast_scan/cli/cmd/FoDMastScanStartCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/mast_scan/cli/cmd/FoDMastScanStartCommand.java
@@ -153,8 +153,13 @@ public class FoDMastScanStartCommand extends AbstractFoDScanStartCommand {
                 }
             }
         }
-        // check if the entitlement is still valid
-        FoDReleaseAssessmentTypeHelper.validateEntitlement(relId, atd);
+
+        // check if the entitlement can still be used
+        if (FoDReleaseAssessmentTypeHelper.validateEntitlementCanBeUsed(relId, atd)) {
+            LOG.info("The entitlement '" + entitlementIdToUse + "' is still valid.");
+        } else {
+            LOG.info("The entitlement '" + entitlementIdToUse + "' is no longer valid.");
+        }
     }
 
 

--- a/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
+++ b/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
@@ -36,7 +36,7 @@ fcli.fod.app.app-criticality = The business criticality of the application. Vali
 fcli.fod.release.sdlc-status = The SDLC lifecycle status of the release. Valid values: ${COMPLETION-CANDIDATES}
 fcli.fod.scan.time-period = Time period to retrieve results over. Valid values: ${COMPLETION-CANDIDATES}. Default value is Last30.
 fcli.fod.scan.entitlement-preference = The entitlement preference to use. Valid values: ${COMPLETION-CANDIDATES}. Default is SubscriptionFirstThenSingleScan.
-fcli.fod.scan.assessment-type = The assessment type to use. Use 'fod release lsat' to find valid values.
+fcli.fod.scan.assessment-type = The assessment type to use, this can be the Id or the Name. Use 'fod release lsat' to find valid values.
 fcli.fod.scan.in-progress-action = The action to use if a scan is already in progress. Valid values: ${COMPLETION-CANDIDATES}.
 fcli.fod.scan.remediation-preference = The remediation preference to use. Valid values: ${COMPLETION-CANDIDATES}.
 fcli.fod.microservice.resolver.name = Microservice name in the format <application>:<microservice>.
@@ -506,25 +506,22 @@ fcli.fod.sast-scan.start.purchase-entitlement = Purchase an entitlement if one i
 fcli.fod.sast-scan.start.notes = Scan notes.
 fcli.fod.sast-scan.start.file = Absolute path of the ScanCentral package (.Zip) file to upload.
 fcli.fod.sast-scan.start.validate-entitlement = Validate if an entitlement has been set and is still valid.
-fcli.fod.sast-scan.setup.usage.header = (PREVIEW) Configure SAST scan details for the release.
-fcli.fod.sast-scan.setup.usage.description.0 = This command is not fully implemented and is intended for preview only. \
-  Command name, options and behavior may change at any time, even between patch or minor releases, potentially affecting \
-  any workflows in which this command is being used.
-fcli.fod.sast-scan.setup.usage.description.1 = To correctly setup a scan you will need to provide the name of the \
-  assessment type using the '--assessment-type=xxx' option. Since assessment types can potentially be configured \
-  differently for each tenant, you can find the correct name using the 'fod rest lookup AssessmentTypes' command.
-fcli.fod.sast-scan.setup.usage.description.2 = If you know the Id of an entitlement that you want to use then you \
-  can supply it to the '--entitlement-id=xxx' option. If not, you can supply both '--assessment-type' and \
-  '--entitlement-frequency' options and the command will try to find an appropriate entitlement.
-fcli.fod.sast-scan.setup.usage.description.3 = For the '--technology-stack' and '--language-level' options it is \
-  recommended to examine the drop-down list values in the FoD UI. However, you can also use the 'fod rest lookup' command. \
-  For example, to list all the technology stacks you would use 'fod rest lookup TechnologyTypes' and then for the \
-  language levels (if appropriate) you would use the 'Value' field returned in 'fod rest lookup LanguageLevels'. \
+fcli.fod.sast-scan.setup.usage.header = Configure SAST scan details for the release.
+fcli.fod.sast-scan.setup.usage.description.0 = To correctly setup a scan you will need to provide the \
+  assessment type Id or Name using the '--assessment-type' option. Since assessment types can potentially be configured \
+  differently for each tenant, you can find the correct Id and Name using the 'fod release lsat' command.
+fcli.fod.sast-scan.setup.usage.description.1 = If you know the Id of an entitlement that you want to use then you \
+  can supply it to the '--entitlement-id' option. If not, and you supply both the '--assessment-type' and \
+  '--entitlement-frequency' options the command will try to find an appropriate entitlement.
+fcli.fod.sast-scan.setup.usage.description.2 = If you do not specify a '--technology-stack' and '--language-level' (if appropriate) \
+  the default value of 'AutoDetect' will be used. However, if you wish to specify them you can use the 'fod rest lookup' command \
+  to find the values. For example, to list all the technology stacks you can use 'fod rest lookup TechnologyTypes' and then for the \
+  language levels (if appropriate) you can use the 'Value' field returned in 'fod rest lookup LanguageLevels'. \
   For example, for Java which is typically value '7', you would use 'fod rest lookup LanguageLevels -q "group=='7'".
 fcli.fod.sast-scan.setup.entitlement-frequency = The Entitlement Frequency to use. Valid values: ${COMPLETION-CANDIDATES}.
-fcli.fod.sast-scan.setup.entitlement-id = Entitlement Id to use. If not specified Frequency and Assessment Type will be used to find one.
+fcli.fod.sast-scan.setup.entitlement-id = Entitlement Id to use. If not specified Entitlement Frequency and Assessment Type will be used to find one.
 fcli.fod.sast-scan.setup.validate-entitlement = Check if the entitlement assigned is still valid, e.g. it has not expired.
-fcli.fod.sast-scan.setup.assessment-type = The type of Static assessment to carry out. Use 'fod release lsat' to find valid values.
+fcli.fod.sast-scan.setup.assessment-type = The assessment type to use, this can be the Id or the Name. Use 'fod release lsat' to find valid values.
 fcli.fod.sast-scan.setup.technology-stack = The technology stack of the application. Default value: ${DEFAULT-VALUE}.
 fcli.fod.sast-scan.setup.language-level = The language level of the technology stack (if needed).
 fcli.fod.sast-scan.setup.oss = Perform Open Source Analysis scan.
@@ -591,15 +588,15 @@ fcli.fod.dast-scan.start-legacy.usage.description.0 = This command is not fully 
   any workflows in which this command is being used.
 fcli.fod.dast-scan.start-legacy.usage.description.1 = The scan will need to have been previously setup using the FoD UI or the \
   'fod dast-scan setup' command.
-fcli.fod.dast-scan.start-legacy.usage.description.2 = To correctly start a scan you will need to provide the name of the \
-  assessment type using the '--assessment-type=xxx' option. Since assessment types can potentially be configured \
-  differently for each tenant, you can find the correct name using the 'fod rest lookup AssessmentTypes' command.
+fcli.fod.dast-scan.start-legacy.usage.description.2 = To correctly start a scan you will need to provide the Id or Name of the \
+  assessment type using the '--assessment-type' option. Since assessment types can potentially be configured \
+  differently for each tenant, you can find the correct name using the 'fod release lsat' command.
 fcli.fod.dast-scan.start-legacy.usage.description.3 = The scan will need to have been previously setup using the FoD UI or the \
   'fod dast-scan setup' command.
 fcli.fod.dast-scan.start-legacy.usage.description.4 = If you know the Id of an entitlement that you want to use then you \
-  can supply it to the '--entitlement-id=xxx' option. If not, you can supply both '--assessment-type' and \
-  '--entitlement-frequency' options and the command will try to find an appropriate entitlement.
-fcli.fod.dast-scan.start-legacy.assessment-type = The type of Dynamic assessment to carry out. Use 'fod rest lookup AssessmentTypes' to find valid values.
+  can supply it to the '--entitlement-id' option. If not, and you supply both the '--assessment-type' and \
+  '--entitlement-frequency' options the command will try to find an appropriate entitlement.
+fcli.fod.dast-scan.start-legacy.assessment-type = The assessment type to use, this can be the Id or the Name. Use 'fod release lsat' to find valid values.
 fcli.fod.dast-scan.start-legacy.start-date = ${fcli.fod.sast-scan.start.start-date}
 fcli.fod.dast-scan.start-legacy.entitlement-id = ${fcli.fod.sast-scan.start.entitlement-id}
 fcli.fod.dast-scan.start-legacy.notes = ${fcli.fod.sast-scan.start.notes}
@@ -625,12 +622,12 @@ fcli.fod.dast-scan.setup-api.usage.header = (PREVIEW) Configure DAST Automated A
 fcli.fod.dast-scan.setup-website.usage.description.0 = This command is intended for preview only. \
   Command name, options and behavior may change at any time, even between patch or minor releases, potentially affecting \
   any workflows in which this command is being used.
-fcli.fod.dast-scan.setup-website.usage.description.1 = To correctly setup a scan you will need to provide the name of the \
-  assessment type using the '--assessment-type=xxx' option. Since assessment types can potentially be configured \
-  differently for each tenant, you can find the correct name using the 'fod rest lookup AssessmentTypes' command.
+fcli.fod.dast-scan.setup-website.usage.description.1 = To correctly setup a scan you will need to provide the Id or Name of the \
+  assessment type using the '--assessment-type' option. Since assessment types can potentially be configured \
+  differently for each tenant, you can find the correct name using the 'fod release lsat' command.
 fcli.fod.dast-scan.setup-website.usage.description.2 = If you know the Id of an entitlement that you want to use then you \
-  can supply it to the '--entitlement-id=xxx' option. If not, you can supply both '--assessment-type' and \
-  '--entitlement-frequency' options and the command will try to find an appropriate entitlement.
+  can supply it to the '--entitlement-id' option. If not, and you supply both the '--assessment-type' and \
+  '--entitlement-frequency' options the command will try to find an appropriate entitlement.
 fcli.fod.dast-scan.setup-website.usage.description.3 = If you wish to use a Login Macro for authentication then you \
   can upload it directly using the '--file' option, or you can refer to a previously uploaded File Id that was uploaded \
   using the 'fod dast-scan upload-file' command.
@@ -649,7 +646,7 @@ fcli.fod.dast-scan.setup-api.usage.description.3 = In order to use an OpenAPI sp
 
 fcli.fod.dast-scan.setup-website.file = A Login Macro file to upload and use for authentication in the website scan.
 fcli.fod.dast-scan.setup-website.entitlement-id = Entitlement Id to use. If not specified Frequency and Assessment Type will be used to find one.
-fcli.fod.dast-scan.setup-website.assessment-type = The type of DAST assessment to carry out. Use 'fod rest lookup AssessmentTypes' to display valid values.
+fcli.fod.dast-scan.setup-website.assessment-type = The assessment type to use, this can be the Id or the Name. Use 'fod release lsat' to find valid values.
 fcli.fod.dast-scan.setup-website-setup-scan.entitlement-frequency = The Entitlement Frequency to use. Valid values: ${COMPLETION-CANDIDATES}.
 fcli.fod.dast-scan.setup-website.site-url = The URL of the website to be scanned. This cannot be changed after a scan has been completed on the release.
 fcli.fod.dast-scan.setup-website.redundant-page-detection = Enable redundant page detection.
@@ -741,17 +738,15 @@ fcli.fod.mast-scan.wait-for.while = ${fcli.fod.scan.wait-for.while}
 fcli.fod.mast-scan.wait-for.any-state = ${fcli.fod.scan.wait-for.any-state}
 fcli.fod.mast-scan.start.usage.header = Start a new MAST scan.
 fcli.fod.mast-scan.start.usage.description.0 = This command currently supports scanning of 'Mobile Assessment' type only.
-fcli.fod.mast-scan.start.usage.description.1 = To correctly start a scan you will need to provide the name of the \
-  assessment type using the '--assessment-type=xxx' option. This will usually be "Mobile Assessment" but since assessment \
+fcli.fod.mast-scan.start.usage.description.1 = To correctly start a scan you will need to provide the Id or Name of the \
+  assessment type using the '--assessment-type' option. This will usually be "Mobile Assessment" but since assessment \
   types can potentially be configured differently for each tenant, you can find the correct name using the 'fod release lsat' \
   command for the release.
 fcli.fod.mast-scan.start.usage.description.2 = If you know the Id of an entitlement that you want to use then you \
-  can supply it to the '--entitlement-id=xxx' option. If not, you can supply both '--assessment-type' and \
-  '--entitlement-frequency' options and the command will try to find an appropriate entitlement.
-fcli.fod.mast-scan.start.usage.description.2 = The scan will need to have been previously setup using the FoD UI or the \
-  'fod mast-scan setup' command.
+  can supply it to the '--entitlement-id' option. If not, and you supply both the '--assessment-type' and \
+  '--entitlement-frequency' options the command will try to find an appropriate entitlement.
 fcli.fod.mast-scan.start.start-date = ${fcli.fod.sast-scan.start.start-date}
-fcli.fod.mast-scan.start.assessment-type = The type of MAST assessment to carry out. Use 'fod release lsat' to find valid values.
+fcli.fod.mast-scan.start.assessment-type = The assessment type to use, this can be the Id or the Name. Use 'fod release lsat' to find valid values.
 fcli.fod.mast-scan.start.entitlement-id = ${fcli.fod.sast-scan.start.entitlement-id}
 fcli.fod.mast-scan.start.entitlement-frequency = The Entitlement Frequency to use. Valid values: ${COMPLETION-CANDIDATES}.
 fcli.fod.mast-scan.start.notes = ${fcli.fod.sast-scan.start.notes}
@@ -762,16 +757,16 @@ fcli.fod.mast-scan.start.timezone = The timezone to use for starting the scan. U
 fcli.fod.mast-scan.start.validate-entitlement = Validate if an entitlement has been set and is still valid.
 fcli.fod.mast-scan.setup.usage.header = Configure MAST scan details for the release.
 fcli.fod.mast-scan.start.usage.description.0 = This command currently supports scanning of 'Mobile Assessment' type only.
-fcli.fod.mast-scan.setup.usage.description.1 = To correctly setup a scan you will need to provide the name of the \
-  assessment type using the '--assessment-type=xxx' option. Since assessment types can potentially be configured \
+fcli.fod.mast-scan.setup.usage.description.1 = To correctly setup a scan you will need to provide the Id or Name of the \
+  assessment type using the '--assessment-type' option. Since assessment types can potentially be configured \
   differently for each tenant, you can find the correct name using the 'fod release lsat' command.
 fcli.fod.mast-scan.setup.usage.description.2 = If you know the Id of an entitlement that you want to use then you \
-  can supply it to the '--entitlement-id=xxx' option. If not, you can supply both '--assessment-type' and \
+  can supply it to the '--entitlement-id' option. If not, and you supply both '--assessment-type' and \
   '--entitlement-frequency' options and the command will try to find an appropriate entitlement.
 fcli.fod.mast-scan.setup.entitlement-frequency = The Entitlement Frequency to use. Valid values: ${COMPLETION-CANDIDATES}.
 fcli.fod.mast-scan.setup.entitlement-id = Entitlement Id to use. If not specified Frequency and Assessment Type will be used to find one.
 fcli.fod.mast-scan.setup.validate-entitlement = Check if the entitlement assigned is still valid, e.g. it has not expired.
-fcli.fod.mast-scan.setup.assessment-type = The type of Mobile assessment to carry out. Use 'fod release lsat' to find valid values.
+fcli.fod.mast-scan.setup.assessment-type = The assessment type to use, this can be the Id or the Name. Use 'fod release lsat' to find valid values.
 fcli.fod.mast-scan.setup.framework = The Mobile Framework to use. Valid values: ${COMPLETION-CANDIDATES}. Default value: ${DEFAULT-VALUE}.
 fcli.fod.mast-scan.setup.platform = The Mobile Platform to use. Valid values: ${COMPLETION-CANDIDATES}. Default value: ${DEFAULT-VALUE}.
 fcli.fod.mast-scan.setup.timezone = The timezone to use for starting the scan. Use 'fod rest lookup TimeZones' to see the values. Default value: ${DEFAULT-VALUE}.
@@ -801,7 +796,7 @@ fcli.fod.oss-scan.get.usage.header = Get OSS scan details.
 fcli.fod.oss-scan.list.usage.header = List OSS scans.
 fcli.fod.oss-scan.import.usage.header = Import existing OSS scan results (from an SBOM file).
 fcli.fod.oss-scan.import.usage.description = As FoD doesn't return a scan id for imported scans, the output of this command cannot be used with commands that expect a scan id, like the wait-for command.
-fcli.fod.oss-scan.import.file = FPR file containing existing OSS scan results to be imported.
+fcli.fod.oss-scan.import.file = JSON or XML SBOM file to be imported.
 fcli.fod.oss-scan.import.type = Open Source scan results file type. Valid values: ${COMPLETION-CANDIDATES} (default value is CycloneDX).
 fcli.fod.oss-scan.import-debricked.usage.header = Import results from Debricked.
 fcli.fod.oss-scan.import-debricked.file = Save a copy of the SBOM file downloaded from \


### PR DESCRIPTION
Updated the `fcli fod sast-scan setup` command `assessment-type` option to work with either string (name) or integer (id)

Updated and tidied up the documentation of the command.

Tidied up entitlement checking - it is just logging for now as we have had issues in the past where this has caused scans to fail as the API does not always report these values correctly.