### PR TITLE
feat: `fcli ssc session login`: Allow for bypassing SC-SAST/SC-DAST connection test(#740)

### DIFF
--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/cli/cmd/SSCSessionLoginCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/cli/cmd/SSCSessionLoginCommand.java
@@ -64,20 +64,30 @@ public class SSCSessionLoginCommand extends AbstractSessionLoginCommand<SSCAndSc
         try ( var unirest = GenericUnirestFactory.createUnirestInstance() ) {
             testAuthenticatedSCSastConnection(unirest, sessionData);
         }
-        catch(UnirestException  expt) {
-        	logoutBeforeNewLogin(sessionName, sessionData);
-        	getSessionHelper().destroy(sessionName);
-        	String scSastUrl = sessionData.getScSastUrlConfig().getUrl();
-        	throw new FcliSimpleException(String.format("SC-SAST is temporarily unavailable. You can still connect to SSC by using the --disable=sc-sast argument.\nSSC URL: %s\nSC-SAST URL: %s" , sscUrl,scSastUrl), expt.getMessage());
-        }
-        try ( var unirest = GenericUnirestFactory.createUnirestInstance() ) {
-            testAuthenticatedSCDastConnection(unirest, sessionData);
-        }
-        catch(UnirestException  expt) {
-        	logoutBeforeNewLogin(sessionName, sessionData);
-        	getSessionHelper().destroy(sessionName);
-        	String scDastUrl = sessionData.getScDastUrlConfig().getUrl();
-        	throw new FcliSimpleException(String.format("SC-DAST is temporarily unavailable. You can still connect to SSC by using the --disable=sc-dast argument.\nSSC URL: %s\nSC-DAST URL: %s", sscUrl,scDastUrl), expt.getMessage());
+		catch (UnirestException e) {
+			logoutBeforeNewLogin(sessionName, sessionData);
+			getSessionHelper().destroy(sessionName);
+			String scSastUrlConfiguredInSSC = sessionData.getScSastUrlConfig().getUrl();
+			String userGivenScSastUrl = sessionLoginOptions.getSscAndScanCentralUrlConfigOptions().getScSastControllerUrl();
+			if (userGivenScSastUrl != null) {
+				throw new FcliSimpleException(
+						String.format("Unable to connect to the given SC-SAST URL.\nSSC URL: %s\nSC-SAST URL: %s",
+								sscUrl, userGivenScSastUrl),
+						e);
+			} else {
+				throw new FcliSimpleException(String.format(
+						"Unable to connect to SC-SAST URL as configured in SSC; please contact your SSC administrator, or use the --disable option to disable SC-SAST functionality for this session.\nSSC URL: %s\nSC-SAST URL: %s",
+						sscUrl, scSastUrlConfiguredInSSC), e);
+			}
+
+		}
+		try (var unirest = GenericUnirestFactory.createUnirestInstance()) {
+			testAuthenticatedSCDastConnection(unirest, sessionData);
+		} catch (UnirestException e) {
+			logoutBeforeNewLogin(sessionName, sessionData);
+			getSessionHelper().destroy(sessionName);
+			String scDastUrl = sessionData.getScDastUrlConfig().getUrl();
+			throw new FcliSimpleException(String.format("Unable to connect to SC-DAST URL as configured in SSC; please contact your SSC administrator, or use the --disable option to disable SC-DAST functionality for this session.\nSSC URL: %s\nSC-DAST URL: %s", sscUrl, scDastUrl), e);
         }
     }
 

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/cli/cmd/SSCSessionLoginCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/cli/cmd/SSCSessionLoginCommand.java
@@ -27,6 +27,7 @@ import com.fortify.cli.ssc._common.session.helper.ISSCAndScanCentralUrlConfig;
 import com.fortify.cli.ssc._common.session.helper.SSCAndScanCentralSessionDescriptor;
 import com.fortify.cli.ssc._common.session.helper.SSCAndScanCentralSessionHelper;
 
+import kong.unirest.UnirestException;
 import kong.unirest.UnirestInstance;
 import lombok.Getter;
 import picocli.CommandLine.ArgGroup;
@@ -59,11 +60,24 @@ public class SSCSessionLoginCommand extends AbstractSessionLoginCommand<SSCAndSc
         // SSC connection will already have been validated during login, so we only need to
         // verify SC-SAST & SC-DAST connections.
         SSCAndScanCentralSessionDescriptor sessionData = SSCAndScanCentralSessionHelper.instance().get(sessionName, true);
+        String sscUrl = sessionData.getSscUrlConfig().getUrl();
         try ( var unirest = GenericUnirestFactory.createUnirestInstance() ) {
             testAuthenticatedSCSastConnection(unirest, sessionData);
         }
+        catch(UnirestException  expt) {
+        	logoutBeforeNewLogin(sessionName, sessionData);
+        	getSessionHelper().destroy(sessionName);
+        	String scSastUrl = sessionData.getScSastUrlConfig().getUrl();
+        	throw new FcliSimpleException(String.format("SC-SAST is temporarily unavailable. You can still connect to SSC by using the --disable=sc-sast argument.\nSSC URL: %s\nSC-SAST URL: %s" , sscUrl,scSastUrl), expt.getMessage());
+        }
         try ( var unirest = GenericUnirestFactory.createUnirestInstance() ) {
             testAuthenticatedSCDastConnection(unirest, sessionData);
+        }
+        catch(UnirestException  expt) {
+        	logoutBeforeNewLogin(sessionName, sessionData);
+        	getSessionHelper().destroy(sessionName);
+        	String scDastUrl = sessionData.getScDastUrlConfig().getUrl();
+        	throw new FcliSimpleException(String.format("SC-DAST is temporarily unavailable. You can still connect to SSC by using the --disable=sc-dast argument.\nSSC URL: %s\nSC-DAST URL: %s", sscUrl,scDastUrl), expt.getMessage());
         }
     }
 

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/cli/mixin/SSCAndScanCentralSessionLoginOptions.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/cli/mixin/SSCAndScanCentralSessionLoginOptions.java
@@ -13,6 +13,7 @@
 package com.fortify.cli.ssc._common.session.cli.mixin;
 
 import java.time.OffsetDateTime;
