### PR TITLE
fix(aviator): Resolve file token leak during Aviator artifact uploads

### DIFF
--- a/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/cli/cmd/AviatorSSCAuditCommand.java
+++ b/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/cli/cmd/AviatorSSCAuditCommand.java
@@ -74,7 +74,7 @@ public class AviatorSSCAuditCommand extends AbstractSSCJsonNodeOutputCommand imp
 
             String artifactId = "UPLOAD_SKIPPED";
             if (auditResult.getUpdatedFile() != null && !"SKIPPED".equals(auditResult.getStatus()) && !"FAILED".equals(auditResult.getStatus())) {
-                artifactId = uploadAuditedFprToSSC(unirest, auditResult.getUpdatedFile(), av, logger);
+                artifactId = uploadAuditedFprToSSC(unirest, auditResult.getUpdatedFile(), av);
             }
 
             return AviatorSSCAuditHelper.buildResultNode(av, artifactId, action);
@@ -113,9 +113,8 @@ public class AviatorSSCAuditCommand extends AbstractSSCJsonNodeOutputCommand imp
     }
 
     @SneakyThrows
-    private String uploadAuditedFprToSSC(UnirestInstance unirest, File auditedFpr, SSCAppVersionDescriptor av, AviatorLoggerImpl logger) {
-        JsonNode uploadResponse = SSCFileTransferHelper.htmlUpload(unirest, SSCUrls.PROJECT_VERSION_ARTIFACTS(av.getVersionId()), auditedFpr,
-                SSCFileTransferHelper.ISSCAddUploadTokenFunction.QUERYSTRING_MAT, JsonNode.class);
+    private String uploadAuditedFprToSSC(UnirestInstance unirest, File auditedFpr, SSCAppVersionDescriptor av) {
+        JsonNode uploadResponse = SSCFileTransferHelper.restUpload(unirest, SSCUrls.PROJECT_VERSION_ARTIFACTS(av.getVersionId()), auditedFpr, JsonNode.class);
         return uploadResponse.path("data").path("id").asText("UPLOAD_FAILED");
     }
 

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/rest/ssc/transfer/SSCFileTransferHelper.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/rest/ssc/transfer/SSCFileTransferHelper.java
@@ -76,14 +76,12 @@ public class SSCFileTransferHelper {
         if ( isHtmlEndpoint(endpoint) ) {
             throw new FcliBugException("Uploads to %s should be done through SSCFileTransferHelper::htmlUpload", endpoint);
         }
-        try ( SSCFileTransferTokenSupplier tokenSupplier = new SSCFileTransferTokenSupplier(unirest, SSCFileTransferTokenType.UPLOAD); ) {
-            try ( SSCProgressMonitor uploadMonitor = new SSCProgressMonitor("Upload") ) {
-                return unirest.post(endpoint)
+        try ( SSCProgressMonitor uploadMonitor = new SSCProgressMonitor("Upload") ) {
+            return unirest.post(endpoint)
                     .multiPartContent() // Force multipart request with correct Content-Type header
                     .field("file", filePath)
                     .uploadMonitor(uploadMonitor)
                     .asObject(returnType).getBody();
-            }
         }
     }
 


### PR DESCRIPTION
This PR updates the Aviator audit command to use the new `SSCFileTransferHelper.restUpload` method for uploading the audited FPR.

The new `restUpload` method performs a direct multipart upload to the SSC artifacts endpoint without generating a file token. This change fixes the token leak that occurred when the previous implementation created unused file tokens for every upload.