### PR TITLE
Add `gitlab-codequality-report` actions for SSC and FOD

### DIFF
--- a/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/actions/zip/gitlab-codequality-report.yaml
+++ b/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/actions/zip/gitlab-codequality-report.yaml
@@ -1,0 +1,68 @@
+# yaml-language-server: $schema=https://fortify.github.io/fcli/schemas/action/fcli-action-schema-dev-2.x.json
+
+author: Fortify
+usage:
+  header: Generate a GitLab Code Quality report listing FoD SAST vulnerabilities.
+  description: |
+    For information on how to import this report into GitLab, see 
+    https://docs.gitlab.com/ee/ci/yaml/artifacts_reports.html#artifactsreportscodequality
+
+config:
+  rest.target.default: fod
+  
+cli.options:
+  file:
+    names: --file, -f
+    description: "Optional output file name (or 'stdout' / 'stderr'). Default value: gl-fortify-codequality.json"
+    required: false
+    default: gl-fortify-codequality.json
+  release:
+    names: --release, --rel
+    description: "Required release id or <appName>:[<microserviceName>:]<releaseName>"
+  
+steps:
+  - var.set:
+      rel: ${#fod.release(cli.release)}
+  - log.progress: Loading static scan summary
+  - rest.call:
+      staticScanSummary:
+        uri:  /api/v3/scans/${rel.currentStaticScanId}/summary
+        if:   ${rel.currentStaticScanId!=null}
+        on.fail: 
+          - log.warn: Unable to load static scan summary, some scan metadata may be missing from the report
+  - log.progress: Processing issue data
+  - rest.call:
+      issues:
+        uri: /api/v3/releases/${rel.releaseId}/vulnerabilities?limit=50
+        query:
+          filters: scantype:Static
+        log.progress:
+          page.post-process: Processed ${totalIssueCount?:0} of ${issues_raw.totalCount} issues
+        records.for-each:
+          record.var-name: issue
+          embed:
+            details:
+              uri: /api/v3/releases/${rel.releaseId}/vulnerabilities/${issue.vulnId}/details
+            recommendations:
+              uri: /api/v3/releases/${rel.releaseId}/vulnerabilities/${issue.vulnId}/recommendations
+          do:
+            - var.set:
+                vulnerabilities..: {fmt: vulnerabilities}
+  - out.write:
+      ${cli.file}: {fmt: gitlab-codequality-report}
+  - if: ${!{'stdout','stderr'}.contains(cli.file)}
+    log.info: Output written to ${cli.file}
+
+formatters:
+  gitlab-codequality-report:
+      ${vulnerabilities?:{}} 
+     
+  vulnerabilities:
+      description: ${#abbreviate(#htmlToText(issue.details?.summary?:""), 5000)}
+      check_name: ${issue.category}
+      fingerprint: ${issue.instanceId}
+      location:
+          path: ${issue.primaryLocationFull}
+          lines: 
+              begin: ${issue.lineNumber}
+      severity: ${issue.severityString}

--- a/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/actions/zip/gitlab-codequality-report.yaml
+++ b/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/actions/zip/gitlab-codequality-report.yaml
@@ -19,17 +19,16 @@ cli.options:
   release:
     names: --release, --rel
     description: "Required release id or <appName>:[<microserviceName>:]<releaseName>"
+  sourceDir:
+    names: --source-dir
+    required: false
+    description: "(PREVIEW) Optional local repository directory to convert Fortify-reported source file paths to actual repository file paths"
+
   
 steps:
   - var.set:
       rel: ${#fod.release(cli.release)}
-  - log.progress: Loading static scan summary
-  - rest.call:
-      staticScanSummary:
-        uri:  /api/v3/scans/${rel.currentStaticScanId}/summary
-        if:   ${rel.currentStaticScanId!=null}
-        on.fail: 
-          - log.warn: Unable to load static scan summary, some scan metadata may be missing from the report
+      issueSourceFileResolver: ${#issueSourceFileResolver({sourceDir:cli.sourceDir})}
   - log.progress: Processing issue data
   - rest.call:
       issues:
@@ -62,7 +61,7 @@ formatters:
       check_name: ${issue.category}
       fingerprint: ${issue.instanceId}
       location:
-          path: ${issue.primaryLocationFull}
+          path: ${issueSourceFileResolver.resolve(issue.primaryLocationFull)}
           lines: 
-              begin: ${issue.lineNumber}
+              begin: ${issue.lineNumber==0?1:issue.lineNumber}
       severity: ${issue.severityString}

--- a/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/actions/zip/gitlab-codequality-report.yaml
+++ b/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/actions/zip/gitlab-codequality-report.yaml
@@ -1,0 +1,89 @@
+# yaml-language-server: $schema=https://fortify.github.io/fcli/schemas/action/fcli-action-schema-dev-2.x.json
+
+author: Fortify
+usage:
+  header: Generate a GitLab Code Quality report listing SSC SAST vulnerabilities.
+  description: |
+    For information on how to import this report into GitLab, see 
+    https://docs.gitlab.com/ee/ci/yaml/artifacts_reports.html#artifactsreportscodequality
+
+config:
+  rest.target.default: ssc
+
+cli.options:
+  file:
+    names: --file, -f
+    description: "Optional output file name (or 'stdout' / 'stderr'). Default value: gl-fortify-sast.json"
+    required: false
+    default: gl-fortify-codequality.json
+  appversion:
+    names: --appversion, --av
+    description: "Required application version id or <appName>:<versionName>"
+  filterset:
+    names: --filterset, --fs
+    description: "Filter set name or guid from which to load issue data. Default value: Default filter set for given application version"
+    required: false
+  page-size:
+    names: --page-size
+    description: "Number of vulnerabilities to retrieve at a time. Higher numbers may reduce time required to build the report, at the cost of increased memory usage (on both fcli and SSC), and could potentially negatively affect overall SSC performance or result in read time-outs (see `--socket-timeout` option on `fcli ssc session login` command). Default value: 100"
+    required: false
+    default: "100"
+  sourceDir:
+    names: --source-dir
+    required: false
+    description: "(PREVIEW) Optional local repository directory to convert Fortify-reported source file paths to actual repository file paths"
+
+steps:
+  - var.set:
+      av: ${#ssc.appVersion(cli.appversion)}
+      fs: ${#ssc.filterSet(av, cli.filterset)}
+      issueSourceFileResolver: ${#issueSourceFileResolver({sourceDir:cli.sourceDir})}
+  - log.progress: Loading latest static scan
+  - rest.call:
+      artifacts:
+        uri:  /api/v1/projectVersions/${av.id}/artifacts
+        type: paged
+        query:
+          embed: scans
+        records.for-each:
+          record.var-name: artifact
+          breakIf: ${lastStaticScan!=null}
+          do:
+            - var.set:
+                lastStaticScan: ${artifact._embed.scans?.^[type=='SCA']}
+  - log.progress: Processing issue data
+  - rest.call:
+      issues:
+        uri: /api/v1/projectVersions/${av.id}/issues
+        query:
+          filter: ISSUE[11111111-1111-1111-1111-111111111151]:SCA
+          filterset: ${fs.guid}
+          limit: ${cli['page-size']}
+        log.progress:
+          page.post-process: Processed ${totalIssueCount?:0} of ${issues_raw.count} issues
+        records.for-each:
+          record.var-name: issue
+          embed:
+            details:
+              uri: /api/v1/issueDetails/${issue.id}
+          do:
+            - var.set:
+                vulnerabilities..: {fmt: vulnerabilities}
+  - out.write:
+      ${cli.file}: {fmt: gitlab-codequality-report}
+  - if: ${!{'stdout','stderr'}.contains(cli.file)}
+    log.info: Output written to ${cli.file}
+
+formatters:
+  gitlab-codequality-report:
+    ${vulnerabilities?:{}}
+
+  vulnerabilities:
+    description: ${#abbreviate(#htmlToText(issue.details?.brief?:""), 5000)}
+    check_name: ${issue.category}
+    fingerprint: ${issue.issueInstanceId}
+    location:
+        path:  ${issueSourceFileResolver.resolve(issue.fullFileName)}
+        lines:
+            begin: ${issue.lineNumber==0?1:issue.lineNumber}
+    severity: ${issue.friority}

--- a/fcli-other/fcli-functional-test/src/ftest/groovy/com/fortify/cli/ftest/fod/FoDBuiltinActionRunSpec.groovy
+++ b/fcli-other/fcli-functional-test/src/ftest/groovy/com/fortify/cli/ftest/fod/FoDBuiltinActionRunSpec.groovy
@@ -48,6 +48,7 @@ class FoDBuiltinActionRunSpec extends FcliBaseSpec {
                        'github-sast-report',
                        'gitlab-dast-report',
                        'gitlab-sast-report',
+                       'gitlab-codequality-report',
                        'sarif-sast-report',
                        'sonarqube-sast-report']
     }

--- a/fcli-other/fcli-functional-test/src/ftest/groovy/com/fortify/cli/ftest/ssc/SSCBuiltinActionRunSpec.groovy
+++ b/fcli-other/fcli-functional-test/src/ftest/groovy/com/fortify/cli/ftest/ssc/SSCBuiltinActionRunSpec.groovy
@@ -50,6 +50,7 @@ class SSCBuiltinActionRunSpec extends FcliBaseSpec {
                        'gitlab-debricked-report',
                        'gitlab-sast-report',
                        'gitlab-sonatype-report',
+                       'gitlab-codequality-report',
                        'sarif-sast-report',
                        'sonarqube-sast-report']
     }


### PR DESCRIPTION
This is an implementation for showing SAST results as [Code Quality reports](https://docs.gitlab.com/ci/testing/code_quality/).
As per other GitLab reports they need to run in the context of a GitLab pipeline for authentication.