### PR TITLE
Implement DAST Automated queueing behaviour

### DIFF
--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/cli/cmd/AbstractFoDScanCancelCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/cli/cmd/AbstractFoDScanCancelCommand.java
@@ -32,9 +32,13 @@ public abstract class AbstractFoDScanCancelCommand extends AbstractFoDJsonNodeOu
     @Override
     public final JsonNode getJsonNode(UnirestInstance unirest) {
         FoDScanDescriptor descriptor = scanResolver.getScanDescriptor(unirest, getScanType());
-        unirest.post(FoDUrls.RELEASE + "/scans/{scanId}/cancel-scan")
+        JsonNode response = unirest.post(FoDUrls.RELEASE + "/scans/{scanId}/cancel-scan")
                 .routeParam("relId", String.valueOf(descriptor.getReleaseId()))
-                .routeParam("scanId", String.valueOf(descriptor.getScanId()));
+                .routeParam("scanId", String.valueOf(descriptor.getScanId()))
+                .asObject(JsonNode.class).getBody();
+        if (response.has("success") && !response.get("success").asBoolean()) {
+            throw new IllegalStateException("Error cancelling scan: "+response.get("message").asText());
+        }
         return descriptor.asJsonNode();
     }
     

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/cli/cmd/AbstractFoDScanCancelCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/cli/cmd/AbstractFoDScanCancelCommand.java
@@ -20,6 +20,7 @@ import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDJsonNodeOutputComma
 import com.fortify.cli.fod._common.rest.FoDUrls;
 import com.fortify.cli.fod._common.scan.cli.mixin.FoDScanResolverMixin;
 import com.fortify.cli.fod._common.scan.helper.FoDScanDescriptor;
+import com.fortify.cli.fod._common.scan.helper.FoDScanHelper;
 import com.fortify.cli.fod._common.scan.helper.FoDScanType;
 
 import kong.unirest.UnirestInstance;
@@ -32,13 +33,9 @@ public abstract class AbstractFoDScanCancelCommand extends AbstractFoDJsonNodeOu
     @Override
     public final JsonNode getJsonNode(UnirestInstance unirest) {
         FoDScanDescriptor descriptor = scanResolver.getScanDescriptor(unirest, getScanType());
-        JsonNode response = unirest.post(FoDUrls.RELEASE + "/scans/{scanId}/cancel-scan")
-                .routeParam("relId", String.valueOf(descriptor.getReleaseId()))
-                .routeParam("scanId", String.valueOf(descriptor.getScanId()))
-                .asObject(JsonNode.class).getBody();
-        if (response.has("success") && !response.get("success").asBoolean()) {
-            throw new IllegalStateException("Error cancelling scan: "+response.get("message").asText());
-        }
+        FoDScanHelper.cancelScan(unirest,
+                String.valueOf(descriptor.getReleaseId()),
+                String.valueOf(descriptor.getScanId()));
         return descriptor.asJsonNode();
     }
     

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/cli/cmd/AbstractFoDScanStartCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/cli/cmd/AbstractFoDScanStartCommand.java
@@ -43,12 +43,12 @@ public abstract class AbstractFoDScanStartCommand extends AbstractFoDJsonNodeOut
     protected abstract FoDScanDescriptor startScan(UnirestInstance unirest, FoDReleaseDescriptor releaseDescriptor);
 
     @Override
-    public final String getActionCommandResult() {
+    public String getActionCommandResult() {
         return "STARTED";
     }
 
     @Override
-    public final boolean isSingular() {
+    public boolean isSingular() {
         return true;
     }
 }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/cli/mixin/FoDInProgressScanActionTypeMixins.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/cli/mixin/FoDInProgressScanActionTypeMixins.java
@@ -23,5 +23,9 @@ public class FoDInProgressScanActionTypeMixins {
         @Option(names = {"--in-progress", "--in-progress-action"}, required = false, descriptionKey = "fcli.fod.scan.in-progress-action")
         @Getter private FoDEnums.InProgressScanActionType inProgressScanActionType;
     }
+    public static class DefaultOption {
+        @Option(names = {"--in-progress", "--in-progress-action"}, required = false, defaultValue = "DoNotStartScan", descriptionKey = "fcli.fod.scan.in-progress-action")
+        @Getter private FoDEnums.InProgressScanActionType inProgressScanActionType;
+    }
 
 }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/FoDScanDescriptor.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/FoDScanDescriptor.java
