### PR TITLE
Attribute options for microservices

### DIFF
--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/app/attr/helper/FoDAttributeHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/app/attr/helper/FoDAttributeHelper.java
@@ -105,6 +105,15 @@ public class FoDAttributeHelper {
             FoDAttributeDescriptor attributeDescriptor = FoDAttributeHelper.getAttributeDescriptor(unirest, attr.getKey(), true);
             updatesWithId.put(Integer.valueOf(attributeDescriptor.getId()), attr.getValue());
         }
+        if (current == null || current.isEmpty()) {
+            for (Map.Entry<Integer, String> entry : updatesWithId.entrySet()) {
+                ObjectNode attrObj = objectMapper.createObjectNode();
+                attrObj.put("id", entry.getKey());
+                attrObj.put("value", entry.getValue());
+                attrArray.add(attrObj);
+            }
+            return attrArray;
+        };
         for (FoDAttributeDescriptor attr : current) {
             ObjectNode attrObj = objectMapper.createObjectNode();
             attrObj.put("id", attr.getId());

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/app/attr/helper/FoDAttributeHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/app/attr/helper/FoDAttributeHelper.java
@@ -12,12 +12,7 @@
  *******************************************************************************/
 package com.fortify.cli.fod.app.attr.helper;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -96,34 +91,43 @@ public class FoDAttributeHelper {
     }
 
     public static JsonNode mergeAttributesNode(UnirestInstance unirest, FoDEnums.AttributeTypes attrType,
-                                           ArrayList<FoDAttributeDescriptor> current,
-                                           Map<String, String> updates) {
+                                               ArrayList<FoDAttributeDescriptor> current,
+                                               Map<String, String> updates) {
         ArrayNode attrArray = objectMapper.createArrayNode();
         if (updates == null || updates.isEmpty()) return attrArray;
+
+        // Map attribute id to value from updates
         Map<Integer, String> updatesWithId = new HashMap<>();
         for (Map.Entry<String, String> attr : updates.entrySet()) {
-            FoDAttributeDescriptor attributeDescriptor = FoDAttributeHelper.getAttributeDescriptor(unirest, attr.getKey(), true);
-            updatesWithId.put(Integer.valueOf(attributeDescriptor.getId()), attr.getValue());
+            FoDAttributeDescriptor desc = getAttributeDescriptor(unirest, attr.getKey(), true);
+            updatesWithId.put(desc.getId(), attr.getValue());
         }
-        if (current == null || current.isEmpty()) {
-            for (Map.Entry<Integer, String> entry : updatesWithId.entrySet()) {
+
+        // Track which ids have been processed
+        Set<Integer> processedIds = new HashSet<>();
+
+        // Add current attributes, updating values if present in updates
+        if (current != null) {
+            for (FoDAttributeDescriptor attr : current) {
+                int id = attr.getId();
+                ObjectNode attrObj = objectMapper.createObjectNode();
+                attrObj.put("id", id);
+                attrObj.put("value", updatesWithId.getOrDefault(id, attr.getValue()));
+                attrArray.add(attrObj);
+                processedIds.add(id);
+            }
+        }
+
+        // Add new attributes from updates not already in current
+        for (Map.Entry<Integer, String> entry : updatesWithId.entrySet()) {
+            if (!processedIds.contains(entry.getKey())) {
                 ObjectNode attrObj = objectMapper.createObjectNode();
                 attrObj.put("id", entry.getKey());
                 attrObj.put("value", entry.getValue());
                 attrArray.add(attrObj);
             }
-            return attrArray;
-        };
-        for (FoDAttributeDescriptor attr : current) {
-            ObjectNode attrObj = objectMapper.createObjectNode();
-            attrObj.put("id", attr.getId());
-            if (updatesWithId.containsKey(Integer.valueOf(attr.getId()))) {
-                attrObj.put("value", updatesWithId.get(Integer.valueOf(attr.getId())));
-            } else {
-                attrObj.put("value", attr.getValue());
-            }
-            attrArray.add(attrObj);
         }
+
         return attrArray;
     }
 

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/microservice/cli/cmd/FoDMicroserviceCreateCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/microservice/cli/cmd/FoDMicroserviceCreateCommand.java
@@ -18,6 +18,9 @@ import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.output.transform.IActionCommandResultSupplier;
 import com.fortify.cli.fod._common.cli.mixin.FoDDelimiterMixin;
 import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDJsonNodeOutputCommand;
+import com.fortify.cli.fod._common.util.FoDEnums;
+import com.fortify.cli.fod.app.attr.cli.mixin.FoDAttributeUpdateOptions;
+import com.fortify.cli.fod.app.attr.helper.FoDAttributeHelper;
 import com.fortify.cli.fod.app.helper.FoDAppDescriptor;
 import com.fortify.cli.fod.microservice.cli.mixin.FoDMicroserviceByQualifiedNameResolverMixin;
 import com.fortify.cli.fod.microservice.helper.FoDMicroserviceDescriptor;
@@ -40,6 +43,10 @@ public class FoDMicroserviceCreateCommand extends AbstractFoDJsonNodeOutputComma
 
     @Option(names={"--skip-if-exists"})
     private boolean skipIfExists = false;
+    @Option(names={"--auto-required-attrs"}, required = false)
+    private boolean autoRequiredAttrs = false;
+
+    @Mixin private FoDAttributeUpdateOptions.OptionalAttrOption msAttrs;
 
     @Override
     public JsonNode getJsonNode(UnirestInstance unirest) {
@@ -51,6 +58,8 @@ public class FoDMicroserviceCreateCommand extends AbstractFoDJsonNodeOutputComma
         FoDQualifiedMicroserviceNameDescriptor qualifiedMicroserviceNameDescriptor = qualifiedMicroserviceNameResolver.getQualifiedMicroserviceNameDescriptor();
         FoDMicroserviceUpdateRequest msCreateRequest = FoDMicroserviceUpdateRequest.builder()
                 .microserviceName(qualifiedMicroserviceNameDescriptor.getMicroserviceName())
+                .attributes(FoDAttributeHelper.getAttributesNode(unirest, FoDEnums.AttributeTypes.Microservice,
+                                msAttrs.getAttributes(), autoRequiredAttrs))
                 .build();
         return FoDMicroserviceHelper.createMicroservice(unirest, appDescriptor, msCreateRequest).asJsonNode();
     }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/microservice/cli/cmd/FoDMicroserviceListCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/microservice/cli/cmd/FoDMicroserviceListCommand.java
@@ -45,7 +45,7 @@ public class FoDMicroserviceListCommand extends AbstractFoDBaseRequestOutputComm
     public HttpRequest<?> getBaseRequest(UnirestInstance unirest) {
         return unirest.get(FoDUrls.MICROSERVICES)
                 .routeParam("appId", appResolver.getAppId(unirest))
-                .queryString("includeReleases", "false");
+                .queryString("includeReleases", "true");
     }
 
     @Override

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/microservice/cli/cmd/FoDMicroserviceUpdateCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/microservice/cli/cmd/FoDMicroserviceUpdateCommand.java
@@ -14,10 +14,15 @@
 package com.fortify.cli.fod.microservice.cli.cmd;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.output.transform.IActionCommandResultSupplier;
 import com.fortify.cli.fod._common.cli.mixin.FoDDelimiterMixin;
 import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDJsonNodeOutputCommand;
+import com.fortify.cli.fod._common.util.FoDEnums;
+import com.fortify.cli.fod.app.attr.cli.mixin.FoDAttributeUpdateOptions;
+import com.fortify.cli.fod.app.attr.helper.FoDAttributeDescriptor;
+import com.fortify.cli.fod.app.attr.helper.FoDAttributeHelper;
 import com.fortify.cli.fod.microservice.cli.mixin.FoDMicroserviceByQualifiedNameResolverMixin;
 import com.fortify.cli.fod.microservice.helper.FoDMicroserviceDescriptor;
 import com.fortify.cli.fod.microservice.helper.FoDMicroserviceHelper;
@@ -29,21 +34,38 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 
+import java.util.ArrayList;
+import java.util.Map;
+
 @Command(name = OutputHelperMixins.Update.CMD_NAME)
 public class FoDMicroserviceUpdateCommand extends AbstractFoDJsonNodeOutputCommand implements IActionCommandResultSupplier {
     @Getter @Mixin private OutputHelperMixins.Update outputHelper;
-    
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
     @Mixin private FoDDelimiterMixin delimiterMixin; // Is automatically injected in resolver mixins
     @Mixin private FoDMicroserviceByQualifiedNameResolverMixin.PositionalParameter microserviceResolver;
 
     @Option(names = {"--name", "-n"}, required = true)
     private String microserviceName;
 
+    @Mixin private FoDAttributeUpdateOptions.OptionalAttrOption msAttrsUpdate;
+
     @Override
     public JsonNode getJsonNode(UnirestInstance unirest) {
+        FoDMicroserviceDescriptor msDescriptor = microserviceResolver.getMicroserviceDescriptor(unirest, true);
+        ArrayList<FoDAttributeDescriptor> msAttrsCurrent = msDescriptor.getAttributes();
+        Map<String, String> attributeUpdates = msAttrsUpdate.getAttributes();
+        JsonNode jsonAttrs = objectMapper.createArrayNode();
+        if (attributeUpdates != null && !attributeUpdates.isEmpty()) {
+            jsonAttrs = FoDAttributeHelper.mergeAttributesNode(unirest, FoDEnums.AttributeTypes.Microservice,
+                    msAttrsCurrent, attributeUpdates);
+        } else {
+            jsonAttrs = FoDAttributeHelper.getAttributesNode(FoDEnums.AttributeTypes.Microservice, msAttrsCurrent);
+        }
         FoDMicroserviceDescriptor appMicroserviceDescriptor = microserviceResolver.getMicroserviceDescriptor(unirest, true);
         FoDMicroserviceUpdateRequest msUpdateRequest = FoDMicroserviceUpdateRequest.builder()
-                .microserviceName(microserviceName).build();
+                .microserviceName(microserviceName)
+                .attributes(jsonAttrs).build();
         return FoDMicroserviceHelper.updateMicroservice(unirest, appMicroserviceDescriptor, msUpdateRequest).asJsonNode();
     }
 

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/microservice/helper/FoDMicroserviceDescriptor.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/microservice/helper/FoDMicroserviceDescriptor.java
@@ -16,9 +16,14 @@ package com.fortify.cli.fod.microservice.helper;
 import com.formkiq.graalvm.annotations.Reflectable;
 import com.fortify.cli.common.json.JsonNodeHolder;
 
+import com.fortify.cli.fod.app.attr.helper.FoDAttributeDescriptor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 @Reflectable @NoArgsConstructor
 @Data @EqualsAndHashCode(callSuper = true)
@@ -27,4 +32,13 @@ public class FoDMicroserviceDescriptor extends JsonNodeHolder {
     private String applicationName;
     private String microserviceId;
     private String microserviceName;
+    private ArrayList<FoDAttributeDescriptor> attributes;
+
+    public Map<Integer, String> attributesAsMap() {
+        Map<Integer, String> attrMap = new HashMap<>();
+        for (FoDAttributeDescriptor attr : attributes) {
+            attrMap.put(attr.getId(), attr.getValue());
+        }
+        return  attrMap;
+    }
 }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/microservice/helper/FoDMicroserviceHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/microservice/helper/FoDMicroserviceHelper.java
@@ -23,6 +23,9 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fortify.cli.common.exception.FcliSimpleException;
 import com.fortify.cli.common.json.JsonHelper;
 import com.fortify.cli.fod._common.rest.FoDUrls;
+import com.fortify.cli.fod._common.util.FoDEnums;
+import com.fortify.cli.fod.app.attr.cli.mixin.FoDAttributeUpdateOptions;
+import com.fortify.cli.fod.app.attr.helper.FoDAttributeHelper;
 import com.fortify.cli.fod.app.helper.FoDAppDescriptor;
 import com.fortify.cli.fod.app.helper.FoDAppHelper;
 
@@ -43,7 +46,7 @@ public class FoDMicroserviceHelper {
             FoDQualifiedMicroserviceNameDescriptor microserviceNameDescriptor, boolean failIfNotFound) {
         var microservices = (ArrayNode)unirest.get(FoDUrls.MICROSERVICES)
                 .routeParam("appId", appDescriptor.getApplicationId())
-                .queryString("includeReleases", "false")
+                .queryString("includeReleases", "true")
                 .asObject(JsonNode.class).getBody().get("items");
         var matching = JsonHelper.stream(microservices)
                 .filter(match(microserviceNameDescriptor))
@@ -92,8 +95,14 @@ public class FoDMicroserviceHelper {
         return getDescriptor(appDescriptor, response, msRequest.getMicroserviceName());
     }
     
-    public static final FoDMicroserviceDescriptor createMicroservice(UnirestInstance unirest, FoDAppDescriptor appDescriptor, String microserviceName) {
-        var request = FoDMicroserviceUpdateRequest.builder().microserviceName(microserviceName).build();
+    public static final FoDMicroserviceDescriptor createMicroservice(UnirestInstance unirest, FoDAppDescriptor appDescriptor,
+                                                                     String microserviceName, FoDAttributeUpdateOptions.OptionalAttrOption msAttrs,
+                                                                     boolean autoRequiredAttrs) {
+        var request = FoDMicroserviceUpdateRequest.builder()
+                .microserviceName(microserviceName)
+                .attributes(FoDAttributeHelper.getAttributesNode(unirest, FoDEnums.AttributeTypes.Microservice,
+                        msAttrs.getAttributes(), autoRequiredAttrs))
+                .build();
         return createMicroservice(unirest, appDescriptor, request);
     }
 

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/microservice/helper/FoDMicroserviceUpdateRequest.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/microservice/helper/FoDMicroserviceUpdateRequest.java
@@ -13,6 +13,7 @@
 
 package com.fortify.cli.fod.microservice.helper;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.formkiq.graalvm.annotations.Reflectable;
 
 import lombok.AllArgsConstructor;
@@ -25,4 +26,6 @@ import lombok.ToString;
 @Getter @ToString @Builder
 public class FoDMicroserviceUpdateRequest {
     private String microserviceName;
+    private JsonNode attributes;
+    private Boolean autoRequiredAttrs;
 }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/release/cli/cmd/FoDReleaseCreateCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/release/cli/cmd/FoDReleaseCreateCommand.java
@@ -74,7 +74,7 @@ public class FoDReleaseCreateCommand extends AbstractFoDJsonNodeOutputCommand im
 
     @Mixin private FoDSdlcStatusTypeOptions.RequiredOption sdlcStatus;
     @Mixin private FoDAttributeUpdateOptions.OptionalAttrOption relAttrs;
-    
+
     @ArgGroup(exclusive = false, headingKey = "fcli.fod.release.create.app-options") 
     private FoDReleaseAppCreateOptionsArgGroup appCreateOptions = new FoDReleaseAppCreateOptionsArgGroup();
 
@@ -138,7 +138,7 @@ public class FoDReleaseCreateCommand extends AbstractFoDJsonNodeOutputCommand im
             if ( StringUtils.isBlank(microserviceName) ) {
                 throw new FcliSimpleException("Microservice name must be specified for microservices application");
             }
-            microserviceDescriptor = FoDMicroserviceHelper.createMicroservice(unirest, appDescriptor, releaseNameResolver.getQualifiedReleaseNameDescriptor().getMicroserviceName());
+            microserviceDescriptor = FoDMicroserviceHelper.createMicroservice(unirest, appDescriptor, releaseNameResolver.getQualifiedReleaseNameDescriptor().getMicroserviceName(), relAttrs, autoRequiredAttrs);
             msCreated = true;
         }
         return createRelease(unirest, appDescriptor, microserviceDescriptor, msCreated);

--- a/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
+++ b/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
@@ -334,6 +334,12 @@ fcli.fod.microservice.output.table.header.applicationName = Application
 
 fcli.fod.microservice.create.usage.header = Create a new application microservice.
 fcli.fod.microservice.create.name = The name of the microservice to create for the application.
+fcli.fod.microservice.create.attrs = Set of microservice attribute id's or names and their values to set. \
+  Please note for user attributes only the userId is currently supported.
+fcli.fod.microservice.create.auto-required-attrs = Automatically set a default value for required attributes. \
+  Please note for Picklist and User attributes this will set the value to the first item in the list, \
+  for Boolean attributes it will set the value to 'false' and for Text attributes it will fill \
+  with 'autofilled by fcli'.
 fcli.fod.microservice.create.skip-if-exists = Check to see if microservice already exists before creating.
 fcli.fod.microservice.delete.usage.header = Delete an application microservice.
 fcli.fod.microservice.list.usage.header = List application microservices.
@@ -341,6 +347,8 @@ fcli.fod.microservice.list.include-releases = Include all microservice releases 
 fcli.fod.microservice.get.usage.header = Get application microservices.
 fcli.fod.microservice.update.usage.header = Update an existing application microservice.
 fcli.fod.microservice.update.name = The updated name for the microservice.
+fcli.fod.microservice.update.attrs = Set of microservice attribute id's or names and their values to set. \
+  Please note for user attributes only the userId is currently supported.
 fcli.fod.microservice.update.invalid-parameter = Unable to resolve application name and microservice name.
 
 # fcli fod release


### PR DESCRIPTION
Added options for attributes to be created/updated on microservices and support for `--auto-requried-attrs` option.

Tested on individual microservices and when created as part `fcli fod release create` and `fcli fod action run setup-release`.