+import java.util.HashSet;
 import java.util.Set;
 
 import com.fortify.cli.common.log.LogSensitivityLevel;
@@ -53,23 +54,20 @@ public class SSCAndScanCentralSessionLoginOptions {
         @MaskValue(sensitivity = LogSensitivityLevel.low, description = "SC-SAST CONTROLLER URL")
         @Getter private String scSastControllerUrl;
 
-        @DisableTest(TestType.MULTI_OPT_PLURAL_NAME)
-		@Option(names = { "--disable" }, required = false, split = ",", order =3, descriptionKey = "fcli.ssc.component.list.disable")
-		@Getter private Set<SSCComponentDisable> disable;
+		@DisableTest(TestType.MULTI_OPT_PLURAL_NAME)
+		@Option(names = { "--disable" }, required = false, split = ",", order = 3)
+		@Getter	private Set<SSCComponentDisable> disabledComponents = new HashSet<>();
 
 		@RequiredArgsConstructor
 		public static enum SSCComponentDisable {
-			sc_sast("sc-sast"), sc_dast("sc-dast");
-
-			@Getter
-			private final String param;
+			sc_sast, sc_dast;
 
 			@Override
-	        public String toString() {
-	            return super.toString().replace('_', '-');
-	        }
+			public String toString() {
+				return name().replace('_', '-');
+			}
 		}
-    }
+	}
     
     public static class SSCAndScanCentralCredentialConfigOptions implements ISSCAndScanCentralCredentialsConfig {
         @ArgGroup(exclusive = true, multiplicity = "1", order = 1) 

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/cli/mixin/SSCAndScanCentralSessionLoginOptions.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/cli/mixin/SSCAndScanCentralSessionLoginOptions.java
@@ -13,6 +13,7 @@
 package com.fortify.cli.ssc._common.session.cli.mixin;
 
 import java.time.OffsetDateTime;
+import java.util.Set;
 
 import com.fortify.cli.common.log.LogSensitivityLevel;
 import com.fortify.cli.common.log.MaskValue;
@@ -21,12 +22,15 @@ import com.fortify.cli.common.rest.cli.mixin.UrlConfigOptions;
 import com.fortify.cli.common.session.cli.mixin.UserCredentialOptions;
 import com.fortify.cli.common.util.DateTimePeriodHelper;
 import com.fortify.cli.common.util.DateTimePeriodHelper.Period;
+import com.fortify.cli.common.util.DisableTest;
+import com.fortify.cli.common.util.DisableTest.TestType;
 import com.fortify.cli.ssc._common.session.helper.ISSCAndScanCentralCredentialsConfig;
 import com.fortify.cli.ssc._common.session.helper.ISSCAndScanCentralUrlConfig;
 import com.fortify.cli.ssc._common.session.helper.ISSCUserCredentialsConfig;
 import com.fortify.cli.ssc.access_control.helper.SSCTokenConverter;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -45,9 +49,26 @@ public class SSCAndScanCentralSessionLoginOptions {
         @MaskValue(sensitivity = LogSensitivityLevel.low, description = "SSC HOST", pattern = MaskValue.URL_HOSTNAME_PATTERN)
         @Getter private String sscUrl;
         
-        @Option(names = {"--sc-sast-url"}, required = false, order=1)
+        @Option(names = {"--sc-sast-url"}, required = false, order=2)
         @MaskValue(sensitivity = LogSensitivityLevel.low, description = "SC-SAST CONTROLLER URL")
         @Getter private String scSastControllerUrl;
+
+        @DisableTest(TestType.MULTI_OPT_PLURAL_NAME)
+		@Option(names = { "--disable" }, required = false, split = ",", order =3, descriptionKey = "fcli.ssc.component.list.disable")
+		@Getter private Set<SSCComponentDisable> disable;
+
+		@RequiredArgsConstructor
+		public static enum SSCComponentDisable {
+			sc_sast("sc-sast"), sc_dast("sc-dast");
+
+			@Getter
+			private final String param;
+
+			@Override
+	        public String toString() {
+	            return super.toString().replace('_', '-');
+	        }
+		}
     }
     
     public static class SSCAndScanCentralCredentialConfigOptions implements ISSCAndScanCentralCredentialsConfig {

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/helper/ISSCAndScanCentralUrlConfig.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/helper/ISSCAndScanCentralUrlConfig.java
@@ -3,7 +3,10 @@
  */
 package com.fortify.cli.ssc._common.session.helper;
 
+import java.util.Set;
+
 import com.fortify.cli.common.rest.unirest.config.IConnectionConfig;
+import com.fortify.cli.ssc._common.session.cli.mixin.SSCAndScanCentralSessionLoginOptions.SSCAndScanCentralUrlConfigOptions.SSCComponentDisable;
 
 /**
  * Interface for the functions to get the SSC URL and the Controller URL
@@ -11,4 +14,5 @@ import com.fortify.cli.common.rest.unirest.config.IConnectionConfig;
 public interface ISSCAndScanCentralUrlConfig extends IConnectionConfig {
     String getSscUrl();
     String getScSastControllerUrl();
+    Set<SSCComponentDisable> getDisable();
 }

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/helper/ISSCAndScanCentralUrlConfig.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/helper/ISSCAndScanCentralUrlConfig.java
@@ -14,5 +14,5 @@ import com.fortify.cli.ssc._common.session.cli.mixin.SSCAndScanCentralSessionLog
 public interface ISSCAndScanCentralUrlConfig extends IConnectionConfig {
     String getSscUrl();
     String getScSastControllerUrl();
-    Set<SSCComponentDisable> getDisable();
+    Set<SSCComponentDisable> getDisabledComponents();
 }

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/helper/SSCAndScanCentralSessionDescriptor.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/helper/SSCAndScanCentralSessionDescriptor.java
@@ -13,6 +13,7 @@
 package com.fortify.cli.ssc._common.session.helper;
 
 import java.util.Date;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -30,6 +31,7 @@ import com.fortify.cli.common.rest.unirest.config.IUserCredentialsConfig;
 import com.fortify.cli.common.rest.unirest.config.UrlConfig;
 import com.fortify.cli.common.session.helper.AbstractSessionDescriptor;
 import com.fortify.cli.common.util.StringUtils;
+import com.fortify.cli.ssc._common.session.cli.mixin.SSCAndScanCentralSessionLoginOptions.SSCAndScanCentralUrlConfigOptions.SSCComponentDisable;
 import com.fortify.cli.ssc.access_control.helper.SSCTokenCreateRequest;
 import com.fortify.cli.ssc.access_control.helper.SSCTokenGetOrCreateResponse;
 import com.fortify.cli.ssc.access_control.helper.SSCTokenGetOrCreateResponse.SSCTokenData;
@@ -112,8 +114,28 @@ public class SSCAndScanCentralSessionDescriptor extends AbstractSessionDescripto
                 .sscTokenData(sscTokenData)
                 .revokeTokenOnLogout(providedSscToken==null);
         var sscConfigProperties = getSscConfigProperties(sscUrlConfig, sscTokenData.getToken());
-        addScSastSessionConfig(sessionDescriptorBuilder, sscAndScanCentralUrlConfig, sscAndScanCentralCredentialsConfig.getScSastClientAuthToken(), sscConfigProperties);
-        addScDastSessionConfig(sessionDescriptorBuilder, sscAndScanCentralUrlConfig, sscConfigProperties);
+        boolean disableSast = false;
+        boolean disableDast = false;
+        Set<SSCComponentDisable> disabledComponents = sscAndScanCentralUrlConfig.getDisable();
+        if(disabledComponents != null) {
+        	for (SSCComponentDisable disable : disabledComponents) {
+                if (disable == SSCComponentDisable.sc_sast) {
+                	disableSast = true;
+                } else if (disable == SSCComponentDisable.sc_dast) {
+                	disableDast = true;
+                }
+            }
+        }
+		if (disableSast) {
+			sessionDescriptorBuilder.scSastDisabledReason("Disabled by user");
+		} else {
+			addScSastSessionConfig(sessionDescriptorBuilder, sscAndScanCentralUrlConfig,
+					sscAndScanCentralCredentialsConfig.getScSastClientAuthToken(), sscConfigProperties);
+		}
+        if (disableDast)
+        	sessionDescriptorBuilder.scDastDisabledReason("Disabled by user");
+        else
+        	addScDastSessionConfig(sessionDescriptorBuilder, sscAndScanCentralUrlConfig, sscConfigProperties);
         return sessionDescriptorBuilder.build();
     }
     

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/helper/SSCAndScanCentralSessionDescriptor.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/helper/SSCAndScanCentralSessionDescriptor.java
@@ -113,26 +113,15 @@ public class SSCAndScanCentralSessionDescriptor extends AbstractSessionDescripto
                 .sscUrlConfig(sscUrlConfig)
                 .sscTokenData(sscTokenData)
                 .revokeTokenOnLogout(providedSscToken==null);
-        var sscConfigProperties = getSscConfigProperties(sscUrlConfig, sscTokenData.getToken());
-        boolean disableSast = false;
-        boolean disableDast = false;
-        Set<SSCComponentDisable> disabledComponents = sscAndScanCentralUrlConfig.getDisable();
-        if(disabledComponents != null) {
-        	for (SSCComponentDisable disable : disabledComponents) {
-                if (disable == SSCComponentDisable.sc_sast) {
-                	disableSast = true;
-                } else if (disable == SSCComponentDisable.sc_dast) {
-                	disableDast = true;
-                }
-            }
-        }
-		if (disableSast) {
+		var sscConfigProperties = getSscConfigProperties(sscUrlConfig, sscTokenData.getToken());
+		Set<SSCComponentDisable> disabledComponents = sscAndScanCentralUrlConfig.getDisabledComponents();
+		if (disabledComponents.contains(SSCComponentDisable.sc_sast)) {
 			sessionDescriptorBuilder.scSastDisabledReason("Disabled by user");
 		} else {
 			addScSastSessionConfig(sessionDescriptorBuilder, sscAndScanCentralUrlConfig,
 					sscAndScanCentralCredentialsConfig.getScSastClientAuthToken(), sscConfigProperties);
 		}
-        if (disableDast)
+        if (disabledComponents.contains(SSCComponentDisable.sc_dast))
         	sessionDescriptorBuilder.scDastDisabledReason("Disabled by user");
         else
         	addScDastSessionConfig(sessionDescriptorBuilder, sscAndScanCentralUrlConfig, sscConfigProperties);

--- a/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/i18n/SSCMessages.properties
+++ b/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/i18n/SSCMessages.properties
@@ -82,6 +82,7 @@ fcli.ssc.session.login.token = SSC token in either encoded (REST) or decoded (ap
   use an AutomationToken, CIToken, or UnifiedLoginToken.
 fcli.ssc.session.login.sc-sast-url = Override ScanCentral SAST Controller URL. If not specified, the controller URL as configured in SSC will be used.
 fcli.ssc.session.login.ssc-session = Name for this SSC session. Default value: ${DEFAULT-VALUE}.
+fcli.ssc.session.login.disable = By default, sessions for SSC, SC-SAST, and SC-DAST are created. To bypass a session, use the --disable option.%nAllowed values: ${COMPLETION-CANDIDATES}.
   
 fcli.ssc.session.logout.usage.header = Terminate Fortify SSC session.
 fcli.ssc.session.logout.usage.description.0 = This command terminates an SSC session previously created \

--- a/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/i18n/SSCMessages.properties
+++ b/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/i18n/SSCMessages.properties
@@ -82,7 +82,9 @@ fcli.ssc.session.login.token = SSC token in either encoded (REST) or decoded (ap
   use an AutomationToken, CIToken, or UnifiedLoginToken.
 fcli.ssc.session.login.sc-sast-url = Override ScanCentral SAST Controller URL. If not specified, the controller URL as configured in SSC will be used.
 fcli.ssc.session.login.ssc-session = Name for this SSC session. Default value: ${DEFAULT-VALUE}.
-fcli.ssc.session.login.disable = By default, sessions for SSC, SC-SAST, and SC-DAST are created. To bypass a session, use the --disable option.%nAllowed values: ${COMPLETION-CANDIDATES}.
+fcli.ssc.session.login.disable = By default, an SSC session allows access to SC-SAST & SC-DAST (if configured). \
+  This option allows for disabling SC-SAST and/or SC-DAST for this session, thereby avoiding unnecessary connection \
+  checks and preventing any associated failures. Allowed values: ${COMPLETION-CANDIDATES}.
   
 fcli.ssc.session.logout.usage.header = Terminate Fortify SSC session.
 fcli.ssc.session.logout.usage.description.0 = This command terminates an SSC session previously created \


### PR DESCRIPTION
Add --disable option to bypass the SC-SAST and SC-DAST session while creating SSC session.
![image](https://github.com/user-attachments/assets/fc2760d4-b737-49e3-9a51-cb7784c52bff)


