### PR TITLE
fix: Prevent null addition error in bulkaudit action

### DIFF
--- a/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/actions/zip/bulkaudit.yaml
+++ b/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/actions/zip/bulkaudit.yaml
@@ -216,6 +216,7 @@ steps:
           stats.create_successes: 0
           stats.create_failures: 0
           stats.audit_attempts: 0
+          stats.audit_failures: 0
           stats.entitlement_exhausted: false
           stats.create_skipped_due_to_entitlement: 0
 


### PR DESCRIPTION
MR fixes a null increment error in `bulkaudit.yaml` by initializing `stats.audit_failures` to zero, ensuring audit failure statistics are tracked reliably during bulk SAST Aviator audits.