### PR TITLE
feat: `fcli ssc session login`: Allow for bypassing SC-SAST/SC-DAST connection test(#740)

### DIFF
--- a/fcli-core/fcli-action/src/main/resources/com/fortify/cli/generic_action/actions/build-time/ci-envvars.yaml
+++ b/fcli-core/fcli-action/src/main/resources/com/fortify/cli/generic_action/actions/build-time/ci-envvars.yaml
@@ -127,12 +127,18 @@ formatters:
           `SETUP_EXTRA_OPTS`. To allow this action to create new applications, depending on FoD version,
           you may (also) need to provide the `--app-owner <user id or name>` option through `SETUP_EXTRA_OPTS`.
     scan:
-      - names: DO_SAST_SCAN\nSAST_SCAN_EXTRA_OPTS\nDO_SAST_WAIT
+      - names: DO_SAST_SCAN\nSAST_SCAN_EXTRA_OPTS
         desc: >-
           For now, this fcli action only supports running a SAST scan, which is enabled by default. The
           `SAST_SCAN_EXTRA_OPTS` environment variable can be used to pass extra options to the `fcli fod sast-scan start`
           command. By default, this action will wait until the scan has been completed, unless `DO_SAST_WAIT`
           is set to `false`; note that any post-scan tasks will be skipped in this case.
+      - names: DO_SAST_WAIT\nSAST_WAIT_EXTRA_OPTS
+        desc: >-
+          By default, the scan process is configured to wait until completion. This behavior can be changed by setting
+          DO_SAST_WAIT to 'false'. note that any post-scan tasks will be skipped in this case. Extra options
+          for a custom fcli action can be passed through the `SAST_WAIT_EXTRA_OPTS` environment variable,
+          which may include fcli options to allow unsigned custom actions to be used.
     postScan:
       - names: DO_RELEASE_SUMMARY\nRELEASE_SUMMARY_ACTION\nRELEASE_SUMMARY_EXTRA_OPTS
         desc: >-
@@ -201,12 +207,18 @@ formatters:
           application version representing your default branch by passing the `--copy-from` option through
           `SETUP_EXTRA_OPTS`.
     scan:
-      - names: DO_SAST_SCAN\nSAST_SCAN_EXTRA_OPTS\nDO_SAST_WAIT
+      - names: DO_SAST_SCAN\nSAST_SCAN_EXTRA_OPTS
         desc: >-
             For now, this fcli action only supports running a SAST scan, which is enabled by default. The
             `SAST_SCAN_EXTRA_OPTS` environment variable can be used to pass extra options to the `fcli sc-sast scan start`
             command. By default, this action will wait until the scan has been completed, unless `DO_SAST_WAIT`
             is set to `false`; note that any post-scan tasks will be skipped in this case.
+      - names: DO_SAST_WAIT\nSAST_WAIT_EXTRA_OPTS
+        desc: >-
+          By default, the scan process is configured to wait until completion. This behavior can be changed by setting
+          DO_SAST_WAIT to 'false'. note that any post-scan tasks will be skipped in this case. Extra options
+          for a custom fcli action can be passed through the `SAST_WAIT_EXTRA_OPTS` environment variable,
+          which may include fcli options to allow unsigned custom actions to be used.
     postScan:
       - names: DO_APPVERSION_SUMMARY\nAPPVERSION_SUMMARY_ACTION\nAPPVERSION_SUMMARY_EXTRA_OPTS
         desc: >-

--- a/fcli-core/fcli-action/src/main/resources/com/fortify/cli/generic_action/actions/build-time/ci-envvars.yaml
+++ b/fcli-core/fcli-action/src/main/resources/com/fortify/cli/generic_action/actions/build-time/ci-envvars.yaml
@@ -127,18 +127,12 @@ formatters:
           `SETUP_EXTRA_OPTS`. To allow this action to create new applications, depending on FoD version,
           you may (also) need to provide the `--app-owner <user id or name>` option through `SETUP_EXTRA_OPTS`.
     scan:
-      - names: DO_SAST_SCAN\nSAST_SCAN_EXTRA_OPTS
+      - names: DO_SAST_SCAN\nSAST_SCAN_EXTRA_OPTS\nDO_SAST_WAIT
         desc: >-
           For now, this fcli action only supports running a SAST scan, which is enabled by default. The
           `SAST_SCAN_EXTRA_OPTS` environment variable can be used to pass extra options to the `fcli fod sast-scan start`
           command. By default, this action will wait until the scan has been completed, unless `DO_SAST_WAIT`
           is set to `false`; note that any post-scan tasks will be skipped in this case.
-      - names: DO_SAST_WAIT\nSAST_WAIT_EXTRA_OPTS
-        desc: >-
-          By default, the scan process is configured to wait until completion. This behavior can be changed by setting
-          DO_SAST_WAIT to 'false'. note that any post-scan tasks will be skipped in this case. Extra options
-          for a custom fcli action can be passed through the `SAST_WAIT_EXTRA_OPTS` environment variable,
-          which may include fcli options to allow unsigned custom actions to be used.
     postScan:
       - names: DO_RELEASE_SUMMARY\nRELEASE_SUMMARY_ACTION\nRELEASE_SUMMARY_EXTRA_OPTS
         desc: >-
@@ -207,18 +201,12 @@ formatters:
           application version representing your default branch by passing the `--copy-from` option through
           `SETUP_EXTRA_OPTS`.
     scan:
-      - names: DO_SAST_SCAN\nSAST_SCAN_EXTRA_OPTS
+      - names: DO_SAST_SCAN\nSAST_SCAN_EXTRA_OPTS\nDO_SAST_WAIT
         desc: >-
             For now, this fcli action only supports running a SAST scan, which is enabled by default. The
             `SAST_SCAN_EXTRA_OPTS` environment variable can be used to pass extra options to the `fcli sc-sast scan start`
             command. By default, this action will wait until the scan has been completed, unless `DO_SAST_WAIT`
             is set to `false`; note that any post-scan tasks will be skipped in this case.
-      - names: DO_SAST_WAIT\nSAST_WAIT_EXTRA_OPTS
-        desc: >-
-          By default, the scan process is configured to wait until completion. This behavior can be changed by setting
-          DO_SAST_WAIT to 'false'. note that any post-scan tasks will be skipped in this case. Extra options
-          for a custom fcli action can be passed through the `SAST_WAIT_EXTRA_OPTS` environment variable,
-          which may include fcli options to allow unsigned custom actions to be used.
     postScan:
       - names: DO_APPVERSION_SUMMARY\nAPPVERSION_SUMMARY_ACTION\nAPPVERSION_SUMMARY_EXTRA_OPTS
         desc: >-

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/cli/cmd/SSCSessionLoginCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/cli/cmd/SSCSessionLoginCommand.java
@@ -16,17 +16,20 @@ import com.fortify.cli.common.exception.FcliSimpleException;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.rest.unirest.GenericUnirestFactory;
 import com.fortify.cli.common.rest.unirest.UnexpectedHttpResponseException;
+import com.fortify.cli.common.rest.unirest.config.IUrlConfig;
 import com.fortify.cli.common.session.cli.cmd.AbstractSessionLoginCommand;
 import com.fortify.cli.common.util.StringUtils;
 import com.fortify.cli.ssc._common.rest.cli.mixin.SSCAndScanCentralUnirestInstanceSupplierMixin;
 import com.fortify.cli.ssc._common.rest.helper.SSCAndScanCentralUnirestHelper;
 import com.fortify.cli.ssc._common.session.cli.mixin.SSCAndScanCentralSessionLoginOptions;
+import com.fortify.cli.ssc._common.session.cli.mixin.SSCAndScanCentralSessionLoginOptions.SSCAndScanCentralUrlConfigOptions;
 import com.fortify.cli.ssc._common.session.cli.mixin.SSCSessionNameArgGroup;
 import com.fortify.cli.ssc._common.session.helper.ISSCAndScanCentralCredentialsConfig;
 import com.fortify.cli.ssc._common.session.helper.ISSCAndScanCentralUrlConfig;
 import com.fortify.cli.ssc._common.session.helper.SSCAndScanCentralSessionDescriptor;
 import com.fortify.cli.ssc._common.session.helper.SSCAndScanCentralSessionHelper;
 
+import kong.unirest.UnirestException;
 import kong.unirest.UnirestInstance;
 import lombok.Getter;
 import picocli.CommandLine.ArgGroup;
@@ -59,12 +62,25 @@ public class SSCSessionLoginCommand extends AbstractSessionLoginCommand<SSCAndSc
         // SSC connection will already have been validated during login, so we only need to
         // verify SC-SAST & SC-DAST connections.
         SSCAndScanCentralSessionDescriptor sessionData = SSCAndScanCentralSessionHelper.instance().get(sessionName, true);
+        String sscUrl = sessionData.getSscUrlConfig().getUrl();
         try ( var unirest = GenericUnirestFactory.createUnirestInstance() ) {
             testAuthenticatedSCSastConnection(unirest, sessionData);
-        }
+        }	
+        catch(UnirestException  expt) {
+        	logoutBeforeNewLogin(sessionName, sessionData);
+        	getSessionHelper().destroy(sessionName);
+        	String scSastUrl = sessionData.getScSastUrlConfig().getUrl();
+        	throw new FcliSimpleException(String.format("SC-SAST is temporarily unavailable. You can still connect to SSC by using the --disable=sc-sast option.\nSSC URL: %s\nSC-SAST URL: %s" , sscUrl,scSastUrl), expt.getMessage());
+        }	
         try ( var unirest = GenericUnirestFactory.createUnirestInstance() ) {
             testAuthenticatedSCDastConnection(unirest, sessionData);
         }
