### PR TITLE
Implement `--skip-if-exists` for all scan commands and refactor setup classes

### DIFF
--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/cli/cmd/AbstractFoDScanSetupCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/cli/cmd/AbstractFoDScanSetupCommand.java
@@ -13,94 +13,49 @@
 
 package com.fortify.cli.fod._common.scan.cli.cmd;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fortify.cli.common.cli.mixin.CommonOptionMixins;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fortify.cli.common.output.transform.IActionCommandResultSupplier;
 import com.fortify.cli.fod._common.cli.mixin.FoDDelimiterMixin;
 import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDJsonNodeOutputCommand;
-import com.fortify.cli.fod._common.rest.FoDUrls;
-import com.fortify.cli.fod._common.rest.helper.FoDFileTransferHelper;
 import com.fortify.cli.fod._common.scan.cli.mixin.FoDEntitlementFrequencyTypeMixins;
-import com.fortify.cli.fod._common.scan.helper.FoDScanType;
 import com.fortify.cli.fod.release.cli.mixin.FoDReleaseByQualifiedNameOrIdResolverMixin;
+import com.fortify.cli.fod.release.helper.FoDReleaseDescriptor;
 
-import kong.unirest.HttpRequest;
 import kong.unirest.UnirestInstance;
-import lombok.Getter;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 
-public abstract class AbstractFoDScanSetupCommand extends AbstractFoDJsonNodeOutputCommand implements IActionCommandResultSupplier {
-    @Getter private static final ObjectMapper objectMapper = new ObjectMapper();
-
-    //private static final Log LOG = LogFactory.getLog(AbstractFoDScanSetupCommand.class);
-
-
+public abstract class AbstractFoDScanSetupCommand<T> extends AbstractFoDJsonNodeOutputCommand implements IActionCommandResultSupplier {
+    private static final Log LOG = LogFactory.getLog(AbstractFoDScanSetupCommand.class);
     @Mixin protected FoDDelimiterMixin delimiterMixin; // Is automatically injected in resolver mixins
     @Mixin protected FoDReleaseByQualifiedNameOrIdResolverMixin.RequiredOption releaseResolver;
 
     @Option(names = {"--assessment-type"}, required = true)
     protected String assessmentType; // Plain text name as custom assessment types can be created
-    @Mixin
-    protected FoDEntitlementFrequencyTypeMixins.RequiredOption entitlementFrequencyTypeMixin;
+    @Mixin protected FoDEntitlementFrequencyTypeMixins.RequiredOption entitlementFrequencyTypeMixin;
     @Option(names = {"--entitlement-id"})
-    protected Integer entitlementId = 0;
+    protected Integer entitlementId;
+    @Option(names={"--skip-if-exists"})
+    protected Boolean skipIfExists = false;
 
-    @Mixin
-    protected CommonOptionMixins.OptionalFile uploadFileMixin;
+    protected String assessmentTypeName;
 
-    // the File Id previously uploaded or uploaded using "uploadFileToUse" below
-    private int fileId = 0;
-
-    protected void setFileId(int fileId) {
-        this.fileId = fileId;
-    }
-
-    protected int uploadFileToUse(UnirestInstance unirest, String releaseId, FoDScanType scanType, String fileType) {
-        int fileIdToUse = 0;
-        HttpRequest<?> uploadFileRequest = null;
-        switch (scanType) {
-            case Dynamic:
-                // Only supporting DAST Automated file uploads from fcli for now
-                uploadFileRequest = getDastAutomatedUploadFileRequest(unirest, releaseId, fileType);
-                break;
-            case Static:
-            case Mobile:
-                // Neither Static or Mobile require any file uploads yet
-                break;
-            default:
+    protected abstract boolean isExistingSetup(T setupDescriptor);
+    protected abstract ObjectNode convertToObjectNode(T setupDescriptor);
+    protected JsonNode handleSkipIfExists(boolean skipIfExists, T setupDescriptor) {
+        if (skipIfExists && isExistingSetup(setupDescriptor)) {
+            ObjectNode skippedNode = convertToObjectNode(setupDescriptor);
+            skippedNode.put("__action__", "SKIPPED_EXISTING");
+            return skippedNode;
         }
-        JsonNode response = FoDFileTransferHelper.upload(unirest, uploadFileRequest, uploadFileMixin.getFile());
-        fileIdToUse = response.get("fileId").intValue(); fileId = fileIdToUse;
-        return fileIdToUse;
+        return null;
     }
-
-    protected HttpRequest<?> getDastAutomatedUploadFileRequest(UnirestInstance unirest, String releaseId, String dastFileType) {
-        return unirest.patch(FoDUrls.DAST_AUTOMATED_SCANS + "/scan-setup/file-upload")
-                .routeParam("relId", releaseId)
-                .queryString("dastFileType", dastFileType);
-    }
-
-    @Override
-    public final JsonNode getJsonNode(UnirestInstance unirest) {
-        var releaseDescriptor = releaseResolver.getReleaseDescriptor(unirest);
-        var releaseId = releaseDescriptor.getReleaseId();
-        HttpRequest<?> request = getBaseRequest(unirest, releaseId);
-        request.asString(); // successful invocation returns empty response
-        return releaseDescriptor.asObjectNode()
-                .put("scanType", getScanType())
-                .put("setupType", getSetupType())
-                .put("filename", (uploadFileMixin.getFile() != null ? uploadFileMixin.getFile().getName() : "N/A"))
-                .put("entitlementId", entitlementId)
-                .put("fileId", fileId);
-    }
-
-    protected abstract String getScanType();
-    protected abstract String getSetupType();
-
-    protected abstract HttpRequest<?> getBaseRequest(UnirestInstance unirest, String releaseId);
-
+    protected abstract JsonNode setup(UnirestInstance unirest, FoDReleaseDescriptor releaseDescriptor, T currentSetup);
+    
     @Override
     public final String getActionCommandResult() {
         return "SETUP";
@@ -110,4 +65,5 @@ public abstract class AbstractFoDScanSetupCommand extends AbstractFoDJsonNodeOut
     public final boolean isSingular() {
         return true;
     }
+
 }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/FoDScanHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/FoDScanHelper.java
@@ -16,7 +16,6 @@ package com.fortify.cli.fod._common.scan.helper;
 import static java.util.function.Predicate.not;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Objects;
 import java.util.Optional;
@@ -43,7 +42,6 @@ import com.fortify.cli.fod._common.scan.helper.dast.FoDScanDastAutomatedSetupOpe
 import com.fortify.cli.fod._common.scan.helper.dast.FoDScanDastAutomatedSetupPostmanRequest;
 import com.fortify.cli.fod._common.util.FoDEnums;
 import com.fortify.cli.fod.dast_scan.helper.FoDScanConfigDastAutomatedDescriptor;
-import com.fortify.cli.fod.release.helper.FoDReleaseAssessmentTypeDescriptor;
 import com.fortify.cli.fod.release.helper.FoDReleaseAssessmentTypeHelper;
 import com.fortify.cli.fod.rest.lookup.helper.FoDLookupDescriptor;
 import com.fortify.cli.fod.rest.lookup.helper.FoDLookupHelper;
@@ -193,76 +191,9 @@ public class FoDScanHelper {
                 .build();
     }
 
-
     public static final HttpRequest<?> addDefaultScanListParams(HttpRequest<?> request) {
         return request.queryString("orderBy", "startedDateTime")
                 .queryString("orderByDirection", "DESC");
-    }
-
-    public static HttpRequest<?> getPostmanSetupRequest(UnirestInstance unirest, String releaseId,
-                                                        FoDScanDastAutomatedSetupBaseRequest base,
-                                                        ArrayList<Integer> collectionFileIds) {
-        FoDScanDastAutomatedSetupPostmanRequest setupRequest = FoDScanDastAutomatedSetupPostmanRequest.builder()
-                .collectionFileIds(collectionFileIds)
-                .build();
-        BeanUtils.copyProperties(base, setupRequest);
-
-        return unirest.put(FoDUrls.DAST_AUTOMATED_SCANS + "/postman-scan-setup")
-                .routeParam("relId", releaseId)
-                .body(setupRequest);
-    }
-
-    @SneakyThrows
-    public static HttpRequest<?> getOpenApiSetupRequest(UnirestInstance unirest, String releaseId,
-                                                        FoDScanDastAutomatedSetupBaseRequest base,
-                                                        Integer fileId, String apiUrl, String apiKey) {
-        boolean isUrl = (apiUrl != null && !apiUrl.isEmpty());
-        int fileIdToUse = (fileId != null ? fileId : 0);
-        FoDScanDastAutomatedSetupOpenApiRequest setupRequest = FoDScanDastAutomatedSetupOpenApiRequest.builder()
-                .sourceType(isUrl ? "Url" : "FileId")
-                .sourceUrn(isUrl ? apiUrl : String.valueOf(fileIdToUse))
-                .apiKey(apiKey)
-                .build();
-        BeanUtils.copyProperties(base, setupRequest);
-
-        return unirest.put(FoDUrls.DAST_AUTOMATED_SCANS + "/openapi-scan-setup")
-                .routeParam("relId", releaseId)
-                .body(setupRequest);
-    }
-
-    public static HttpRequest<?> getGraphQlSetupRequest(UnirestInstance unirest, String releaseId,
-                                                        FoDScanDastAutomatedSetupBaseRequest base,
-                                                        Integer fileId, String apiUrl, FoDEnums.ApiSchemeType schemeType, String host, String servicePath) {
-        boolean isUrl = (apiUrl != null && !apiUrl.isEmpty());
-        int fileIdToUse = (fileId != null ? fileId : 0);
-        FoDScanDastAutomatedSetupGraphQlRequest setupRequest = FoDScanDastAutomatedSetupGraphQlRequest.builder()
-                .sourceType(isUrl ? "Url" : "FileId")
-                .sourceUrn(isUrl ? apiUrl : String.valueOf(fileIdToUse))
-                .schemeType(schemeType)
-                .host(host)
-                .servicePath(servicePath)
-                .build();
-        BeanUtils.copyProperties(base, setupRequest);
-
-        return unirest.put(FoDUrls.DAST_AUTOMATED_SCANS + "/graphql-scan-setup")
-                .routeParam("relId", releaseId)
-                .body(setupRequest);
-    }
-
-    public static HttpRequest<?> getGrpcSetupRequest(UnirestInstance unirest, String releaseId,
-                                                     FoDScanDastAutomatedSetupBaseRequest base,
-                                                     Integer fileId, FoDEnums.ApiSchemeType schemeType, String host, String servicePath) {
-        FoDScanDastAutomatedSetupGrpcRequest setupRequest = FoDScanDastAutomatedSetupGrpcRequest.builder()
-                .fileId(fileId)
-                .schemeType(schemeType)
-                .host(host)
-                .servicePath(servicePath)
-                .build();
-        BeanUtils.copyProperties(base, setupRequest);
-
-        return unirest.put(FoDUrls.DAST_AUTOMATED_SCANS + "/grpc-scan-setup")
-                .routeParam("relId", releaseId)
-                .body(setupRequest);
     }
 
     private static final FoDScanDescriptor getDescriptor(JsonNode node) {

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/FoDScanPollingDescriptor.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/FoDScanPollingDescriptor.java
@@ -28,6 +28,7 @@ public class FoDScanPollingDescriptor extends JsonNodeHolder {
     private String TenantId;
     private String AnalysisStatusId;
     private String OpenSourceStatusId;
+    private String QueuePositionWithinApplication;
     private String AnalysisStatusTypeValue;
     private String AnalysisStatusReasonId;
     private String AnalysisStatusReason;

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/mobile/FoDScanMobileHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/mobile/FoDScanMobileHelper.java
@@ -17,6 +17,7 @@ import java.io.File;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fortify.cli.common.exception.FcliSimpleException;
 import com.fortify.cli.common.json.JsonHelper;
 import com.fortify.cli.fod._common.rest.FoDUrls;
@@ -25,8 +26,10 @@ import com.fortify.cli.fod._common.scan.helper.FoDScanDescriptor;
 import com.fortify.cli.fod._common.scan.helper.FoDScanHelper;
 import com.fortify.cli.fod._common.scan.helper.FoDScanType;
 import com.fortify.cli.fod._common.scan.helper.FoDStartScanResponse;
+import com.fortify.cli.fod.mast_scan.helper.FoDScanConfigMobileDescriptor;
 import com.fortify.cli.fod.release.helper.FoDReleaseDescriptor;
 
+import kong.unirest.GetRequest;
 import kong.unirest.HttpRequest;
 import kong.unirest.UnirestInstance;
 import lombok.Getter;
@@ -64,6 +67,14 @@ public class FoDScanMobileHelper extends FoDScanHelper {
             .put("releaseName", releaseDescriptor.getReleaseName())
             .put("microserviceName", releaseDescriptor.getMicroserviceName());
         return JsonHelper.treeToValue(node, FoDScanDescriptor.class);
+    }
+
+    public static final FoDScanConfigMobileDescriptor getSetupDescriptor(UnirestInstance unirest, String relId) {
+        GetRequest request = unirest.get(FoDUrls.MOBILE_SCANS + "/scan-setup")
+                .routeParam("relId", relId);
+        JsonNode setup = request.asObject(ObjectNode.class).getBody()
+                .put("applicationName", "test");
+        return JsonHelper.treeToValue(setup, FoDScanConfigMobileDescriptor.class);
     }
 
 }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/AbstractFoDDastAutomatedScanSetupCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/AbstractFoDDastAutomatedScanSetupCommand.java
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Copyright 2021, 2023 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ *******************************************************************************/
+
+package com.fortify.cli.fod.dast_scan.cli.cmd;
+
+import java.util.ArrayList;
+import java.util.Objects;
+
+import com.fortify.cli.common.output.transform.IRecordTransformer;
+import com.fortify.cli.fod.dast_scan.helper.FileUploadResult;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fortify.cli.common.cli.mixin.CommonOptionMixins;
+import com.fortify.cli.common.exception.FcliSimpleException;
+import com.fortify.cli.fod._common.rest.FoDUrls;
+import com.fortify.cli.fod._common.rest.helper.FoDFileTransferHelper;
+import com.fortify.cli.fod._common.scan.cli.cmd.AbstractFoDScanSetupCommand;
+import com.fortify.cli.fod._common.scan.helper.FoDScanType;
+import com.fortify.cli.fod._common.scan.helper.dast.FoDScanDastAutomatedHelper;
+import com.fortify.cli.fod.dast_scan.helper.FoDScanConfigDastAutomatedDescriptor;
+import com.fortify.cli.fod.release.helper.FoDReleaseAssessmentTypeDescriptor;
+import com.fortify.cli.fod.release.helper.FoDReleaseAssessmentTypeHelper;
+import com.fortify.cli.fod.release.helper.FoDReleaseDescriptor;
+import kong.unirest.HttpRequest;
+import kong.unirest.UnirestInstance;
+import lombok.Getter;
+import picocli.CommandLine.Mixin;
+
+public abstract class AbstractFoDDastAutomatedScanSetupCommand extends AbstractFoDScanSetupCommand<FoDScanConfigDastAutomatedDescriptor> implements IRecordTransformer {
+    private static final Log LOG = LogFactory.getLog(AbstractFoDDastAutomatedScanSetupCommand.class);
+    @Getter private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mixin
+    protected CommonOptionMixins.OptionalFile uploadFileMixin;
+
+    // the File Id previously uploaded or uploaded using "uploadFileToUse" below
+    private int fileId = 0;
+
+    protected void setFileId(int fileId) {
+        this.fileId = fileId;
+    }
+
+    protected FileUploadResult uploadFileToUse(UnirestInstance unirest, String releaseId, FoDScanType scanType, String fileType) {
+        HttpRequest<?> uploadFileRequest = null;
+        switch (scanType) {
+            case Dynamic:
+                // Only supporting DAST Automated file uploads from fcli for now
+                uploadFileRequest = getDastAutomatedUploadFileRequest(unirest, releaseId, fileType);
+                break;
+            case Static:
+            case Mobile:
+                // Neither Static or Mobile require any file uploads yet
+                break;
+            default:
+        }
+        JsonNode response = FoDFileTransferHelper.upload(unirest, uploadFileRequest, uploadFileMixin.getFile());
+        int fileIdToUse = response.get("fileId").intValue();
+        fileId = fileIdToUse;
+        ArrayList<String> hosts = response.has("hosts") ?
+                objectMapper.convertValue(response.get("hosts"), new com.fasterxml.jackson.core.type.TypeReference<ArrayList<String>>() {}) :
+                new ArrayList<>();
+        return new FileUploadResult(fileIdToUse, hosts);
+    }
+
+    protected HttpRequest<?> getDastAutomatedUploadFileRequest(UnirestInstance unirest, String releaseId, String dastFileType) {
+        return unirest.patch(FoDUrls.DAST_AUTOMATED_SCANS + "/scan-setup/file-upload")
+                .routeParam("relId", releaseId)
+                .queryString("dastFileType", dastFileType);
+    }
+
+    @Override
+    protected boolean isExistingSetup(FoDScanConfigDastAutomatedDescriptor setupDescriptor) {
+        return (setupDescriptor != null && setupDescriptor.getAssessmentTypeId() != 0);
+    }
+
+    @Override
+    protected ObjectNode convertToObjectNode(FoDScanConfigDastAutomatedDescriptor setupDescriptor) {
+        return setupDescriptor.asObjectNode();
+    }
+
+    @Override
+    protected JsonNode setup(UnirestInstance unirest, FoDReleaseDescriptor releaseDescriptor,
+                             FoDScanConfigDastAutomatedDescriptor currentSetup) {
+        var releaseId = releaseDescriptor.getReleaseId();
+        HttpRequest<?> request = getBaseRequest(unirest, releaseId);
+        request.asString(); // successful invocation returns empty response
+        return releaseDescriptor.asObjectNode()
+                .put("scanType", getScanType())
+                .put("setupType", getSetupType())
+                .put("filename", (uploadFileMixin.getFile() != null ? uploadFileMixin.getFile().getName() : "N/A"))
+                .put("entitlementId", entitlementId)
+                .put("fileId", fileId);
+        //return FoDScanDastAutomatedHelper.setupScan(unirest, releaseDescriptor, setupDastAutomatScanRequest).asJsonNode();
+    }
+
+    @Override
+    public final JsonNode getJsonNode(UnirestInstance unirest) {
+        var releaseDescriptor = releaseResolver.getReleaseDescriptor(unirest);
+        var releaseId = releaseDescriptor.getReleaseId();
+        var setupDescriptor = FoDScanDastAutomatedHelper.getSetupDescriptor(unirest, releaseId);
+        var skippedNode = handleSkipIfExists(skipIfExists, setupDescriptor);
+        if (skippedNode != null) {
+            return skippedNode;
+        } else {
+            return setup(unirest, releaseDescriptor, setupDescriptor);
+        }
+    }
+
+    protected abstract String getScanType();
+    protected abstract String getSetupType();
+
+    protected abstract HttpRequest<?> getBaseRequest(UnirestInstance unirest, String releaseId);
+
+    protected void validateEntitlement(FoDScanConfigDastAutomatedDescriptor currentSetup, Integer entitlementIdToUse,
+                                       String relId, FoDReleaseAssessmentTypeDescriptor atd) {
+        // validate entitlement specified or currently in use against assessment type found
+        if (entitlementId != null && entitlementId > 0) {
+            // check if "entitlement id" explicitly matches what has been found
+            if (!Objects.equals(entitlementIdToUse, entitlementId)) {
+                throw new FcliSimpleException("Cannot find appropriate assessment type for use with entitlement: " + entitlementId);
+            }
+        } else {
+            if (currentSetup.getEntitlementId() != null && currentSetup.getEntitlementId() > 0) {
+                // check if "entitlement id" is already configured
+                if (!Objects.equals(entitlementIdToUse, currentSetup.getEntitlementId())) {
+                    LOG.warn("Changing current release entitlement from " + currentSetup.getEntitlementId());
+                }
+            }
+        }
+        // check if the entitlement can still be used
+        if (FoDReleaseAssessmentTypeHelper.validateEntitlementCanBeUsed(relId, atd)) {
+            LOG.info("The entitlement '" + entitlementIdToUse + "' is still valid.");
+        } else {
+            LOG.info("The entitlement '" + entitlementIdToUse + "' is no longer valid.");
+        }
+    }
+
+    public JsonNode transformRecord(JsonNode record) {
+        FoDReleaseDescriptor releaseDescriptor = releaseResolver.getReleaseDescriptor(getUnirestInstance());
+        return ((ObjectNode)record)
+                .put("scanType", getScanType())
+                .put("setupType", getSetupType())
+                .put("fileId", (fileId != 0 ? fileId : null))
+                .put("filename", (uploadFileMixin.getFile() != null ? uploadFileMixin.getFile().getName() : "N/A"))
+                .put("applicationName", releaseDescriptor.getApplicationName())
+                .put("releaseName", releaseDescriptor.getReleaseName())
+                .put("microserviceName", releaseDescriptor.getMicroserviceName());
+    }
+}

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/FoDDastAutomatedScanGetConfigCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/FoDDastAutomatedScanGetConfigCommand.java
@@ -22,10 +22,9 @@ import lombok.Getter;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 
-@Getter
 @Command(name = FoDOutputHelperMixins.GetConfig.CMD_NAME)
 public class FoDDastAutomatedScanGetConfigCommand extends AbstractFoDScanConfigGetCommand {
-    @Mixin private FoDOutputHelperMixins.GetConfig outputHelper;
+    @Getter @Mixin private FoDOutputHelperMixins.GetConfig outputHelper;
 
     @Override
     protected FoDScanConfigDastAutomatedDescriptor getDescriptor(UnirestInstance unirest, String releaseId) {

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/FoDDastAutomatedScanGetConfigCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/FoDDastAutomatedScanGetConfigCommand.java
@@ -22,9 +22,10 @@ import lombok.Getter;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 
+@Getter
 @Command(name = FoDOutputHelperMixins.GetConfig.CMD_NAME)
 public class FoDDastAutomatedScanGetConfigCommand extends AbstractFoDScanConfigGetCommand {
-    @Getter @Mixin private FoDOutputHelperMixins.GetConfig outputHelper;
+    @Mixin private FoDOutputHelperMixins.GetConfig outputHelper;
 
     @Override
     protected FoDScanConfigDastAutomatedDescriptor getDescriptor(UnirestInstance unirest, String releaseId) {

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/FoDDastAutomatedScanSetupApiCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/FoDDastAutomatedScanSetupApiCommand.java
@@ -1,6 +1,6 @@
 /**
  * Copyright 2023 Open Text.
- *
+ * <p>
  * The only warranties for products and services of Open Text
  * and its affiliates and licensors ("Open Text") are as may
  * be set forth in the express warranty statements accompanying
@@ -12,31 +12,41 @@
  */
 package com.fortify.cli.fod.dast_scan.cli.cmd;
 
-import java.util.ArrayList;
-import java.util.Collections;
-
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fortify.cli.common.cli.util.CommandGroup;
 import com.fortify.cli.common.exception.FcliSimpleException;
 import com.fortify.cli.fod._common.output.cli.mixin.FoDOutputHelperMixins;
-import com.fortify.cli.fod._common.scan.cli.cmd.AbstractFoDScanSetupCommand;
 import com.fortify.cli.fod._common.scan.helper.FoDScanAssessmentTypeDescriptor;
 import com.fortify.cli.fod._common.scan.helper.FoDScanHelper;
 import com.fortify.cli.fod._common.scan.helper.FoDScanType;
 import com.fortify.cli.fod._common.scan.helper.dast.FoDScanDastAutomatedSetupBaseRequest;
 import com.fortify.cli.fod._common.util.FoDEnums;
-
+import com.fortify.cli.fod.dast_scan.helper.FileUploadResult;
+import com.fortify.cli.fod.dast_scan.helper.FoDScanConfigDastAutomatedDescriptor;
+import com.fortify.cli.fod.dast_scan.helper.FoDScanConfigDastAutomatedHelper;
+import com.fortify.cli.fod.release.helper.FoDReleaseAssessmentTypeHelper;
+import com.fortify.cli.fod.release.helper.FoDReleaseDescriptor;
 import kong.unirest.HttpRequest;
 import kong.unirest.UnirestInstance;
 import lombok.Getter;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 
-@Command(name = FoDOutputHelperMixins.SetupApi.CMD_NAME) @CommandGroup("*-scan-setup")
-public class FoDDastAutomatedScanSetupApiCommand extends AbstractFoDScanSetupCommand {
-    @Getter @Mixin private FoDOutputHelperMixins.SetupWorkflow outputHelper;
+import java.util.ArrayList;
+import java.util.Collections;
 
-    @Option(names={"--type"}, required = true)
+@Command(name = FoDOutputHelperMixins.SetupApi.CMD_NAME)
+@CommandGroup("*-scan-setup")
+public class FoDDastAutomatedScanSetupApiCommand extends AbstractFoDDastAutomatedScanSetupCommand {
+    private static final Log LOG = LogFactory.getLog(FoDDastAutomatedScanSetupApiCommand.class);
+    @Getter
+    @Mixin
+    private FoDOutputHelperMixins.SetupWorkflow outputHelper;
+
+    @Option(names = {"--type"}, required = true)
     private FoDEnums.DastAutomatedApiTypes apiType;
 
     @Option(names = {"--file-id"})
@@ -54,9 +64,9 @@ public class FoDDastAutomatedScanSetupApiCommand extends AbstractFoDScanSetupCom
     @Option(names = {"--service-path"})
     private String apiServicePath;
 
-    @Option(names={"--environment"}, defaultValue = "External")
+    @Option(names = {"--environment"}, defaultValue = "External")
     private FoDEnums.DynamicScanEnvironmentFacingType environmentFacingType;
-    @Option(names={"--timebox"})
+    @Option(names = {"--timebox"})
     private Integer timebox;
     @Option(names = {"--timezone"})
     private String timezone;
@@ -75,21 +85,40 @@ public class FoDDastAutomatedScanSetupApiCommand extends AbstractFoDScanSetupCom
     protected String getScanType() {
         return "DAST Automated";
     }
+
     @Override
     protected String getSetupType() {
         return "API";
     }
 
     @Override
-    protected HttpRequest<?> getBaseRequest(UnirestInstance unirest, String releaseId) {
+    protected HttpRequest<?> getBaseRequest(UnirestInstance unirest, String relId) {
+        return null;
+    }
+
+    @Override
+    protected JsonNode setup(UnirestInstance unirest, FoDReleaseDescriptor releaseDescriptor, FoDScanConfigDastAutomatedDescriptor currentSetup) {
+        var relId = releaseDescriptor.getReleaseId();
+
         validate();
+
+        LOG.info("Finding appropriate entitlement to use.");
+
+        var atd = FoDReleaseAssessmentTypeHelper.getAssessmentTypeDescriptor(unirest, relId, FoDScanType.Dynamic,
+                entitlementFrequencyTypeMixin.getEntitlementFrequencyType(), assessmentType);
+        var assessmentTypeId = atd.getAssessmentTypeId();
+        var entitlementIdToUse = atd.getEntitlementId();
+        assessmentTypeName = atd.getName();
+
+        if (currentSetup != null) validateEntitlement(currentSetup, entitlementIdToUse, relId, atd);
+        LOG.info("Configuring release to use entitlement " + entitlementIdToUse);
 
         FoDEnums.DastAutomatedFileTypes dastFileType = apiType.getDastFileType();
         boolean requiresNetworkAuthentication = false;
-        Integer fileIdToUse = fileId;
+        FileUploadResult fileUploadResult = null;
 
         if (uploadFileMixin != null && uploadFileMixin.getFile() != null) {
-            fileIdToUse = uploadFileToUse(unirest, releaseId, FoDScanType.Dynamic, dastFileType.name());
+            fileUploadResult = uploadFileToUse(unirest, relId, FoDScanType.Dynamic, dastFileType != null ? dastFileType.name() : null);
         }
         FoDScanDastAutomatedSetupBaseRequest.NetworkAuthenticationType networkAuthenticationSettings = null;
         if (networkAuthenticationType != null) {
@@ -101,9 +130,10 @@ public class FoDDastAutomatedScanSetupApiCommand extends AbstractFoDScanSetupCom
             // if Fortify Connect network site override environmentFacingType to Internal
             environmentFacingType = FoDEnums.DynamicScanEnvironmentFacingType.Internal;
         }
-        
-        FoDScanAssessmentTypeDescriptor assessmentTypeDescriptor = FoDScanHelper.getEntitlementToUse(unirest, releaseId, FoDScanType.Dynamic,
-                assessmentType, entitlementFrequencyTypeMixin.getEntitlementFrequencyType(), entitlementId);
+
+        FoDScanAssessmentTypeDescriptor assessmentTypeDescriptor = FoDScanHelper.getEntitlementToUse(unirest, relId, FoDScanType.Dynamic,
+                assessmentType, entitlementFrequencyTypeMixin.getEntitlementFrequencyType(),
+                entitlementId != null && entitlementId > 0 ? entitlementId : 0);
         entitlementId = assessmentTypeDescriptor.getEntitlementId();
         FoDScanDastAutomatedSetupBaseRequest setupBaseRequest = FoDScanDastAutomatedSetupBaseRequest.builder()
                 .dynamicScanEnvironmentFacingType(environmentFacingType != null ?
@@ -121,14 +151,18 @@ public class FoDDastAutomatedScanSetupApiCommand extends AbstractFoDScanSetupCom
                 .build();
 
         if (apiType.equals(FoDEnums.DastAutomatedApiTypes.Postman)) {
-            ArrayList<Integer> collectionFileIds = new ArrayList<>(Collections.singletonList(fileIdToUse));
-            return FoDScanHelper.getPostmanSetupRequest(unirest, releaseId, setupBaseRequest, collectionFileIds);
+            //ArrayList<Integer> collectionFileIds = new ArrayList<>(Collections.singletonList(fileIdToUse));
+            return FoDScanConfigDastAutomatedHelper.setupPostmanScan(unirest, releaseDescriptor, setupBaseRequest,
+                    new ArrayList<>(Collections.singletonList(fileUploadResult != null ? fileUploadResult.getFileId() : 0)));
         } else if (apiType.equals(FoDEnums.DastAutomatedApiTypes.OpenApi)) {
-            return FoDScanHelper.getOpenApiSetupRequest(unirest, releaseId, setupBaseRequest, fileIdToUse, apiUrl, apiKey);
+            return FoDScanConfigDastAutomatedHelper.setupOpenApiScan(unirest, releaseDescriptor, setupBaseRequest,
+                    fileUploadResult, apiUrl, apiKey);
         } else if (apiType.equals(FoDEnums.DastAutomatedApiTypes.GraphQL)) {
-            return FoDScanHelper.getGraphQlSetupRequest(unirest, releaseId, setupBaseRequest, fileIdToUse, apiUrl, apiSchemeType, apiHost, apiServicePath);
+            return FoDScanConfigDastAutomatedHelper.setupGraphQlScan(unirest, releaseDescriptor, setupBaseRequest,
+                    fileUploadResult, apiUrl, apiSchemeType, apiHost, apiServicePath);
         } else if (apiType.equals(FoDEnums.DastAutomatedApiTypes.GRPC)) {
-            return FoDScanHelper.getGrpcSetupRequest(unirest, releaseId, setupBaseRequest, fileIdToUse, apiSchemeType, apiHost, apiServicePath);
+            return FoDScanConfigDastAutomatedHelper.setupGrpcScan(unirest, releaseDescriptor, setupBaseRequest,
+                    fileUploadResult, apiSchemeType, apiHost, apiServicePath);
         } else {
             throw new FcliSimpleException("Unexpected DAST Automated API type: " + apiType);
         }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/FoDDastAutomatedScanSetupWorkflowCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/FoDDastAutomatedScanSetupWorkflowCommand.java
@@ -14,32 +14,39 @@ package com.fortify.cli.fod.dast_scan.cli.cmd;
 
 import java.util.ArrayList;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fortify.cli.common.cli.util.CommandGroup;
 import com.fortify.cli.common.exception.FcliSimpleException;
 import com.fortify.cli.fod._common.output.cli.mixin.FoDOutputHelperMixins;
-import com.fortify.cli.fod._common.rest.FoDUrls;
-import com.fortify.cli.fod._common.scan.cli.cmd.AbstractFoDScanSetupCommand;
 import com.fortify.cli.fod._common.scan.helper.FoDScanAssessmentTypeDescriptor;
 import com.fortify.cli.fod._common.scan.helper.FoDScanHelper;
 import com.fortify.cli.fod._common.scan.helper.FoDScanType;
 import com.fortify.cli.fod._common.scan.helper.dast.FoDScanDastAutomatedSetupWorkflowRequest;
 import com.fortify.cli.fod._common.util.FoDEnums;
 
+import com.fortify.cli.fod.dast_scan.helper.FileUploadResult;
+import com.fortify.cli.fod.dast_scan.helper.FoDScanConfigDastAutomatedDescriptor;
+import com.fortify.cli.fod.dast_scan.helper.FoDScanConfigDastAutomatedHelper;
+import com.fortify.cli.fod.release.helper.FoDReleaseAssessmentTypeHelper;
+import com.fortify.cli.fod.release.helper.FoDReleaseDescriptor;
 import kong.unirest.HttpRequest;
 import kong.unirest.UnirestInstance;
 import lombok.Getter;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 
 @Command(name = FoDOutputHelperMixins.SetupWorkflow.CMD_NAME) @CommandGroup("*-scan-setup")
-public class FoDDastAutomatedScanSetupWorkflowCommand extends AbstractFoDScanSetupCommand {
+public class FoDDastAutomatedScanSetupWorkflowCommand extends AbstractFoDDastAutomatedScanSetupCommand {
+    private static final Log LOG = LogFactory.getLog(FoDDastAutomatedScanSetupWorkflowCommand.class);
     @Getter @Mixin private FoDOutputHelperMixins.SetupWorkflow outputHelper;
-
     private final static FoDEnums.DastAutomatedFileTypes dastFileType = FoDEnums.DastAutomatedFileTypes.WorkflowDrivenMacro;
 
-    @Option(names={"--hosts", "--allowed-hosts"}, split=",")
-    private ArrayList<String> allowedHosts;
+    //@Option(names={"--hosts", "--allowed-hosts"}, split=",")
+    //private ArrayList<String> allowedHosts;
     @Option(names = {"--file-id"})
     private Integer workflowMacroFileId;
     @Option(names={"--policy"}, required = true, defaultValue = "Standard")
@@ -70,17 +77,37 @@ public class FoDDastAutomatedScanSetupWorkflowCommand extends AbstractFoDScanSet
 
     @Override
     protected HttpRequest<?> getBaseRequest(UnirestInstance unirest, String releaseId) {
+        return null;
+    }
+
+    @Override
+    protected JsonNode setup(UnirestInstance unirest, FoDReleaseDescriptor releaseDescriptor,
+                             FoDScanConfigDastAutomatedDescriptor currentSetup) {
+        var relId = releaseDescriptor.getReleaseId();
+
+        LOG.info("Finding appropriate entitlement to use.");
+
+        var atd = FoDReleaseAssessmentTypeHelper.getAssessmentTypeDescriptor(unirest, relId, FoDScanType.Dynamic,
+                entitlementFrequencyTypeMixin.getEntitlementFrequencyType(), assessmentType);
+        var assessmentTypeId = atd.getAssessmentTypeId();
+        var entitlementIdToUse = atd.getEntitlementId();
+        assessmentTypeName = atd.getName();
+
+        if (currentSetup != null) validateEntitlement(currentSetup, entitlementIdToUse, relId, atd);
+        LOG.info("Configuring release to use entitlement " + entitlementIdToUse);
+
         validate();
 
         boolean requiresNetworkAuthentication = false;
-        Integer fileIdToUse = workflowMacroFileId;
+        int fileIdToUse = (workflowMacroFileId != null ? workflowMacroFileId : 0);
+        FileUploadResult fileUploadResult = null;
 
         if (uploadFileMixin != null && uploadFileMixin.getFile() != null) {
-            fileIdToUse = uploadFileToUse(unirest, releaseId, FoDScanType.Dynamic, dastFileType.name());
+            fileUploadResult = uploadFileToUse(unirest, relId, FoDScanType.Dynamic, dastFileType.name());
         }
         ArrayList<FoDScanDastAutomatedSetupWorkflowRequest.WorkflowDrivenMacro> workflowDrivenMacros = new ArrayList<>();
         FoDScanDastAutomatedSetupWorkflowRequest.WorkflowDrivenMacro workflowDrivenMacro =
-                new FoDScanDastAutomatedSetupWorkflowRequest.WorkflowDrivenMacro(fileIdToUse, allowedHosts);
+                new FoDScanDastAutomatedSetupWorkflowRequest.WorkflowDrivenMacro(fileUploadResult.getFileId(), fileUploadResult.getHosts());
         workflowDrivenMacros.add(workflowDrivenMacro);
         FoDScanDastAutomatedSetupWorkflowRequest.NetworkAuthenticationType networkAuthenticationSettings = null;
         if (networkAuthenticationType != null) {
@@ -93,13 +120,15 @@ public class FoDDastAutomatedScanSetupWorkflowCommand extends AbstractFoDScanSet
             environmentFacingType = FoDEnums.DynamicScanEnvironmentFacingType.Internal;
         }
         
-        FoDScanAssessmentTypeDescriptor assessmentTypeDescriptor = FoDScanHelper.getEntitlementToUse(unirest, releaseId, FoDScanType.Dynamic,
-                assessmentType, entitlementFrequencyTypeMixin.getEntitlementFrequencyType(), entitlementId);
+        FoDScanAssessmentTypeDescriptor assessmentTypeDescriptor = FoDScanHelper.getEntitlementToUse(unirest, relId, FoDScanType.Dynamic,
+                assessmentType, entitlementFrequencyTypeMixin.getEntitlementFrequencyType(),
+                entitlementId != null && entitlementId > 0 ? entitlementId : 0);
         entitlementId = assessmentTypeDescriptor.getEntitlementId();
         FoDScanDastAutomatedSetupWorkflowRequest setupRequest = FoDScanDastAutomatedSetupWorkflowRequest.builder()
                 .workflowDrivenMacro(workflowDrivenMacros)
                 .policy(scanPolicy)
-                .dynamicScanEnvironmentFacingType(environmentFacingType != null ? environmentFacingType : FoDEnums.DynamicScanEnvironmentFacingType.Internal)
+                .dynamicScanEnvironmentFacingType(environmentFacingType != null ? environmentFacingType :
+                        FoDEnums.DynamicScanEnvironmentFacingType.Internal)
                 .timeZone(timeZoneToUse)
                 .requiresNetworkAuthentication(requiresNetworkAuthentication)
                 .networkAuthenticationSettings(networkAuthenticationSettings)
@@ -110,16 +139,15 @@ public class FoDDastAutomatedScanSetupWorkflowCommand extends AbstractFoDScanSet
                 .networkName(fodConnectNetwork != null ? fodConnectNetwork : "")
                 .build();
 
-        return unirest.put(FoDUrls.DAST_AUTOMATED_SCANS + "/workflow-scan-setup")
-                .routeParam("relId", releaseId)
-                .body(setupRequest);
+        return FoDScanConfigDastAutomatedHelper.setupScan(unirest, releaseDescriptor, setupRequest, "/workflow-scan-setup").asJsonNode();
     }
 
     private void validate() {
         // check we have a valid workflow file
         if (uploadFileMixin == null || uploadFileMixin.getFile() == null) {
             throw new FcliSimpleException("A valid workflow macro file needs to be provided.");
-        } else {
+        }
+        /*else {
             if (allowedHosts == null || allowedHosts.isEmpty()) {
                 throw new FcliSimpleException("Please specify at least one '--allowed-hosts'.");
             }
@@ -131,7 +159,7 @@ public class FoDDastAutomatedScanSetupWorkflowCommand extends AbstractFoDScanSet
                     throw new FcliSimpleException("The 'allowedHosts' options should not include 'http://' or 'https://'.");
                 }
             });
-        }
+        }*/
     }
 
 }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/FoDDastLegacyScanStartCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/FoDDastLegacyScanStartCommand.java
@@ -150,7 +150,6 @@ public class FoDDastLegacyScanStartCommand extends AbstractFoDScanStartCommand {
                     .scanTool(FcliBuildProperties.INSTANCE.getFcliProjectName())
                     .scanToolVersion(FcliBuildProperties.INSTANCE.getFcliVersion()).build();
 
-            //System.out.println(startScanRequest);
             return FoDScanDastLegacyHelper.startScan(unirest, releaseDescriptor, startScanRequest);
         }
     }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/helper/FileUploadResult.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/helper/FileUploadResult.java
@@ -12,11 +12,11 @@
  */
 package com.fortify.cli.fod.dast_scan.helper;
 
-import lombok.Getter;
+import lombok.Data;
 
 import java.util.ArrayList;
 
-@Getter
+@Data
 public class FileUploadResult {
     private final int fileId;
     private final ArrayList<String> hosts;

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/helper/FileUploadResult.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/helper/FileUploadResult.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2023 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.fod.dast_scan.helper;
+
+import lombok.Getter;
+
+import java.util.ArrayList;
+
+@Getter
+public class FileUploadResult {
+    private final int fileId;
+    private final ArrayList<String> hosts;
+
+    public FileUploadResult(int fileId, ArrayList<String> hosts) {
+        this.fileId = fileId;
+        this.hosts = hosts;
+    }
+
+}

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/helper/FoDScanConfigDastAutomatedHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/helper/FoDScanConfigDastAutomatedHelper.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright 2021, 2023 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ *******************************************************************************/
+
+package com.fortify.cli.fod.dast_scan.helper;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fortify.cli.common.json.JsonHelper;
+import com.fortify.cli.fod._common.rest.FoDUrls;
+import com.fortify.cli.fod._common.scan.helper.dast.*;
+import com.fortify.cli.fod._common.util.FoDEnums;
+import com.fortify.cli.fod.release.helper.FoDReleaseDescriptor;
+
+import kong.unirest.UnirestInstance;
+import lombok.SneakyThrows;
+import org.springframework.beans.BeanUtils;
+
+import java.util.ArrayList;
+
+public class FoDScanConfigDastAutomatedHelper {
+    public static FoDScanConfigDastAutomatedDescriptor getSetupDescriptor(UnirestInstance unirest, String releaseId) {
+        var body = unirest.get(com.fortify.cli.fod._common.rest.FoDUrls.DAST_AUTOMATED_SCANS + "/scan-setup")
+                .routeParam("relId", releaseId)
+                .asObject(ObjectNode.class)
+                .getBody();
+        return JsonHelper.treeToValue(body, FoDScanConfigDastAutomatedDescriptor.class);
+    }
+
+    public static <T> FoDScanConfigDastAutomatedDescriptor setupScan(UnirestInstance unirest,
+                                                                     FoDReleaseDescriptor releaseDescriptor,
+                                                                     T setupDastAutomatedScanRequest, String ep) {
+        var releaseId = releaseDescriptor.getReleaseId();
+        unirest.put(FoDUrls.DAST_AUTOMATED_SCANS + ep)
+                .routeParam("relId", releaseId)
+                .body(setupDastAutomatedScanRequest)
+                .asString().getBody();
+        return getSetupDescriptor(unirest, releaseId);
+    }
+
+    @SneakyThrows
+    public static JsonNode setupPostmanScan(UnirestInstance unirest, FoDReleaseDescriptor releaseDescriptor,
+                                            FoDScanDastAutomatedSetupBaseRequest base,
+                                            ArrayList<Integer> collectionFileIds) {
+        FoDScanDastAutomatedSetupPostmanRequest setupRequest = FoDScanDastAutomatedSetupPostmanRequest.builder()
+                .collectionFileIds(collectionFileIds)
+                .build();
+        BeanUtils.copyProperties(base, setupRequest);
+        return FoDScanConfigDastAutomatedHelper.setupScan(unirest, releaseDescriptor, setupRequest,
+                "/postman-scan-setup").asJsonNode();
+    }
+
+    @SneakyThrows
+    public static JsonNode setupOpenApiScan(UnirestInstance unirest, FoDReleaseDescriptor releaseDescriptor,
+                                            FoDScanDastAutomatedSetupBaseRequest base, FileUploadResult fileUploadResult,
+                                            String apiUrl, String apiKey) {
+        boolean isUrl = (apiUrl != null && !apiUrl.isEmpty());
+        int fileIdToUse = (fileUploadResult != null ? fileUploadResult.getFileId() : 0);
+        FoDScanDastAutomatedSetupOpenApiRequest setupRequest = FoDScanDastAutomatedSetupOpenApiRequest.builder()
+                .sourceType(isUrl ? "Url" : "FileId")
+                .sourceUrn(isUrl ? apiUrl : String.valueOf(fileIdToUse))
+                .apiKey(apiKey)
+                .build();
+        BeanUtils.copyProperties(base, setupRequest);
+        return FoDScanConfigDastAutomatedHelper.setupScan(unirest, releaseDescriptor, setupRequest,
+                "/openapi-scan-setup").asJsonNode();
+    }
+
+    @SneakyThrows
+    public static JsonNode setupGraphQlScan(UnirestInstance unirest, FoDReleaseDescriptor releaseDescriptor,
+                                            FoDScanDastAutomatedSetupBaseRequest base, FileUploadResult fileUploadResult,
+                                            String apiUrl, FoDEnums.ApiSchemeType schemeType, String host,
+                                            String servicePath) {
+        boolean isUrl = (apiUrl != null && !apiUrl.isEmpty());
+        int fileIdToUse = (fileUploadResult != null ? fileUploadResult.getFileId() : 0);
+        FoDScanDastAutomatedSetupGraphQlRequest setupRequest = FoDScanDastAutomatedSetupGraphQlRequest.builder()
+                .sourceType(isUrl ? "Url" : "FileId")
+                .sourceUrn(isUrl ? apiUrl : String.valueOf(fileIdToUse))
+                .schemeType(schemeType)
+                .host(host)
+                .servicePath(servicePath)
+                .build();
+        BeanUtils.copyProperties(base, setupRequest);
+        return FoDScanConfigDastAutomatedHelper.setupScan(unirest, releaseDescriptor, setupRequest,
+                "/graphql-scan-setup").asJsonNode();
+    }
+
+    @SneakyThrows
+    public static JsonNode setupGrpcScan(UnirestInstance unirest, FoDReleaseDescriptor releaseDescriptor,
+                                         FoDScanDastAutomatedSetupBaseRequest base, FileUploadResult fileUploadResult,
+                                         FoDEnums.ApiSchemeType schemeType, String host, String servicePath) {
+        int fileIdToUse = (fileUploadResult != null ? fileUploadResult.getFileId() : 0);
+        FoDScanDastAutomatedSetupGrpcRequest setupRequest = FoDScanDastAutomatedSetupGrpcRequest.builder()
+                .fileId(fileIdToUse)
+                .schemeType(schemeType)
+                .host(host)
+                .servicePath(servicePath)
+                .build();
+        BeanUtils.copyProperties(base, setupRequest);
+        return FoDScanConfigDastAutomatedHelper.setupScan(unirest, releaseDescriptor, setupRequest,
+                "/grpc-scan-setup").asJsonNode();
+    }
+}

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/helper/FoDScanConfigDastAutomatedHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/helper/FoDScanConfigDastAutomatedHelper.java
@@ -13,7 +13,6 @@
 
 package com.fortify.cli.fod.dast_scan.helper;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fortify.cli.common.json.JsonHelper;
 import com.fortify.cli.fod._common.rest.FoDUrls;
@@ -48,7 +47,7 @@ public class FoDScanConfigDastAutomatedHelper {
     }
 
     @SneakyThrows
-    public static JsonNode setupPostmanScan(UnirestInstance unirest, FoDReleaseDescriptor releaseDescriptor,
+    public static <T> FoDScanConfigDastAutomatedDescriptor setupPostmanScan(UnirestInstance unirest, FoDReleaseDescriptor releaseDescriptor,
                                             FoDScanDastAutomatedSetupBaseRequest base,
                                             ArrayList<Integer> collectionFileIds) {
         FoDScanDastAutomatedSetupPostmanRequest setupRequest = FoDScanDastAutomatedSetupPostmanRequest.builder()
@@ -56,11 +55,11 @@ public class FoDScanConfigDastAutomatedHelper {
                 .build();
         BeanUtils.copyProperties(base, setupRequest);
         return FoDScanConfigDastAutomatedHelper.setupScan(unirest, releaseDescriptor, setupRequest,
-                "/postman-scan-setup").asJsonNode();
+                "/postman-scan-setup");
     }
 
     @SneakyThrows
-    public static JsonNode setupOpenApiScan(UnirestInstance unirest, FoDReleaseDescriptor releaseDescriptor,
+    public static <T> FoDScanConfigDastAutomatedDescriptor setupOpenApiScan(UnirestInstance unirest, FoDReleaseDescriptor releaseDescriptor,
                                             FoDScanDastAutomatedSetupBaseRequest base, FileUploadResult fileUploadResult,
                                             String apiUrl, String apiKey) {
         boolean isUrl = (apiUrl != null && !apiUrl.isEmpty());
@@ -72,11 +71,11 @@ public class FoDScanConfigDastAutomatedHelper {
                 .build();
         BeanUtils.copyProperties(base, setupRequest);
         return FoDScanConfigDastAutomatedHelper.setupScan(unirest, releaseDescriptor, setupRequest,
-                "/openapi-scan-setup").asJsonNode();
+                "/openapi-scan-setup");
     }
 
     @SneakyThrows
-    public static JsonNode setupGraphQlScan(UnirestInstance unirest, FoDReleaseDescriptor releaseDescriptor,
+    public static <T> FoDScanConfigDastAutomatedDescriptor setupGraphQlScan(UnirestInstance unirest, FoDReleaseDescriptor releaseDescriptor,
                                             FoDScanDastAutomatedSetupBaseRequest base, FileUploadResult fileUploadResult,
                                             String apiUrl, FoDEnums.ApiSchemeType schemeType, String host,
                                             String servicePath) {
@@ -91,11 +90,11 @@ public class FoDScanConfigDastAutomatedHelper {
                 .build();
         BeanUtils.copyProperties(base, setupRequest);
         return FoDScanConfigDastAutomatedHelper.setupScan(unirest, releaseDescriptor, setupRequest,
-                "/graphql-scan-setup").asJsonNode();
+                "/graphql-scan-setup");
     }
 
     @SneakyThrows
-    public static JsonNode setupGrpcScan(UnirestInstance unirest, FoDReleaseDescriptor releaseDescriptor,
+    public static <T> FoDScanConfigDastAutomatedDescriptor setupGrpcScan(UnirestInstance unirest, FoDReleaseDescriptor releaseDescriptor,
                                          FoDScanDastAutomatedSetupBaseRequest base, FileUploadResult fileUploadResult,
                                          FoDEnums.ApiSchemeType schemeType, String host, String servicePath) {
         int fileIdToUse = (fileUploadResult != null ? fileUploadResult.getFileId() : 0);
@@ -107,6 +106,6 @@ public class FoDScanConfigDastAutomatedHelper {
                 .build();
         BeanUtils.copyProperties(base, setupRequest);
         return FoDScanConfigDastAutomatedHelper.setupScan(unirest, releaseDescriptor, setupRequest,
-                "/grpc-scan-setup").asJsonNode();
+                "/grpc-scan-setup");
     }
 }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/mast_scan/cli/cmd/FoDMastScanSetupCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/mast_scan/cli/cmd/FoDMastScanSetupCommand.java
@@ -16,6 +16,7 @@ package com.fortify.cli.fod.mast_scan.cli.cmd;
 import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 
+import com.fortify.cli.fod._common.scan.cli.cmd.AbstractFoDScanSetupCommand;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -29,14 +30,10 @@ import com.fortify.cli.common.output.transform.IRecordTransformer;
 import com.fortify.cli.common.progress.cli.mixin.ProgressWriterFactoryMixin;
 import com.fortify.cli.common.util.DisableTest;
 import com.fortify.cli.common.util.DisableTest.TestType;
-import com.fortify.cli.fod._common.cli.mixin.FoDDelimiterMixin;
-import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDJsonNodeOutputCommand;
-import com.fortify.cli.fod._common.scan.cli.mixin.FoDEntitlementFrequencyTypeMixins;
 import com.fortify.cli.fod._common.scan.helper.FoDScanType;
 import com.fortify.cli.fod.mast_scan.helper.FoDScanConfigMobileDescriptor;
 import com.fortify.cli.fod.mast_scan.helper.FoDScanConfigMobileHelper;
 import com.fortify.cli.fod.mast_scan.helper.FoDScanConfigMobileSetupRequest;
-import com.fortify.cli.fod.release.cli.mixin.FoDReleaseByQualifiedNameOrIdResolverMixin;
 import com.fortify.cli.fod.release.helper.FoDReleaseAssessmentTypeDescriptor;
 import com.fortify.cli.fod.release.helper.FoDReleaseAssessmentTypeHelper;
 import com.fortify.cli.fod.release.helper.FoDReleaseDescriptor;
@@ -49,21 +46,11 @@ import picocli.CommandLine.Option;
 
 @Command(name = OutputHelperMixins.Setup.CMD_NAME, hidden = false) @CommandGroup("*-scan-setup")
 @DisableTest(TestType.CMD_DEFAULT_TABLE_OPTIONS_PRESENT)
-public class FoDMastScanSetupCommand extends AbstractFoDJsonNodeOutputCommand implements IRecordTransformer, IActionCommandResultSupplier {
-    private static final Log LOG = LogFactory.getLog(FoDMastScanStartCommand.class);
+public class FoDMastScanSetupCommand extends AbstractFoDScanSetupCommand<FoDScanConfigMobileDescriptor> implements IRecordTransformer, IActionCommandResultSupplier {
+    private static final Log LOG = LogFactory.getLog(FoDMastScanSetupCommand.class);
     DateTimeFormatter dtf = DateTimeFormatter.ofPattern("MM/dd/yyyy HH:mm");
     @Getter @Mixin private OutputHelperMixins.Start outputHelper;
 
-    @Mixin
-    private FoDDelimiterMixin delimiterMixin; // Is automatically injected in resolver mixins
-    @Mixin
-    private FoDReleaseByQualifiedNameOrIdResolverMixin.RequiredOption releaseResolver;
-
-    @Option(names = {"--assessment-type"}, required = true)
-    private String mobileAssessmentType; // Plain text name as custom assessment types can be created
-    @Option(names = {"--entitlement-id"})
-    private Integer entitlementId;
-    @Mixin private FoDEntitlementFrequencyTypeMixins.RequiredOption entitlementFrequencyTypeMixin;
     private enum MobileFrameworks { iOS, Android }
     @Option(names = {"--framework"}, required = true, defaultValue = "Android")
     private MobileFrameworks mobileFramework;
@@ -75,59 +62,68 @@ public class FoDMastScanSetupCommand extends AbstractFoDJsonNodeOutputCommand im
     private enum MobilePlatforms { Phone, Tablet, Both }
     @Option(names = {"--platform"}, defaultValue = "Phone")
     private MobilePlatforms mobilePlatform;
-    @Option(names={"--skip-if-exists"})
-    private Boolean skipIfExists = false;
- 
+
     @Mixin private ProgressWriterFactoryMixin progressWriterFactory;
 
-    private String assessmentTypeName;
+    @Override
+    protected boolean isExistingSetup(FoDScanConfigMobileDescriptor setupDescriptor) {
+        return (setupDescriptor != null && setupDescriptor.getAssessmentTypeId() != 0);
+    }
+
+    @Override
+    protected ObjectNode convertToObjectNode(FoDScanConfigMobileDescriptor setupDescriptor) {
+        return setupDescriptor.asObjectNode();
+    }
+
+    @Override
+    protected JsonNode setup(UnirestInstance unirest, FoDReleaseDescriptor releaseDescriptor,
+                             FoDScanConfigMobileDescriptor currentSetup) {
+        var releaseId = releaseDescriptor.getReleaseId();
+
+        LOG.info("Finding appropriate entitlement to use.");
+
+        var atd = FoDReleaseAssessmentTypeHelper.getAssessmentTypeDescriptor(unirest, releaseId, FoDScanType.Mobile,
+                entitlementFrequencyTypeMixin.getEntitlementFrequencyType(), assessmentType);
+        Integer assessmentTypeId = atd.getAssessmentTypeId();
+        Integer entitlementIdToUse = atd.getEntitlementId();
+        assessmentTypeName = atd.getName();
+
+        validateEntitlement(currentSetup, entitlementIdToUse, releaseId, atd);
+        LOG.info("Configuring release to use entitlement " + entitlementIdToUse);
+
+        // Note: for some reason the API uses "None" for Automated audit but shows "Automated" in the UI!
+        var auditPreference = auditPreferenceType.name();
+        if (auditPreferenceType.name().equals("Automated")) {
+            auditPreference = "None";
+        }
+
+        FoDScanConfigMobileSetupRequest setupMastScanRequest = FoDScanConfigMobileSetupRequest.builder()
+                .assessmentTypeId(assessmentTypeId)
+                // Note: entitlementFrequencyType is not actually used by the API, but we include it for completeness
+                .entitlementFrequencyType(entitlementFrequencyTypeMixin.getEntitlementFrequencyType().name())
+                .frameworkType(mobileFramework.name())
+                .platformType(mobilePlatform.name())
+                .auditPreferenceType(auditPreference)
+                .timeZone(timezone).build();
+
+        return FoDScanConfigMobileHelper.setupScan(unirest, releaseDescriptor, setupMastScanRequest).asJsonNode();
+    }
 
     @Override
     public JsonNode getJsonNode(UnirestInstance unirest) {
         try (var progressWriter = progressWriterFactory.create()) {
             var releaseDescriptor = releaseResolver.getReleaseDescriptor(unirest);
             var setupDescriptor = FoDScanConfigMobileHelper.getSetupDescriptor(unirest, releaseDescriptor.getReleaseId());
-            if ( skipIfExists && setupDescriptor.getAssessmentTypeId()!=0 ) {
-                return setupDescriptor.asObjectNode().put("__action__", "SKIPPED_EXISTING");
+            var skippedNode = handleSkipIfExists(skipIfExists, setupDescriptor);
+            if (skippedNode != null) {
+                return skippedNode;
             } else {
-                return setup(unirest, releaseDescriptor, setupDescriptor).asObjectNode();
+                return setup(unirest, releaseDescriptor, setupDescriptor);
             }
         }
     }
 
-    private FoDScanConfigMobileDescriptor setup(UnirestInstance unirest, FoDReleaseDescriptor releaseDescriptor, FoDScanConfigMobileDescriptor currentSetup) {
-        var relId = releaseDescriptor.getReleaseId();
-
-        LOG.info("Finding appropriate entitlement to use.");
-
-        var atd = FoDReleaseAssessmentTypeHelper.getAssessmentTypeDescriptor(unirest, relId, FoDScanType.Mobile, 
-            entitlementFrequencyTypeMixin.getEntitlementFrequencyType(), mobileAssessmentType);
-        Integer assessmentTypeId = atd.getAssessmentTypeId();
-        Integer entitlementIdToUse = atd.getEntitlementId();
-        assessmentTypeName = atd.getName();
-
-        // Note: the API does not currently allow entitlement id to be configured via "scan-setup" only via "scan-start"
-        // we will leave this here for when it does and update setupMastScanRequest below
-        validateEntitlement(currentSetup, entitlementIdToUse, relId, atd);
-        LOG.info("Release will be using entitlement " + entitlementIdToUse);
-
-        // Note: for some reason the API uses "None" for Automated audit but shows "Automated" in the UI!
-        var auditPreference = auditPreferenceType.name();
-        if (auditPreferenceType != null && auditPreferenceType.name().equals("Automated")) {
-            auditPreference = "None";
-        }
-
-        FoDScanConfigMobileSetupRequest setupMastScanRequest = FoDScanConfigMobileSetupRequest.builder()
-                .assessmentTypeId(assessmentTypeId)
-                .frameworkType(mobileFramework.name())
-                .platformType(mobilePlatform.name())
-                .auditPreferenceType(auditPreference)
-                .timeZone(timezone).build();
-
-        return FoDScanConfigMobileHelper.setupScan(unirest, releaseDescriptor, setupMastScanRequest);
-    }
-
-    private void validateEntitlement(FoDScanConfigMobileDescriptor currentSetup, Integer entitlementIdToUse, String relId, FoDReleaseAssessmentTypeDescriptor atd) {
+    private void validateEntitlement(FoDScanConfigMobileDescriptor currentSetup, Integer entitlementIdToUse, String releaseId, FoDReleaseAssessmentTypeDescriptor atd) {
         // validate entitlement specified or currently in use against assessment type found
         if (entitlementId != null && entitlementId > 0) {
             // check if "entitlement id" explicitly matches what has been found
@@ -143,7 +139,7 @@ public class FoDMastScanSetupCommand extends AbstractFoDJsonNodeOutputCommand im
             }
         }
         // check if the entitlement can still be used
-        if (FoDReleaseAssessmentTypeHelper.validateEntitlementCanBeUsed(relId, atd)) {
+        if (FoDReleaseAssessmentTypeHelper.validateEntitlementCanBeUsed(releaseId, atd)) {
             LOG.info("The entitlement '" + entitlementIdToUse + "' is still valid.");
         } else {
             LOG.info("The entitlement '" + entitlementIdToUse + "' is no longer valid.");
@@ -159,16 +155,6 @@ public class FoDMastScanSetupCommand extends AbstractFoDJsonNodeOutputCommand im
             .put("applicationName", releaseDescriptor.getApplicationName())
             .put("releaseName", releaseDescriptor.getReleaseName())
             .put("microserviceName", releaseDescriptor.getMicroserviceName());
-    }
-
-    @Override
-    public String getActionCommandResult() {
-        return "SETUP";
-    }
-
-    @Override
-    public boolean isSingular() {
-        return true;
     }
  
 }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/mast_scan/helper/FoDScanConfigMobileSetupRequest.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/mast_scan/helper/FoDScanConfigMobileSetupRequest.java
@@ -25,6 +25,7 @@ import lombok.NoArgsConstructor;
 public class FoDScanConfigMobileSetupRequest {
     private Integer assessmentTypeId;
     private String auditPreferenceType;
+    private String entitlementFrequencyType;
     private String frameworkType;
     private String platformType;
     private String timeZone;

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/cli/cmd/FoDSastScanSetupCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/cli/cmd/FoDSastScanSetupCommand.java
@@ -15,6 +15,7 @@ package com.fortify.cli.fod.sast_scan.cli.cmd;
 
 import java.util.Objects;
 
+import com.fortify.cli.fod._common.scan.cli.cmd.AbstractFoDScanSetupCommand;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -25,18 +26,13 @@ import com.fortify.cli.common.cli.util.CommandGroup;
 import com.fortify.cli.common.exception.FcliSimpleException;
 import com.fortify.cli.common.exception.FcliTechnicalException;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
-import com.fortify.cli.common.output.transform.IActionCommandResultSupplier;
 import com.fortify.cli.common.output.transform.IRecordTransformer;
 import com.fortify.cli.common.progress.cli.mixin.ProgressWriterFactoryMixin;
 import com.fortify.cli.common.util.DisableTest;
 import com.fortify.cli.common.util.DisableTest.TestType;
-import com.fortify.cli.fod._common.cli.mixin.FoDDelimiterMixin;
-import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDJsonNodeOutputCommand;
-import com.fortify.cli.fod._common.scan.cli.mixin.FoDEntitlementFrequencyTypeMixins;
 import com.fortify.cli.fod._common.scan.helper.FoDScanType;
 import com.fortify.cli.fod._common.scan.helper.sast.FoDScanSastHelper;
 import com.fortify.cli.fod._common.util.FoDEnums;
-import com.fortify.cli.fod.release.cli.mixin.FoDReleaseByQualifiedNameOrIdResolverMixin;
 import com.fortify.cli.fod.release.helper.FoDReleaseAssessmentTypeDescriptor;
 import com.fortify.cli.fod.release.helper.FoDReleaseAssessmentTypeHelper;
 import com.fortify.cli.fod.release.helper.FoDReleaseDescriptor;
@@ -55,18 +51,10 @@ import picocli.CommandLine.Option;
 
 @Command(name = OutputHelperMixins.Setup.CMD_NAME, hidden = false) @CommandGroup("*-scan-setup")
 @DisableTest(TestType.CMD_DEFAULT_TABLE_OPTIONS_PRESENT)
-public class FoDSastScanSetupCommand extends AbstractFoDJsonNodeOutputCommand implements IRecordTransformer, IActionCommandResultSupplier {
+public class FoDSastScanSetupCommand extends AbstractFoDScanSetupCommand<FoDScanConfigSastDescriptor> implements IRecordTransformer {
     private static final Log LOG = LogFactory.getLog(FoDSastScanSetupCommand.class);
     @Getter @Mixin private OutputHelperMixins.Setup outputHelper;
 
-    @Mixin private FoDDelimiterMixin delimiterMixin; // Is automatically injected in resolver mixins
-    @Mixin private FoDReleaseByQualifiedNameOrIdResolverMixin.RequiredOption releaseResolver;
-
-    @Option(names = {"--assessment-type"}, required = true)
-    private String staticAssessmentType; // Plain text name as custom assessment types can be created
-    @Mixin  private FoDEntitlementFrequencyTypeMixins.RequiredOption entitlementFrequencyTypeMixin;
-    @Option(names = {"--entitlement-id"})
-    private Integer entitlementId;
     @Option(names = {"--technology-stack"}, required = true, defaultValue = "Auto Detect")
     private String technologyStack;
     @Option(names = {"--language-level"})
@@ -79,8 +67,6 @@ public class FoDSastScanSetupCommand extends AbstractFoDJsonNodeOutputCommand im
     private final Boolean includeThirdPartyLibraries = false;
     @Option(names = {"--use-source-control"})
     private final Boolean useSourceControl = false;
-    @Option(names={"--skip-if-exists"})
-    private Boolean skipIfExists = false;
     @Option(names={"--use-aviator"})
     private Boolean useAviator = false;
 
@@ -91,28 +77,24 @@ public class FoDSastScanSetupCommand extends AbstractFoDJsonNodeOutputCommand im
     //      using this of course.
     @Mixin private ProgressWriterFactoryMixin progressWriterFactory;
 
-    private String assessmentTypeName;
-
     @Override
-    public JsonNode getJsonNode(UnirestInstance unirest) {
-        try (var progressWriter = progressWriterFactory.create()) {
-            var releaseDescriptor = releaseResolver.getReleaseDescriptor(unirest);
-            var setupDescriptor = FoDScanSastHelper.getSetupDescriptor(unirest, releaseDescriptor.getReleaseId());
-            if ( skipIfExists && setupDescriptor.getAssessmentTypeId()!=0 ) {
-                return setupDescriptor.asObjectNode().put("__action__", "SKIPPED_EXISTING");
-            } else {
-                return setup(unirest, releaseDescriptor, setupDescriptor).asObjectNode();
-            }
-        }
+    protected boolean isExistingSetup(FoDScanConfigSastDescriptor setupDescriptor) {
+        return (setupDescriptor != null && setupDescriptor.getAssessmentTypeId() != 0);
     }
 
-    private FoDScanConfigSastDescriptor setup(UnirestInstance unirest, FoDReleaseDescriptor releaseDescriptor, FoDScanConfigSastDescriptor currentSetup) {
+    @Override
+    protected ObjectNode convertToObjectNode(FoDScanConfigSastDescriptor setupDescriptor) {
+        return setupDescriptor.asObjectNode();
+    }
+
+    @Override
+    protected JsonNode setup(UnirestInstance unirest, FoDReleaseDescriptor releaseDescriptor, FoDScanConfigSastDescriptor currentSetup) {
         var relId = releaseDescriptor.getReleaseId();
 
         LOG.info("Finding appropriate entitlement to use.");
 
-        var atd = FoDReleaseAssessmentTypeHelper.getAssessmentTypeDescriptor(unirest, relId, FoDScanType.Static, 
-        entitlementFrequencyTypeMixin.getEntitlementFrequencyType(), staticAssessmentType);
+        var atd = FoDReleaseAssessmentTypeHelper.getAssessmentTypeDescriptor(unirest, relId, FoDScanType.Static,
+                entitlementFrequencyTypeMixin.getEntitlementFrequencyType(), assessmentType);
         var assessmentTypeId = atd.getAssessmentTypeId();
         var entitlementIdToUse = atd.getEntitlementId();
         assessmentTypeName = atd.getName();
@@ -135,7 +117,21 @@ public class FoDSastScanSetupCommand extends AbstractFoDJsonNodeOutputCommand im
                 .useSourceControl(useSourceControl)
                 .includeFortifyAviator(useAviator).build();
 
-        return FoDScanConfigSastHelper.setupScan(unirest, releaseDescriptor, setupSastScanRequest);
+        return FoDScanConfigSastHelper.setupScan(unirest, releaseDescriptor, setupSastScanRequest).asJsonNode();
+    }
+
+    @Override
+    public JsonNode getJsonNode(UnirestInstance unirest) {
+        try (var progressWriter = progressWriterFactory.create()) {
+            var releaseDescriptor = releaseResolver.getReleaseDescriptor(unirest);
+            var setupDescriptor = FoDScanSastHelper.getSetupDescriptor(unirest, releaseDescriptor.getReleaseId());
+            var skippedNode = handleSkipIfExists(skipIfExists, setupDescriptor);
+            if (skippedNode != null) {
+                return skippedNode;
+            } else {
+                return setup(unirest, releaseDescriptor, setupDescriptor);
+            }
+        }
     }
 
     private Integer getLanguageLevelId(UnirestInstance unirest, Integer technologyStackId) {
@@ -200,13 +196,4 @@ public class FoDSastScanSetupCommand extends AbstractFoDJsonNodeOutputCommand im
                         .put("microserviceName", releaseDescriptor.getMicroserviceName());
     }
 
-    @Override
-    public String getActionCommandResult() {
-        return "SETUP";
-    }
-
-    @Override
-    public boolean isSingular() {
-        return true;
-    }
 }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/cli/cmd/FoDSastScanSetupCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/cli/cmd/FoDSastScanSetupCommand.java
@@ -78,6 +78,21 @@ public class FoDSastScanSetupCommand extends AbstractFoDScanSetupCommand<FoDScan
     @Mixin private ProgressWriterFactoryMixin progressWriterFactory;
 
     @Override
+    protected String getScanType() {
+        return "Static Assessment";
+    }
+
+    @Override
+    protected String getSetupType() {
+        return auditPreferenceType.name();
+    }
+
+    @Override
+    protected FoDScanConfigSastDescriptor getSetupDescriptor(UnirestInstance unirest, String releaseId) {
+        return FoDScanSastHelper.getSetupDescriptor(unirest, releaseId);
+    }
+
+    @Override
     protected boolean isExistingSetup(FoDScanConfigSastDescriptor setupDescriptor) {
         return (setupDescriptor != null && setupDescriptor.getAssessmentTypeId() != 0);
     }
@@ -118,20 +133,6 @@ public class FoDSastScanSetupCommand extends AbstractFoDScanSetupCommand<FoDScan
                 .includeFortifyAviator(useAviator).build();
 
         return FoDScanConfigSastHelper.setupScan(unirest, releaseDescriptor, setupSastScanRequest).asJsonNode();
-    }
-
-    @Override
-    public JsonNode getJsonNode(UnirestInstance unirest) {
-        try (var progressWriter = progressWriterFactory.create()) {
-            var releaseDescriptor = releaseResolver.getReleaseDescriptor(unirest);
-            var setupDescriptor = FoDScanSastHelper.getSetupDescriptor(unirest, releaseDescriptor.getReleaseId());
-            var skippedNode = handleSkipIfExists(skipIfExists, setupDescriptor);
-            if (skippedNode != null) {
-                return skippedNode;
-            } else {
-                return setup(unirest, releaseDescriptor, setupDescriptor);
-            }
-        }
     }
 
     private Integer getLanguageLevelId(UnirestInstance unirest, Integer technologyStackId) {
@@ -188,8 +189,8 @@ public class FoDSastScanSetupCommand extends AbstractFoDScanSetupCommand<FoDScan
         FoDReleaseDescriptor releaseDescriptor = releaseResolver.getReleaseDescriptor(getUnirestInstance());
         return ((ObjectNode)record)
         // Start partial fix for (#598)
-                        .put("scanType", assessmentTypeName)
-                        .put("setupType", auditPreferenceType.name())
+                        .put("scanType", getScanType())
+                        .put("setupType", getSetupType())
         // End               
                         .put("applicationName", releaseDescriptor.getApplicationName())
                         .put("releaseName", releaseDescriptor.getReleaseName())

--- a/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
+++ b/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
@@ -462,6 +462,8 @@ fcli.fod.scan.output.table.header.scanMethodTypeName = Scan Method
 fcli.fod.scan.output.table.header.applicationName = Application
 fcli.fod.scan.output.table.header.microserviceName = Microservice
 fcli.fod.scan.output.table.header.releaseName = Release
+fcli.fod.scan.output.table.header.QueuePositionWithinApplication = Queue Position
+
 fcli.fod.scan.cancel.usage.header = Cancel a scan.
 fcli.fod.scan.get.usage.header = Get scan details.
 fcli.fod.scan.list.usage.header = List scans.
@@ -496,6 +498,7 @@ fcli.fod.sast-scan.output.table.header.scanMethodTypeName = Scan Method
 fcli.fod.sast-scan.output.table.header.applicationName = Application
 fcli.fod.sast-scan.output.table.header.microserviceName = Microservice
 fcli.fod.sast-scan.output.table.header.releaseName = Release
+fcli.fod.sast-scan.output.table.header.QueuePositionWithinApplication = Queue Position
 fcli.fod.sast-scan.cancel.usage.header = Cancel a SAST scan.
 fcli.fod.sast-scan.get.usage.header = Get SAST scan details.
 fcli.fod.sast-scan.get-config.usage.header = (PREVIEW) Get current SAST scan configuration.
@@ -685,6 +688,8 @@ fcli.fod.dast-scan.setup-website.macro-primary-password = Login macro password f
 fcli.fod.dast-scan.setup-website.macro-secondary-username = Login macro username for the secondary user.
 fcli.fod.dast-scan.setup-website.macro-secondary-password = Login macro password for the secondary user.
 fcli.fod.dast-scan.setup-website.vpn = Fortify Connect network name to use for site-to-site VPN. If specified, environment will be set to Internal.
+fcli.fod.dast-scan.setup-website.skip-if-exists = Skip setup if a scan has already been set up. If not specified, any existing scan \
+  setup will be replaced based on the given setup options.
 
 fcli.fod.dast-scan.setup-workflow.file = A Workflow file to upload and use for authentication in the website scan.
 fcli.fod.dast-scan.setup-workflow.allowed-hosts = The FQDN and port of any hosts that that you want to be scanned, e.g. "test.mysite.com:443".
@@ -702,6 +707,8 @@ fcli.fod.dast-scan.setup-workflow.network-username = ${fcli.fod.dast-scan.setup-
 fcli.fod.dast-scan.setup-workflow.network-password = ${fcli.fod.dast-scan.setup-website.network-password}
 fcli.fod.dast-scan.setup-workflow.false-positive-removal = ${fcli.fod.dast-scan.setup-website.false-positive-removal}
 fcli.fod.dast-scan.setup-workflow.vpn = Fortify Connect network name to use for site-to-site VPN. If specified, environment will be set to Internal.
+fcli.fod.dast-scan.setup-workflow.skip-if-exists = Skip setup if a scan has already been set up. If not specified, any existing scan \
+  setup will be replaced based on the given setup options.
 
 fcli.fod.dast-scan.setup-api.type = The type of API to scan. Valid Values: ${COMPLETION-CANDIDATES}
 fcli.fod.dast-scan.setup-api.file = An OpenAPI specification, Postman collection, GraphQL schema file or GRPC proto file.
@@ -725,6 +732,8 @@ fcli.fod.dast-scan.setup-api.network-username = ${fcli.fod.dast-scan.setup-websi
 fcli.fod.dast-scan.setup-api.network-password = ${fcli.fod.dast-scan.setup-website.network-password}
 fcli.fod.dast-scan.setup-api.false-positive-removal = ${fcli.fod.dast-scan.setup-website.false-positive-removal}
 fcli.fod.dast-scan.setup-api.vpn = Fortify Connect network name to use for site-to-site VPN. If specified, environment will be set to Internal.
+fcli.fod.dast-scan.setup-api.skip-if-exists = Skip setup if a scan has already been set up. If not specified, any existing scan \
+  setup will be replaced based on the given setup options.
 
 # fcli fod mast-scan
 fcli.fod.mast-scan.usage.header = Manage FoD MAST scans.
@@ -971,7 +980,7 @@ fcli.fod.*-scan-config.output.table.args = applicationName,microserviceName,rele
 fcli.fod.*-scan-setup.output.table.args = scanType,setupType,fileId,filename,applicationName,microserviceName,releaseName,entitlementId
 fcli.fod.*-scan-start.output.table.args = scanId,scanType,analysisStatusType,applicationName,microserviceName,releaseName
 fcli.fod.*-scan-upload-file.output.table.args = fileId,fileType,filename,applicationName,microserviceName,releaseName
-fcli.fod.*-scan-wait-for.output.table.args = scanId,analysisStatusType,scanType
+fcli.fod.*-scan-wait-for.output.table.args = scanId,analysisStatusType,scanType,QueuePositionWithinApplication
 fcli.fod.session.output.table.args = name,type,url,created,expires,expired
 fcli.fod.rest.lookup.output.table.args = group,text,value
 fcli.fod.report.output.table.args = reportId,reportName,reportStatusType,reportType


### PR DESCRIPTION
fix: Implement FoD `--skip-if-exists` option for all scan types (#593)

chore: Enabled non-working setup commands for FoD DAST automated

fix: Added scan queue position for FoD `wait-for` commands