@@ -34,6 +34,7 @@ public class FoDScanDescriptor extends JsonNodeHolder {
     private String applicationId;
     private String releaseId;
     private String microserviceName;
+    private String analysisStatusType;
     private String status;
 
     @JsonIgnore

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/FoDScanHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/FoDScanHelper.java
@@ -272,5 +272,15 @@ public class FoDScanHelper {
     private static final FoDScanDescriptor getEmptyDescriptor() {
         return JsonHelper.treeToValue(getObjectMapper().createObjectNode(), FoDScanDescriptor.class);
     }
+Fod
+    public static void cancelScan(UnirestInstance unirest, String releaseId, String scanId) {
+        JsonNode cancelResponse = unirest.post(FoDUrls.RELEASE + "/scans/{scanId}/cancel-scan")
+                .routeParam("relId", releaseId)
+                .routeParam("scanId", scanId)
+                .asObject(JsonNode.class).getBody();
+        if (cancelResponse.has("success") && !cancelResponse.get("success").asBoolean()) {
+            throw new IllegalStateException("Error cancelling scan " + cancelResponse.get("message").asText());
+        }
+    }
 
 }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/util/FoDEnums.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/util/FoDEnums.java
@@ -19,7 +19,6 @@ import org.apache.commons.lang3.StringUtils;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 // TODO Any good reason for having one big class defining many enums? Was this somehow generated from FoD?
 // TODO Are all these enums actually used?
@@ -142,42 +141,31 @@ public class FoDEnums {
     }
 
     public enum InProgressScanActionType {
-        DoNotStartScan(0),
-        CancelScanInProgress(1),
-        Queue(2);
+        DoNotStartScan(0, "DoNotStartScan"),
+        CancelScanInProgress(1, "CancelScanInProgress"),
+        Queue(2, "Queue");
 
-        private final int _val;
+        @Getter
+        private final int value;
+        private final String displayName;
 
-        InProgressScanActionType(int val) {
-            this._val = val;
+        InProgressScanActionType(int value, String displayName) {
+            this.value = value;
+            this.displayName = displayName;
         }
 
-        public int getValue() {
-            return this._val;
-        }
-
+        @Override
         public String toString() {
-            switch (this._val) {
-                case 1:
-                    return "CancelInProgressScan";
-                case 2:
-                    return "Queue";
-                case 0:
-                default:
-                    return "DoNotStartScan";
-            }
+            return displayName;
         }
 
-        public static InProgressScanActionType fromInt(int val) {
-            switch (val) {
-                case 2:
-                    return Queue;
-                case 1:
-                    return CancelScanInProgress;
-                case 0:
-                default:
-                    return DoNotStartScan;
+        public static InProgressScanActionType fromInt(int value) {
+            for (InProgressScanActionType type : values()) {
+                if (type.value == value) {
+                    return type;
+                }
             }
+            return DoNotStartScan;
         }
     }
 

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/FoDDastAutomatedScanStartCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/FoDDastAutomatedScanStartCommand.java
@@ -14,27 +14,61 @@
 package com.fortify.cli.fod.dast_scan.cli.cmd;
 
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
+import com.fortify.cli.common.progress.cli.mixin.ProgressWriterFactoryMixin;
 import com.fortify.cli.fod._common.scan.cli.cmd.AbstractFoDScanStartCommand;
+import com.fortify.cli.fod._common.scan.cli.mixin.FoDInProgressScanActionTypeMixins;
 import com.fortify.cli.fod._common.scan.helper.FoDScanDescriptor;
 import com.fortify.cli.fod._common.scan.helper.dast.FoDScanDastAutomatedHelper;
+import com.fortify.cli.fod._common.util.FoDEnums;
 import com.fortify.cli.fod.release.helper.FoDReleaseDescriptor;
 
 import kong.unirest.UnirestInstance;
 import lombok.Getter;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
 import picocli.CommandLine.Mixin;
 
 @Command(name = OutputHelperMixins.Start.CMD_NAME)
 public class FoDDastAutomatedScanStartCommand extends AbstractFoDScanStartCommand {
     @Getter @Mixin private OutputHelperMixins.Start outputHelper;
 
+    @Mixin private FoDInProgressScanActionTypeMixins.DefaultOption inProgressScanActionType;
+    @Option(names="--wait-interval", descriptionKey = "fcli.fod.scan.wait-interval", defaultValue = "10", required = false)
+    private Integer waitInterval;
+    @Option(names="--max-attempts", descriptionKey = "fcli.fod.scan.max-attempts", defaultValue = "30", required = false)
+    private Integer maxAttempts;
+
+    @Mixin private ProgressWriterFactoryMixin progressWriterFactory;
+
+    private String scanAction = "STARTED";
+
     @Override
     protected FoDScanDescriptor startScan(UnirestInstance unirest, FoDReleaseDescriptor releaseDescriptor) {
-            String relId = releaseDescriptor.getReleaseId();
+        String relId = releaseDescriptor.getReleaseId();
+
+        try (var progressWriter = progressWriterFactory.create()) {
 
             // get current setup to ensure the scan has been configured
             FoDScanDastAutomatedHelper.getSetupDescriptor(unirest, relId);
 
+            // check if scan is already in progress
+            FoDScanDescriptor scan = FoDScanDastAutomatedHelper.handleInProgressScan(unirest, releaseDescriptor,
+                    inProgressScanActionType.getInProgressScanActionType(), progressWriter, maxAttempts,
+                    waitInterval);
+
+            if (scan != null && scan.getAnalysisStatusType().equals("In_Progress")) {
+                if (inProgressScanActionType.getInProgressScanActionType() == FoDEnums.InProgressScanActionType.DoNotStartScan) {
+                    scanAction = "NOT_STARTED_SCAN_IN_PROGRESS";
+                    return scan;
+                }
+            }
+
             return FoDScanDastAutomatedHelper.startScan(unirest, releaseDescriptor);
+        }
+    }
+
+    @Override
+    public final String getActionCommandResult() {
+        return scanAction;
     }
 }

--- a/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
+++ b/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
@@ -483,7 +483,9 @@ fcli.fod.scan.wait-for.usage.description.3 = %nPlease note it is recommended to 
 fcli.fod.scan.wait-for.until = Wait until either any or all scans match. If neither --until or --while are specified, default is to wait until all scans match.
 fcli.fod.scan.wait-for.while = Wait while either any or all scans match.
 fcli.fod.scan.wait-for.any-state = One or more scan states against which to match the given scans.
-fcli.fod.scan.chunk-size = Size of each chunk (in bytes) for file uploads. Default is 1048576. 
+fcli.fod.scan.chunk-size = Size of each chunk (in bytes) for file uploads. Default is 1048576.
+fcli.fod.scan.wait-interval = Interval (in seconds) between status checks. Default is 10 seconds.
+fcli.fod.scan.max-attempts = Maximum number of status checks before giving up. Default is 30.
 
 # fcli fod sast-scan
 fcli.fod.sast-scan.usage.header = Manage FoD SAST scans.


### PR DESCRIPTION
Currently, DAST Automated API does not support queueing of scans. This is an implementation at the fcli level to achieve this.
For example:

```
fod dast-scan start --release "App:Release"  --in-progress=Queue
```

The default is not to start a new scan since there is no additional configuration that can be supplied. There is also the ability to cancel the existing scan and start a new one.

Whilst implementing I noticed the existing `fod dast-scan cancel` did not work, so updated this as well.