### PR TITLE
fix: Verify consistent use of .as().getBody()(#410)

### DIFF
--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/access_control/cli/cmd/FoDGroupUpdateCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/access_control/cli/cmd/FoDGroupUpdateCommand.java
@@ -94,7 +94,7 @@ public class FoDGroupUpdateCommand extends AbstractFoDJsonNodeOutputCommand impl
 
     @Override
     public String getActionCommandResult() {
-        return "CREATED";
+        return "REQUESTED";
     }
 
     @Override

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/access_control/helper/FoDUserGroupHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/access_control/helper/FoDUserGroupHelper.java
@@ -155,12 +155,12 @@ public class FoDUserGroupHelper {
                     .applicationId(Integer.valueOf(appDescriptor.getApplicationId())).build();
             ObjectNode body = objectMapper.valueToTree(appAccessRequest);
             unirest.post(FoDUrls.USER_GROUP_APPLICATION_ACCESS).routeParam("userGroupId", String.valueOf(userGroupDescriptor.getId()))
-                    .body(body).asEmpty();
+                    .body(body).asString().getBody();
         } else if (action.equals(FoDEnums.UserGroupApplicationAccessAction.Remove)) {
             unirest.delete(FoDUrls.USER_GROUP_APPLICATION_ACCESS_DELETE)
                     .routeParam("userGroupId", String.valueOf(userGroupDescriptor.getId()))
                     .routeParam("applicationId", String.valueOf(appDescriptor.getApplicationId()))
-                    .asEmpty();
+                    .asString().getBody();
         } else {
             throw new FcliSimpleException("Invalid action specified when updating user group application access");
         }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/access_control/helper/FoDUserHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/access_control/helper/FoDUserHelper.java
@@ -143,12 +143,12 @@ public class FoDUserHelper {
                     .applicationId(Integer.valueOf(appDescriptor.getApplicationId())).build();
             ObjectNode body = objectMapper.valueToTree(appAccessRequest);
             unirest.post(FoDUrls.USER_APPLICATION_ACCESS).routeParam("userId", String.valueOf(userDescriptor.getUserId()))
-                    .body(body).asEmpty();
+                    .body(body).asString().getBody();
         } else if (action.equals(FoDEnums.UserApplicationAccessAction.Remove)) {
             unirest.delete(FoDUrls.USER_APPLICATION_ACCESS_DELETE)
                     .routeParam("userId", String.valueOf(userDescriptor.getUserId()))
                     .routeParam("applicationId", String.valueOf(appDescriptor.getApplicationId()))
-                    .asEmpty();
+                    .asString().getBody();
         } else {
             throw new FcliSimpleException("Invalid action specified when updating users application access");
         }


### PR DESCRIPTION
Replace the .Empty() to .asString().getBody()