+        catch(UnirestException  expt) {
+        	logoutBeforeNewLogin(sessionName, sessionData);
+        	getSessionHelper().destroy(sessionName);
+        	String scDastUrl = sessionData.getScDastUrlConfig().getUrl();
+        	throw new FcliSimpleException(String.format("SC-DAST is temporarily unavailable. You can still connect to SSC by using the --disable=sc-dast option.\nSSC URL: %s\nSC-DAST URL: %s", sscUrl,scDastUrl), expt.getMessage());
+        }	
     }
 
     private void testAuthenticatedSCSastConnection(UnirestInstance u, SSCAndScanCentralSessionDescriptor sessionData) {

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/cli/mixin/SSCAndScanCentralSessionLoginOptions.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/cli/mixin/SSCAndScanCentralSessionLoginOptions.java
@@ -13,6 +13,9 @@
 package com.fortify.cli.ssc._common.session.cli.mixin;
 
 import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.ArrayList;
 
 import com.fortify.cli.common.log.LogSensitivityLevel;
 import com.fortify.cli.common.log.MaskValue;
@@ -21,12 +24,17 @@ import com.fortify.cli.common.rest.cli.mixin.UrlConfigOptions;
 import com.fortify.cli.common.session.cli.mixin.UserCredentialOptions;
 import com.fortify.cli.common.util.DateTimePeriodHelper;
 import com.fortify.cli.common.util.DateTimePeriodHelper.Period;
+import com.fortify.cli.common.util.DisableTest;
+import com.fortify.cli.common.util.DisableTest.TestType;
 import com.fortify.cli.ssc._common.session.helper.ISSCAndScanCentralCredentialsConfig;
 import com.fortify.cli.ssc._common.session.helper.ISSCAndScanCentralUrlConfig;
 import com.fortify.cli.ssc._common.session.helper.ISSCUserCredentialsConfig;
 import com.fortify.cli.ssc.access_control.helper.SSCTokenConverter;
+import com.fortify.cli.ssc.appversion.cli.mixin.SSCAppVersionExcludeMixin.SSCAppVersionExclude;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -45,9 +53,26 @@ public class SSCAndScanCentralSessionLoginOptions {
         @MaskValue(sensitivity = LogSensitivityLevel.low, description = "SSC HOST", pattern = MaskValue.URL_HOSTNAME_PATTERN)
         @Getter private String sscUrl;
         
-        @Option(names = {"--sc-sast-url"}, required = false, order=1)
+        @Option(names = {"--sc-sast-url"}, required = false, order=2)
         @MaskValue(sensitivity = LogSensitivityLevel.low, description = "SC-SAST CONTROLLER URL")
         @Getter private String scSastControllerUrl;
+        
+        @DisableTest(TestType.MULTI_OPT_PLURAL_NAME)
+		@Option(names = { "--disable" }, required = false, split = ",", order =3, descriptionKey = "fcli.ssc.component.list.disable")
+		@Getter private Set<SSCComponentDisable> disable;
+
+		@RequiredArgsConstructor 
+		public static enum SSCComponentDisable {
+			sc_sast("sc-sast"), sc_dast("sc-dast");
+
+			@Getter
+			private final String param;
+
+			@Override
+	        public String toString() {
+	            return super.toString().replace('_', '-');
+	        }
+		}
     }
     
     public static class SSCAndScanCentralCredentialConfigOptions implements ISSCAndScanCentralCredentialsConfig {

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/helper/ISSCAndScanCentralUrlConfig.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/helper/ISSCAndScanCentralUrlConfig.java
@@ -3,7 +3,11 @@
  */
 package com.fortify.cli.ssc._common.session.helper;
 
+import java.util.List;
+import java.util.Set;
+
 import com.fortify.cli.common.rest.unirest.config.IConnectionConfig;
+import com.fortify.cli.ssc._common.session.cli.mixin.SSCAndScanCentralSessionLoginOptions.SSCAndScanCentralUrlConfigOptions.SSCComponentDisable;
 
 /**
  * Interface for the functions to get the SSC URL and the Controller URL
@@ -11,4 +15,5 @@ import com.fortify.cli.common.rest.unirest.config.IConnectionConfig;
 public interface ISSCAndScanCentralUrlConfig extends IConnectionConfig {
     String getSscUrl();
     String getScSastControllerUrl();
+    Set<SSCComponentDisable> getDisable();
 }

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/helper/SSCAndScanCentralSessionDescriptor.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/helper/SSCAndScanCentralSessionDescriptor.java
@@ -13,6 +13,9 @@
 package com.fortify.cli.ssc._common.session.helper;
 
 import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.ArrayList;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -30,6 +33,7 @@ import com.fortify.cli.common.rest.unirest.config.IUserCredentialsConfig;
 import com.fortify.cli.common.rest.unirest.config.UrlConfig;
 import com.fortify.cli.common.session.helper.AbstractSessionDescriptor;
 import com.fortify.cli.common.util.StringUtils;
+import com.fortify.cli.ssc._common.session.cli.mixin.SSCAndScanCentralSessionLoginOptions.SSCAndScanCentralUrlConfigOptions.SSCComponentDisable;
 import com.fortify.cli.ssc.access_control.helper.SSCTokenCreateRequest;
 import com.fortify.cli.ssc.access_control.helper.SSCTokenGetOrCreateResponse;
 import com.fortify.cli.ssc.access_control.helper.SSCTokenGetOrCreateResponse.SSCTokenData;
@@ -112,8 +116,28 @@ public class SSCAndScanCentralSessionDescriptor extends AbstractSessionDescripto
                 .sscTokenData(sscTokenData)
                 .revokeTokenOnLogout(providedSscToken==null);
         var sscConfigProperties = getSscConfigProperties(sscUrlConfig, sscTokenData.getToken());
-        addScSastSessionConfig(sessionDescriptorBuilder, sscAndScanCentralUrlConfig, sscAndScanCentralCredentialsConfig.getScSastClientAuthToken(), sscConfigProperties);
-        addScDastSessionConfig(sessionDescriptorBuilder, sscAndScanCentralUrlConfig, sscConfigProperties);
+        boolean disableSast = false;
+        boolean disableDast = false;
+        Set<SSCComponentDisable> disables = sscAndScanCentralUrlConfig.getDisable();
+        if(disables != null) {
+        	for (SSCComponentDisable disable : disables) {
+                if (disable == SSCComponentDisable.sc_sast) {
+                	disableSast = true;
+                } else if (disable == SSCComponentDisable.sc_dast) {
+                	disableDast = true;
+                }
+            }
+        }
+		if (disableSast) {
+			sessionDescriptorBuilder.scSastDisabledReason("Disabled by user");
+		} else {
+			addScSastSessionConfig(sessionDescriptorBuilder, sscAndScanCentralUrlConfig,
+					sscAndScanCentralCredentialsConfig.getScSastClientAuthToken(), sscConfigProperties);
+		}
+        if (disableDast)
+        	sessionDescriptorBuilder.scDastDisabledReason("Disabled by user");
+        else
+        	addScDastSessionConfig(sessionDescriptorBuilder, sscAndScanCentralUrlConfig, sscConfigProperties);
         return sessionDescriptorBuilder.build();
     }
     

--- a/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/i18n/SSCMessages.properties
+++ b/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/i18n/SSCMessages.properties
@@ -82,6 +82,7 @@ fcli.ssc.session.login.token = SSC token in either encoded (REST) or decoded (ap
   use an AutomationToken, CIToken, or UnifiedLoginToken.
 fcli.ssc.session.login.sc-sast-url = Override ScanCentral SAST Controller URL. If not specified, the controller URL as configured in SSC will be used.
 fcli.ssc.session.login.ssc-session = Name for this SSC session. Default value: ${DEFAULT-VALUE}.
+fcli.ssc.session.login.disable = By default, sessions for SSC, SC-SAST, and SC-DAST are created. To bypass a session, use the --disable option.%nAllowed values: ${COMPLETION-CANDIDATES}.
   
 fcli.ssc.session.logout.usage.header = Terminate Fortify SSC session.
 fcli.ssc.session.logout.usage.description.0 = This command terminates an SSC session previously created \


### PR DESCRIPTION
Add --disable option to bypass the SC-SAST and SC-DAST connection  while creating SSC session.
![image](https://github.com/user-attachments/assets/e83d918a-aaa4-4773-b81a-fcb909206905)
