### PR TITLE
fcli * rest call: Optionally add default prefix

### DIFF
--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/rest/cli/cmd/AbstractRestCallCommand.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/rest/cli/cmd/AbstractRestCallCommand.java
@@ -128,12 +128,17 @@ public abstract class AbstractRestCallCommand extends AbstractOutputCommand impl
         return applyOnProductHelper(INextPageUrlProducerSupplier.class, s->s.getNextPageUrlProducer(), null);
     }
 
+    protected String formatUri(String uri) {
+        return uri;
+    }
+
     @SneakyThrows
     protected final HttpRequest<?> prepareRequest(UnirestInstance unirest) {
         if ( StringUtils.isBlank(uri) ) {
             throw new FcliSimpleException("Uri must be specified");
         }
-        HttpRequest<?> request = unirest.request(httpMethod, uri);
+        String processedUri = formatUri(uri);
+        HttpRequest<?> request = unirest.request(httpMethod, processedUri);
         if ( StringUtils.isNotBlank(data) ) {
             if ( "GET".equals(httpMethod) || !(request instanceof HttpRequestWithBody) ) {
                 throw new FcliSimpleException("Request body not supported for "+httpMethod+" requests");

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/rest/cli/cmd/SSCRestCallCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/rest/cli/cmd/SSCRestCallCommand.java
@@ -34,10 +34,17 @@ public final class SSCRestCallCommand extends AbstractRestCallCommand {
     @Getter private final SSCProductHelper productHelper = SSCProductHelper.INSTANCE;
 
     @Override
-    protected String formatUri(String uri) {
-        if (uri != null && !uri.startsWith("/api/v1")) {
-            return "/api/v1" + uri;
-        }
-        return uri;
-    }
+	protected String formatUri(String uri) {
+		if (uri == null || uri.isBlank()) {
+			return uri;
+		}
+		if (!uri.startsWith("/")) {
+			uri = "/" + uri;
+		}
+		if (!uri.startsWith("/api/v1")) {
+			uri = "/api/v1" + uri;
+		}
+		return uri;
+	}
+
 }

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/rest/cli/cmd/SSCRestCallCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/rest/cli/cmd/SSCRestCallCommand.java
@@ -19,6 +19,9 @@ import com.fortify.cli.common.util.DisableTest.TestType;
 import com.fortify.cli.ssc._common.rest.ssc.cli.mixin.SSCUnirestInstanceSupplierMixin;
 import com.fortify.cli.ssc._common.rest.ssc.helper.SSCProductHelper;
 
+import kong.unirest.HttpRequest;
+import kong.unirest.UnirestInstance;
+
 import lombok.Getter;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
@@ -29,4 +32,12 @@ public final class SSCRestCallCommand extends AbstractRestCallCommand {
     @Getter @Mixin private OutputHelperMixins.RestCall outputHelper;
     @Getter @Mixin private SSCUnirestInstanceSupplierMixin unirestInstanceSupplier;
     @Getter private final SSCProductHelper productHelper = SSCProductHelper.INSTANCE;
+
+    @Override
+    protected String formatUri(String uri) {
+        if (uri != null && !uri.startsWith("/api/v1")) {
+            return "/api/v1" + uri;
+        }
+        return uri;
+    }
 }


### PR DESCRIPTION
Added automatic /api/v1 prefix handling for SSC REST call commands.
