### PR TITLE
Add support for Application level operation to `fcli fod issue ls`

### DIFF
--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/rest/query/cli/mixin/AbstractServerSideQueryMixin.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/rest/query/cli/mixin/AbstractServerSideQueryMixin.java
@@ -62,11 +62,7 @@ public abstract class AbstractServerSideQueryMixin implements IHttpRequestUpdate
     protected abstract String getServerSideQueryParamName();
     protected abstract String getServerSideQueryParamOptionValue();
 
-    protected Expression getExpression() {
-        return this.getSpelExpression();
-    }
-
-    private final Expression getSpelExpression() {
+    protected final Expression getSpelExpression() {
         QueryExpression queryExpression = getQueryExpression();
         return queryExpression==null ? null : queryExpression.getExpression();
     }

--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/rest/query/cli/mixin/AbstractServerSideQueryMixin.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/rest/query/cli/mixin/AbstractServerSideQueryMixin.java
@@ -61,7 +61,11 @@ public abstract class AbstractServerSideQueryMixin implements IHttpRequestUpdate
     
     protected abstract String getServerSideQueryParamName();
     protected abstract String getServerSideQueryParamOptionValue();
-    
+
+    protected Expression getExpression() {
+        return this.getSpelExpression();
+    }
+
     private final Expression getSpelExpression() {
         QueryExpression queryExpression = getQueryExpression();
         return queryExpression==null ? null : queryExpression.getExpression();

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/rest/query/cli/mixin/FoDFiltersParamMixin.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/rest/query/cli/mixin/FoDFiltersParamMixin.java
@@ -15,6 +15,7 @@ package com.fortify.cli.fod._common.rest.query.cli.mixin;
 import com.fortify.cli.common.mcp.MCPExclude;
 import com.fortify.cli.common.rest.query.cli.mixin.AbstractServerSideQueryMixin;
 
+import org.springframework.expression.Expression;
 import picocli.CommandLine.Option;
 
 public class FoDFiltersParamMixin extends AbstractServerSideQueryMixin {
@@ -29,6 +30,14 @@ public class FoDFiltersParamMixin extends AbstractServerSideQueryMixin {
     
     @Override
     protected String getServerSideQueryParamOptionValue() {
+        return filtersParam;
+    }
+
+    public Expression getFilterExpression() {
+        return super.getExpression();
+    }
+
+    public String getFiltersParam() {
         return filtersParam;
     }
 }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/rest/query/cli/mixin/FoDFiltersParamMixin.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/rest/query/cli/mixin/FoDFiltersParamMixin.java
@@ -19,25 +19,21 @@ import org.springframework.expression.Expression;
 import picocli.CommandLine.Option;
 
 public class FoDFiltersParamMixin extends AbstractServerSideQueryMixin {
-    @Option(names="--filters-param", required=false, descriptionKey="fcli.fod.filters-param")
+    @Option(names = "--filters-param", required = false, descriptionKey = "fcli.fod.filters-param")
     @MCPExclude // Not suitable for LLM, as LLM doesn't know option syntax/fields
     private String filtersParam;
-    
+
     @Override
     protected String getServerSideQueryParamName() {
         return "filters";
     }
-    
+
     @Override
-    protected String getServerSideQueryParamOptionValue() {
+    public String getServerSideQueryParamOptionValue() {
         return filtersParam;
     }
 
     public Expression getFilterExpression() {
-        return super.getExpression();
-    }
-
-    public String getFiltersParam() {
-        return filtersParam;
+        return super.getSpelExpression();
     }
 }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/issue/cli/cmd/FoDIssueListCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/issue/cli/cmd/FoDIssueListCommand.java
@@ -12,41 +12,100 @@
  *******************************************************************************/
 package com.fortify.cli.fod.issue.cli.cmd;
 
+import java.util.List;
+import java.util.Optional;
+
+import com.fortify.cli.common.exception.FcliSimpleException;
+import com.fortify.cli.fod.release.helper.FoDReleaseHelper;
+import kong.unirest.UnirestInstance;
+import lombok.Getter;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import com.fortify.cli.common.json.JsonHelper;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamGeneratorSupplier;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamValueGenerator;
 import com.fortify.cli.fod._common.cli.mixin.FoDDelimiterMixin;
-import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDBaseRequestOutputCommand;
+import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDJsonNodeOutputCommand;
 import com.fortify.cli.fod._common.rest.query.FoDFiltersParamGenerator;
 import com.fortify.cli.fod._common.rest.query.cli.mixin.FoDFiltersParamMixin;
 import com.fortify.cli.fod.issue.cli.mixin.FoDIssueEmbedMixin;
 import com.fortify.cli.fod.issue.cli.mixin.FoDIssueIncludeMixin;
+import com.fortify.cli.fod.issue.helper.FoDIssueHelper;
+import com.fortify.cli.fod.app.cli.mixin.FoDAppResolverMixin;
 import com.fortify.cli.fod.release.cli.mixin.FoDReleaseByQualifiedNameOrIdResolverMixin;
 
-import kong.unirest.HttpRequest;
-import kong.unirest.UnirestInstance;
-import lombok.Getter;
-import picocli.CommandLine.Command;
-import picocli.CommandLine.Mixin;
-
 @Command(name = OutputHelperMixins.List.CMD_NAME)
-public class FoDIssueListCommand extends AbstractFoDBaseRequestOutputCommand implements IServerSideQueryParamGeneratorSupplier {
+public class FoDIssueListCommand extends AbstractFoDJsonNodeOutputCommand implements IServerSideQueryParamGeneratorSupplier {
+    private static final Log LOG = LogFactory.getLog(FoDIssueListCommand.class);
+
     @Getter @Mixin private OutputHelperMixins.List outputHelper;
     @Mixin private FoDDelimiterMixin delimiterMixin; // Is automatically injected in resolver mixins
-    @Mixin private FoDReleaseByQualifiedNameOrIdResolverMixin.RequiredOption releaseResolver;
+    @Mixin private FoDAppResolverMixin.OptionalOption appResolver;
+    @Mixin private FoDReleaseByQualifiedNameOrIdResolverMixin.OptionalOption releaseResolver;
     @Mixin private FoDFiltersParamMixin filterParamMixin;
     @Mixin private FoDIssueEmbedMixin embedMixin;
     @Mixin private FoDIssueIncludeMixin includeMixin;
-    @Getter private IServerSideQueryParamValueGenerator serverSideQueryParamGenerator = new FoDFiltersParamGenerator()
-            .add("severityString","severityString");
-            // TODO Add support for other properties 
+    @Getter private final IServerSideQueryParamValueGenerator serverSideQueryParamGenerator = new FoDFiltersParamGenerator()
+            .add("id","id")
+            .add("vulnId","vulnId")
+            .add("instanceId","instanceId")
+            .add("scanType","scanType")
+            .add("status","status")
+            .add("developerStatus","developerStatus")
+            .add("auditorStatus","auditorStatus")
+            .add("severity","severity")
+            .add("severityString","severityString")
+            .add("category","category");
 
     @Override
-    public HttpRequest<?> getBaseRequest(UnirestInstance unirest) {
-        return unirest.get("/api/v3/releases/{releaseId}/vulnerabilities")
-                .routeParam("releaseId", releaseResolver.getReleaseId(unirest));
+    public JsonNode getJsonNode(UnirestInstance unirest) {
+        ArrayNode result = JsonHelper.getObjectMapper().createArrayNode();
+        // Get any server-side filters
+        String filtersParamValue = Optional.ofNullable(filterParamMixin.getFilterExpression())
+                .map(serverSideQueryParamGenerator::getServerSideQueryParamValue)
+                .filter(v -> !v.isEmpty())
+                .orElse(Optional.ofNullable(filterParamMixin.getFiltersParam()).orElse(""));
+        // If a release is specified, just get issues for that release
+        if (releaseResolver.getQualifiedReleaseNameOrId() != null) {
+            if (appResolver.getAppNameOrId() != null) {
+                throw new FcliSimpleException("Cannot specify both an application and release");
+            }
+            // If a release is specified, just get issues for that release
+            result.addAll(FoDIssueHelper.getReleaseIssues(unirest, releaseResolver.getReleaseId(unirest),
+                    includeMixin,
+                    embedMixin,
+                    filtersParamValue,
+                    true));
+            // call mergeReleaseIssues to ensure consistent ordering and deduplication of issues
+            return FoDIssueHelper.mergeReleaseIssues(result);
+        }
+        // If an application is specified, get issues for all releases of that application
+        if (appResolver.getAppNameOrId() != null) {
+            // If an application is specified, get issues for all releases of that application
+            List<String> releases = FoDReleaseHelper.getAllReleaseIdsForApp(unirest, appResolver.getAppId(unirest), true);
+            if (releases.isEmpty()) {
+                throw new FcliSimpleException("No releases found for application " + appResolver.getAppNameOrId());
+            }
+            for (String release : releases) {
+                result.addAll(FoDIssueHelper.getReleaseIssues(unirest, release,
+                        includeMixin,
+                        embedMixin,
+                        filtersParamValue,
+                        true));
+            }
+            // call mergeReleaseIssues to ensure consistent ordering
+            return FoDIssueHelper.mergeReleaseIssues(result);
+        } else {
+            throw new FcliSimpleException("Either an application or release must be specified");
+        }
     }
-    
+
     @Override
     public boolean isSingular() {
         return false;

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/issue/cli/cmd/FoDIssueListCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/issue/cli/cmd/FoDIssueListCommand.java
@@ -70,7 +70,7 @@ public class FoDIssueListCommand extends AbstractFoDJsonNodeOutputCommand implem
         String filtersParamValue = Optional.ofNullable(filterParamMixin.getFilterExpression())
                 .map(serverSideQueryParamGenerator::getServerSideQueryParamValue)
                 .filter(v -> !v.isEmpty())
-                .orElse(Optional.ofNullable(filterParamMixin.getFiltersParam()).orElse(""));
+                .orElse(Optional.ofNullable(filterParamMixin.getServerSideQueryParamOptionValue()).orElse(""));
         // If a release is specified, just get issues for that release
         if (releaseResolver.getQualifiedReleaseNameOrId() != null) {
             if (appResolver.getAppNameOrId() != null) {

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/issue/cli/mixin/FoDIssueIncludeMixin.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/issue/cli/mixin/FoDIssueIncludeMixin.java
@@ -51,12 +51,16 @@ public class FoDIssueIncludeMixin implements IHttpRequestUpdater, IRecordTransfo
     public JsonNode transformRecord(JsonNode record) {
         var objectNode = (ObjectNode)record;
         objectNode.put("location", JsonHelper.evaluateSpelExpression(record, "primaryLocation+(lineNumber==null?'':(':'+lineNumber))", String.class));
+        // Debug: Print closedStatus and isSuppressed for each record
+        //boolean isSuppressed = JsonHelper.evaluateSpelExpression(objectNode, "isSuppressed", Boolean.class);
+        //boolean isFixed = JsonHelper.evaluateSpelExpression(objectNode, "closedStatus", Boolean.class);
         // If includes doesn't include 'visible', we return null for any visible (non-suppressed
         // & non-fixed) issues. We don't need explicit handling for other cases, as suppressed or
         // fixed issues won't be returned by FoD if not explicitly specified through the --include
         // option.
         return !includes.contains(FoDIssueInclude.visible)
-                && JsonHelper.evaluateSpelExpression(objectNode, "!isSuppressed && !closedStatus", Boolean.class)
+                && JsonHelper.evaluateSpelExpression(objectNode,
+                    "!isSuppressed && !(closedStatus || status=='Fix Validated')", Boolean.class)
                 ? null
                 : addVisibilityProperties(objectNode);
     }
@@ -64,11 +68,17 @@ public class FoDIssueIncludeMixin implements IHttpRequestUpdater, IRecordTransfo
     private ObjectNode addVisibilityProperties(ObjectNode record) {
         Map<String,String> visibility = new LinkedHashMap<>();
         if ( getBoolean(record, "isSuppressed") ) { visibility.put("suppressed", "(S)"); }
-        if ( getBoolean(record, "closedStatus") ) { visibility.put("fixed", "(F)"); } 
+        // Updated as per (Issue#820): using status field as wel  to determine fixed status instead of just closedStatus field
+        if ( getBoolean(record, "closedStatus") || isFixValidated(record) ) { visibility.put("fixed", "(F)"); }
         if ( visibility.isEmpty() )               { visibility.put("visible", " "); }
         record.put("visibility", String.join(",", visibility.keySet()))
             .put("visibilityMarker", String.join("", visibility.values()));
         return record;
+    }
+
+    private boolean isFixValidated(ObjectNode record) {
+        var field = record.get("status");
+        return field != null && "Fix Validated".equals(field.asText());
     }
 
     private boolean getBoolean(ObjectNode record, String propertyName) {

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/issue/cli/mixin/FoDIssueIncludeMixin.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/issue/cli/mixin/FoDIssueIncludeMixin.java
@@ -68,7 +68,7 @@ public class FoDIssueIncludeMixin implements IHttpRequestUpdater, IRecordTransfo
     private ObjectNode addVisibilityProperties(ObjectNode record) {
         Map<String,String> visibility = new LinkedHashMap<>();
         if ( getBoolean(record, "isSuppressed") ) { visibility.put("suppressed", "(S)"); }
-        // Updated as per (Issue#820): using status field as wel  to determine fixed status instead of just closedStatus field
+        // Updated as per (Issue#820): using status field as well to determine fixed status instead of just closedStatus field
         if ( getBoolean(record, "closedStatus") || isFixValidated(record) ) { visibility.put("fixed", "(F)"); }
         if ( visibility.isEmpty() )               { visibility.put("visible", " "); }
         record.put("visibility", String.join(",", visibility.keySet()))

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/issue/helper/FoDIssueHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/issue/helper/FoDIssueHelper.java
@@ -113,8 +113,8 @@ public class FoDIssueHelper {
                 throw e;
             }
             LOG.error("Error retrieving issues for release " +
-                    (StringUtils.isNotEmpty(releaseId) ? releaseId : "<null>" +
-                    ": " + e.getMessage()));
+                    (StringUtils.isNotEmpty(releaseId) ? releaseId : "<null>") +
+                    ": " + e.getMessage());
             return JsonHelper.getObjectMapper().createArrayNode();
         }
     }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/issue/helper/FoDIssueHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/issue/helper/FoDIssueHelper.java
@@ -14,16 +14,34 @@ package com.fortify.cli.fod.issue.helper;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fortify.cli.common.json.JsonHelper;
 import com.fortify.cli.common.output.transform.fields.RenameFieldsTransformer;
+import com.fortify.cli.common.rest.unirest.UnexpectedHttpResponseException;
 import com.fortify.cli.fod._common.rest.FoDUrls;
+import com.fortify.cli.fod._common.rest.embed.IFoDEntityEmbedder;
+import com.fortify.cli.fod._common.rest.helper.FoDInputTransformer;
+import com.fortify.cli.fod._common.rest.helper.FoDPagingHelper;
+import com.fortify.cli.fod._common.rest.helper.FoDProductHelper;
+import com.fortify.cli.fod.issue.cli.mixin.FoDIssueEmbedMixin;
+import com.fortify.cli.fod.issue.cli.mixin.FoDIssueIncludeMixin;
+import com.fortify.cli.fod.release.helper.FoDReleaseDescriptor;
+import com.fortify.cli.fod.release.helper.FoDReleaseHelper;
+import io.micrometer.common.util.StringUtils;
+import kong.unirest.HttpRequest;
+import kong.unirest.HttpResponse;
 import kong.unirest.UnirestInstance;
 import lombok.Getter;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class FoDIssueHelper {
-    @Getter
-    private static ObjectMapper objectMapper = new ObjectMapper();
+    private static final Log LOG = LogFactory.getLog(FoDIssueHelper.class);
+    @Getter private static ObjectMapper objectMapper = new ObjectMapper();
 
     public static final JsonNode transformRecord(JsonNode record) {
         return new RenameFieldsTransformer(new String[]{}).transform(record);
@@ -37,8 +55,138 @@ public class FoDIssueHelper {
         return getResponse(result);
     }
 
+    public static final ArrayNode getReleaseIssues(UnirestInstance unirest,
+                                                   String releaseId,
+                                                   FoDIssueIncludeMixin includeMixin,
+                                                   FoDIssueEmbedMixin embedMixin,
+                                                   String filtersParamValue,
+                                                   boolean failOnError) {
+        LOG.debug("Retrieving issues for release id: " + releaseId);
+        FoDReleaseDescriptor releaseDescriptor = FoDReleaseHelper.getReleaseDescriptorFromId(unirest,
+                Integer.parseInt(releaseId), true );
+        String releaseName = releaseDescriptor.getReleaseName();
+        ArrayNode result = JsonHelper.getObjectMapper().createArrayNode();
+        Map<String, Object> queryParams = new HashMap<>();
+        // Add filters parameter if specified
+        if (StringUtils.isNotEmpty(filtersParamValue)) {
+            queryParams.put("filters", filtersParamValue);
+        }
+        // Always order by severity ascending
+        queryParams.put("orderBy", "severity");
+        queryParams.put("orderDirection", "ASC");
+        // Retrieve all issues for the specified release
+        try {
+            HttpRequest<?> request = unirest.get(FoDUrls.VULNERABILITIES)
+                    .routeParam("relId", releaseId)
+                    .queryString(queryParams);
+            if (includeMixin != null) {
+                request = includeMixin.updateRequest(request);
+            }
+            List<JsonNode> results = FoDPagingHelper.pagedRequest(request)
+                    .stream()
+                    .map(HttpResponse::getBody)
+                    .map(FoDInputTransformer::getItems)
+                    .map(ArrayNode.class::cast)
+                    .flatMap(JsonHelper::stream)
+                    .collect(Collectors.toList());
+            // Transform and enhance each issue record
+            for (JsonNode record : results) {
+                if (record instanceof ObjectNode) {
+                    transformRecord(record);
+                    // add releaseName as only releaseId is returned in issue records
+                    ((ObjectNode) record).put("releaseName", releaseName);
+                    // add issueUrl for convenience
+                    ((ObjectNode) record).put("issueUrl", getIssueUrl(unirest, record.get("id").asText()));
+                    // embed additional entities if requested
+                    if (embedMixin != null && embedMixin.getEmbedSuppliers() != null) {
+                        for (FoDIssueEmbedMixin.FoDIssueEmbedderSupplier supplier : embedMixin.getEmbedSuppliers()) {
+                            IFoDEntityEmbedder embedder = supplier.createEntityEmbedder();
+                            embedder.embed(unirest, (ObjectNode) record);
+                        }
+                    }
+                }
+                result.add(record);
+            }
+            return result;
+        } catch (UnexpectedHttpResponseException e) {
+            if (failOnError) {
+                throw e;
+            }
+            LOG.error("Error retrieving issues for release " +
+                    (StringUtils.isNotEmpty(releaseId) ? releaseId : "<null>" +
+                    ": " + e.getMessage()));
+            return JsonHelper.getObjectMapper().createArrayNode();
+        }
+    }
+
+    public static final ArrayNode mergeReleaseIssues(ArrayNode issues) {
+        Map<String, ObjectNode> merged = new HashMap<>();
+        Map<String, Set<String>> releaseNamesByInstance = new HashMap<>();
+        Map<String, Set<String>> releaseIdsByInstance = new HashMap<>();
+        Map<String, Set<String>> idsByInstance = new HashMap<>();
+        Map<String, Set<String>> vulnIdsByInstance = new HashMap<>();
+
+        // Combine releaseId, releaseName, id, and vulnId fields for issues with the same instanceId
+        for (JsonNode record : issues) {
+            if (record instanceof ObjectNode) {
+                String instanceId = record.get("instanceId").asText();
+                String releaseNameVal = record.get("releaseName").asText();
+                String releaseIdVal = record.get("releaseId").asText();
+                String idVal = record.get("id").asText();
+                String vulnIdVal = record.has("vulnId") ? record.get("vulnId").asText() : "";
+
+                releaseNamesByInstance.computeIfAbsent(instanceId, k -> new HashSet<>()).add(releaseNameVal);
+                releaseIdsByInstance.computeIfAbsent(instanceId, k -> new HashSet<>()).add(releaseIdVal);
+                idsByInstance.computeIfAbsent(instanceId, k -> new HashSet<>()).add(idVal);
+                if (!vulnIdVal.isEmpty()) {
+                    vulnIdsByInstance.computeIfAbsent(instanceId, k -> new HashSet<>()).add(vulnIdVal);
+                }
+
+                merged.putIfAbsent(instanceId, (ObjectNode) record.deepCopy());
+            }
+        }
+
+        // Sort merged records by severity, then category, then releaseId
+        List<ObjectNode> sortedRecords = new ArrayList<>(merged.values());
+        sortedRecords.sort(
+                Comparator.comparingInt((ObjectNode n) -> n.get("severity").asInt()).reversed()
+                        .thenComparing(n -> n.get("category").asText())
+                        .thenComparing(n -> n.get("releaseId").asInt())
+        );
+
+        // Add combined fields to each record
+        ArrayNode result = JsonHelper.getObjectMapper().createArrayNode();
+        for (ObjectNode record : sortedRecords) {
+            String instanceId = record.get("instanceId").asText();
+            Set<String> releaseNames = releaseNamesByInstance.get(instanceId);
+            Set<String> releaseIds = releaseIdsByInstance.get(instanceId);
+            Set<String> relatedIds = idsByInstance.get(instanceId);
+            Set<String> vulnIds = vulnIdsByInstance.getOrDefault(instanceId, Collections.emptySet());
+            record.put("vulnIds", String.join(",", vulnIds));
+            record.put("foundInReleases", String.join(",", releaseNames));
+            record.put("foundInReleaseIds", String.join(",", releaseIds));
+            record.put("ids", relatedIds.stream()
+                    .map(Integer::parseInt)
+                    .sorted()
+                    .map(String::valueOf)
+                    .collect(Collectors.joining(",")));
+            result.add(record);
+        }
+        return result;
+    }
+
+
+    public static final String getIssueUrl(UnirestInstance unirestInstance, String issueId) {
+        return String.format("%s/redirect/Issues/%s", getBaseUrl(unirestInstance), issueId);
+    }
+
+
     private static final FoDBulkIssueUpdateResponse getResponse(JsonNode node) {
         return node==null ? null : JsonHelper.treeToValue(node, FoDBulkIssueUpdateResponse.class);
+    }
+
+    private static String getBaseUrl(UnirestInstance unirest) {
+        return FoDProductHelper.INSTANCE.getBrowserUrl(unirest.config().getDefaultBaseUrl());
     }
 
 }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/issue/helper/FoDIssueHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/issue/helper/FoDIssueHelper.java
@@ -162,14 +162,26 @@ public class FoDIssueHelper {
             Set<String> releaseIds = releaseIdsByInstance.get(instanceId);
             Set<String> relatedIds = idsByInstance.get(instanceId);
             Set<String> vulnIds = vulnIdsByInstance.getOrDefault(instanceId, Collections.emptySet());
-            record.put("vulnIds", String.join(",", vulnIds));
-            record.put("foundInReleases", String.join(",", releaseNames));
-            record.put("foundInReleaseIds", String.join(",", releaseIds));
-            record.put("ids", relatedIds.stream()
+            ArrayNode vulnIdsArray = JsonHelper.getObjectMapper().createArrayNode();
+            vulnIds.forEach(vulnIdsArray::add);
+            ArrayNode releaseNamesArray = JsonHelper.getObjectMapper().createArrayNode();
+            releaseNames.forEach(releaseNamesArray::add);
+            ArrayNode releaseIdsArray = JsonHelper.getObjectMapper().createArrayNode();
+            releaseIds.forEach(releaseIdsArray::add);
+            ArrayNode idsArray = JsonHelper.getObjectMapper().createArrayNode();
+            relatedIds.forEach(idsArray::add);
+            record.set("vulnIds", vulnIdsArray);
+            record.put("vulnIdsString", String.join(", ", vulnIds));
+            record.set("foundInReleases", releaseNamesArray);
+            record.put("foundInReleasesString", String.join(", ", releaseNames));
+            record.set("foundInReleaseIds", releaseIdsArray);
+            record.put("foundInReleaseIdsString", String.join(", ", releaseIds));
+            record.set("ids", idsArray);
+            record.put("idsString", relatedIds.stream()
                     .map(Integer::parseInt)
                     .sorted()
                     .map(String::valueOf)
-                    .collect(Collectors.joining(",")));
+                    .collect(Collectors.joining(", ")));
             result.add(record);
         }
         return result;

--- a/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
+++ b/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
@@ -876,7 +876,7 @@ fcli.fod.issue.output.table.header.issueCount = Issues
 fcli.fod.issue.output.table.header.errorCount = Errors
 fcli.fod.issue.list.usage.header = List vulnerabilities.
 fcli.fod.issue.list.usage.description = This command allows for listing FoD vulnerability data \
-  for a given release. By default, only visible issues will be returned; the --include option can \
+  for a given application or release. By default, only visible issues will be returned; the --include option can \
   be used to (also) include suppressed or fixed issues. If any such issues are included, the \
   default table output will show (S) and/or (F) for respectively suppressed and fixed issues. \
   %n%nOptionally, additional details may be included in the output using the --embed option, but \
@@ -888,9 +888,13 @@ fcli.fod.issue.list.usage.description = This command allows for listing FoD vuln
   issues have been processed, so it may take a long time before you see any output, and there's \
   a small risk of running out of memory. Most other output formats (like json, yaml, or csv) \
   output data immediately after each page of issues has been loaded from FoD, resulting in \
-  more immediate output.
-fcli.fod.issue.list.output.table.header.visibilityMarker = 
-# TODO --embed option yet to be added.
+  more immediate output. \
+  %n%nWARNING: The --app option is currently in PREVIEW. If you wish to use this option it is \
+  recommended to use server-side filtering, via use of the --filters-param or --query options. \
+  For example, if you are only interested in issues with a specific severity, you \
+  can use a query like --filters-param "severityString:Critical" or --query "severityString='Critical'".
+fcli.fod.issue.list.output.table.header.visibilityMarker =
+fcli.fod.issue.list.output.table.header.foundInReleases = Releases
 fcli.fod.issue.embed = Embed extra issue data. Due to FoD rate limits, this may significantly \
   affect performance. Allowed values: ${COMPLETION-CANDIDATES}. \
   Using the --output option, this extra data can be included in the output. Using the --query option, \
@@ -981,7 +985,6 @@ fcli.fod.release.wait-for.output.table.args = releaseId,releaseName,microservice
 fcli.fod.release.scan.output.table.args = scanId,scanType,analysisStatusType,applicationName,microserviceName,releaseName,startedDateTime,completedDateTime,scanMethodTypeName
 fcli.fod.release.assessment-type.output.table.args = assessmentTypeId,name,scanType,frequencyType,unitInfo,entitlementId,entitlementDescription
 fcli.fod.oss-scan.oss-components.output.table.args = componentName,componentVersionName,licenseSummary,issueSummary,isVulnerable
-fcli.fod.oss-scan.oss-components.output.table.args = componentName,componentVersionName,licenseSummary,issueSummary,isVulnerable
 fcli.fod.entitlement.output.table.args = entitlementId,entitlementDescription,startDate,endDate,unitInfo
 fcli.fod.*-scan.output.table.args = scanId,analysisStatusType,applicationName,microserviceName,releaseName,startedDateTime,completedDateTime,scanMethodTypeName
 fcli.fod.*-scan-import.output.table.args = importScanSessionId,applicationName,microserviceName,releaseName,scanType
@@ -995,5 +998,5 @@ fcli.fod.session.output.table.args = name,type,url,created,expires,expired
 fcli.fod.rest.lookup.output.table.args = group,text,value
 fcli.fod.report.output.table.args = reportId,reportName,reportStatusType,reportType
 fcli.fod.report.report-template.output.table.args = value,text,group
-fcli.fod.issue.list.output.table.args = vulnId,visibilityMarker,severityString,location,category
+fcli.fod.issue.list.output.table.args = instanceId,visibilityMarker,severityString,category,location,foundInReleases
 fcli.fod.issue.update.output.table.args = issueCount,errorCount

--- a/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
+++ b/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
@@ -895,6 +895,7 @@ fcli.fod.issue.list.usage.description = This command allows for listing FoD vuln
   can use a query like --filters-param "severityString:Critical" or --query "severityString='Critical'".
 fcli.fod.issue.list.output.table.header.visibilityMarker =
 fcli.fod.issue.list.output.table.header.foundInReleases = Releases
+fcli.fod.issue.list.output.table.header.foundInReleasesString = Releases
 fcli.fod.issue.embed = Embed extra issue data. Due to FoD rate limits, this may significantly \
   affect performance. Allowed values: ${COMPLETION-CANDIDATES}. \
   Using the --output option, this extra data can be included in the output. Using the --query option, \
@@ -998,5 +999,5 @@ fcli.fod.session.output.table.args = name,type,url,created,expires,expired
 fcli.fod.rest.lookup.output.table.args = group,text,value
 fcli.fod.report.output.table.args = reportId,reportName,reportStatusType,reportType
 fcli.fod.report.report-template.output.table.args = value,text,group
-fcli.fod.issue.list.output.table.args = instanceId,visibilityMarker,severityString,category,location,foundInReleases
+fcli.fod.issue.list.output.table.args = instanceId,visibilityMarker,severityString,category,location,foundInReleasesString
 fcli.fod.issue.update.output.table.args = issueCount,errorCount


### PR DESCRIPTION
Updated `fcli fod issue ls` command to provide support for issue level operations (#596). 
Also fixed (#820) where no "fixed" issues where being shown.

The command now takes either `--release` or `--application` option with default table output as follows:

```
Instance id                          Severity       Category                                                    Location                                                                        Releases 
0B52EF0DB2EDADFF1E21D45BB4D343DA     Critical       Command Injection                                           insecure_routes.py:86                                                           main     
36E7D78C6B2C00649297F4A77A94F75E     Critical       Cross-Site Scripting: Reflected                             insecure_routes.py:62                                                           main     
71C3F7CC17A10A1439EAD25620489D56     Critical       Cross-Site Scripting: Reflected                             insecure_routes.py:110                                                          main     
04B6D2FB51E81842EA14026B7F71872C     Critical       Cross-Site Scripting: Reflected                             insecure_routes.py:110                                                          main
```

I have chosen to change default first column of "Instance Id" rather than "Vuln Id" is this is consistent where the issue is across multiple releases. Also added a "release" column to indicate the release in which the issue is. When a Application is queried we will not get something like:

```
 Instance id                               Severity       Category                                                    Location                                                                        Releases                                             
0B52EF0DB2EDADFF1E21D45BB4D343DA          Critical       Command Injection                                           insecure_routes.py:86                                                           main                                                 
B094D58AC5667BBFB2E825A9D43A3111  (F)     Critical       Command Injection                                           routes.py:68                                                                    bootstrap-upgrade,merge-to-main#PR4,main,develop     
B93A760A71D82F7DDC74E1E7FAAD21BC  (F)     Critical       Command Injection                                           InsecureRoutes.py:45                                                            main                                                 
8A3DAF56B3280FF7D28E55897014BF20  (F)     Critical       Command Injection                                           routes.py:48                                                                    bootstrap-upgrade,main
```

In terms of additional JSON fields, the following have been added which a use can utilize as they see fit:

```
...
  "releaseName" : "main",
  "issueUrl" : "https://emea.fortify.com/redirect/Issues/42817385",
  "vulnIds" : "f557af8c-4bec-4bc6-9c33-542060b16647",
  "foundInReleases" : "main",
  "foundInReleaseIds" : "162788",
  "ids" : "42817385",
  "location" : "insecure_routes.py:86",
  "visibility" : "visible",
  "visibilityMarker" : " "
} ]
```

Since querying at the issue level can be an expensive operation - the description documentation has been updated accordingly.