### PR TITLE
Incorrect logger instances

### DIFF
--- a/fcli-core/fcli-app/src/main/java/com/fortify/cli/app/runner/util/FortifyCLIStaticInitializer.java
+++ b/fcli-core/fcli-app/src/main/java/com/fortify/cli/app/runner/util/FortifyCLIStaticInitializer.java
@@ -18,8 +18,8 @@ import java.nio.file.Paths;
 import java.util.Locale;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fortify.cli.common.http.ssl.truststore.helper.TrustStoreConfigDescriptor;
 import com.fortify.cli.common.http.ssl.truststore.helper.TrustStoreConfigHelper;
@@ -38,7 +38,7 @@ import lombok.NoArgsConstructor;
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class FortifyCLIStaticInitializer {
-    private final Log log = LogFactory.getLog(getClass());
+    private final Logger log = LoggerFactory.getLogger(getClass());
     @Getter(lazy = true)
     private static final FortifyCLIStaticInitializer instance = new FortifyCLIStaticInitializer(); 
     

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/rest/helper/FoDRetryStrategy.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/rest/helper/FoDRetryStrategy.java
@@ -12,8 +12,8 @@
  */
 package com.fortify.cli.fod._common.rest.helper;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.ServiceUnavailableRetryStrategy;
 import org.apache.http.protocol.HttpContext;
@@ -24,7 +24,7 @@ import org.apache.http.protocol.HttpContext;
  * response.
  */
 public final class FoDRetryStrategy implements ServiceUnavailableRetryStrategy {
-    private static final Log LOG = LogFactory.getLog(FoDRetryStrategy.class);
+    private static final Logger LOG = LoggerFactory.getLogger(FoDRetryStrategy.class);
     private final String HEADER_NAME = "X-Rate-Limit-Reset";
     private int maxRetries = 2;
     private final ThreadLocal<Long> interval = new ThreadLocal<Long>();

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/rest/helper/FoDRetryStrategy.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/rest/helper/FoDRetryStrategy.java
@@ -12,11 +12,11 @@
  */
 package com.fortify.cli.fod._common.rest.helper;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.ServiceUnavailableRetryStrategy;
 import org.apache.http.protocol.HttpContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class implements an Apache HttpClient 4.x {@link ServiceUnavailableRetryStrategy}

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/cli/cmd/AbstractFoDScanSetupCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/cli/cmd/AbstractFoDScanSetupCommand.java
@@ -12,8 +12,8 @@
  */
 package com.fortify.cli.fod._common.scan.cli.cmd;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -30,7 +30,7 @@ import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 
 public abstract class AbstractFoDScanSetupCommand<T> extends AbstractFoDJsonNodeOutputCommand implements IActionCommandResultSupplier {
-    private static final Log LOG = LogFactory.getLog(AbstractFoDScanSetupCommand.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractFoDScanSetupCommand.class);
     @Mixin protected FoDDelimiterMixin delimiterMixin; // Is automatically injected in resolver mixins
     @Mixin protected FoDReleaseByQualifiedNameOrIdResolverMixin.RequiredOption releaseResolver;
     @Mixin protected CommonOptionMixins.SkipIfExistsOption skipIfExistsOption;

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/FoDScanHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/FoDScanHelper.java
@@ -18,8 +18,8 @@ import java.util.Calendar;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -47,7 +47,7 @@ public class FoDScanHelper {
     @Getter
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
-    private static final Log LOG = LogFactory.getLog(FoDScanHelper.class);
+    private static final Logger LOG = LoggerFactory.getLogger(FoDScanHelper.class);
 
 
     // max retention period (in years) of FPRs

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/AbstractFoDDastAutomatedScanSetupCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/AbstractFoDDastAutomatedScanSetupCommand.java
@@ -15,8 +15,8 @@ package com.fortify.cli.fod.dast_scan.cli.cmd;
 import java.util.ArrayList;
 import java.util.Objects;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -39,7 +39,7 @@ import lombok.Getter;
 import picocli.CommandLine.Mixin;
 
 public abstract class AbstractFoDDastAutomatedScanSetupCommand extends AbstractFoDScanSetupCommand<FoDScanConfigDastAutomatedDescriptor> {
-    private static final Log LOG = LogFactory.getLog(AbstractFoDDastAutomatedScanSetupCommand.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractFoDDastAutomatedScanSetupCommand.class);
     @Getter private static final ObjectMapper objectMapper = new ObjectMapper();
 
     @Mixin

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/FoDDastAutomatedScanSetupApiCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/FoDDastAutomatedScanSetupApiCommand.java
@@ -15,8 +15,8 @@ package com.fortify.cli.fod.dast_scan.cli.cmd;
 import java.util.ArrayList;
 import java.util.Collections;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -43,7 +43,7 @@ import picocli.CommandLine.Option;
 @Command(name = FoDOutputHelperMixins.SetupApi.CMD_NAME)
 @CommandGroup("*-scan-setup")
 public class FoDDastAutomatedScanSetupApiCommand extends AbstractFoDDastAutomatedScanSetupCommand {
-    private static final Log LOG = LogFactory.getLog(FoDDastAutomatedScanSetupApiCommand.class);
+    private static final Logger LOG = LoggerFactory.getLogger(FoDDastAutomatedScanSetupApiCommand.class);
     @Getter @Mixin private FoDOutputHelperMixins.SetupWorkflow outputHelper;
 
     @Option(names = {"--type"}, required = true)

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/FoDDastAutomatedScanSetupWebsiteCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/FoDDastAutomatedScanSetupWebsiteCommand.java
@@ -15,8 +15,8 @@ package com.fortify.cli.fod.dast_scan.cli.cmd;
 import java.util.ArrayList;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -41,7 +41,7 @@ import picocli.CommandLine.Option;
 
 @Command(name = FoDOutputHelperMixins.SetupWebsite.CMD_NAME) @CommandGroup("*-scan-setup")
 public class FoDDastAutomatedScanSetupWebsiteCommand extends AbstractFoDDastAutomatedScanSetupCommand {
-    private static final Log LOG = LogFactory.getLog(FoDDastAutomatedScanSetupWebsiteCommand.class);
+    private static final Logger LOG = LoggerFactory.getLogger(FoDDastAutomatedScanSetupWebsiteCommand.class);
     @Getter @Mixin private FoDOutputHelperMixins.SetupWebsite outputHelper;
     private final static FoDEnums.DastAutomatedFileTypes dastFileType = FoDEnums.DastAutomatedFileTypes.LoginMacro;
 

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/FoDDastAutomatedScanSetupWorkflowCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/FoDDastAutomatedScanSetupWorkflowCommand.java
@@ -14,8 +14,8 @@ package com.fortify.cli.fod.dast_scan.cli.cmd;
 
 import java.util.ArrayList;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -41,7 +41,7 @@ import picocli.CommandLine.Option;
 
 @Command(name = FoDOutputHelperMixins.SetupWorkflow.CMD_NAME) @CommandGroup("*-scan-setup")
 public class FoDDastAutomatedScanSetupWorkflowCommand extends AbstractFoDDastAutomatedScanSetupCommand {
-    private static final Log LOG = LogFactory.getLog(FoDDastAutomatedScanSetupWorkflowCommand.class);
+    private static final Logger LOG = LoggerFactory.getLogger(FoDDastAutomatedScanSetupWorkflowCommand.class);
     @Getter @Mixin private FoDOutputHelperMixins.SetupWorkflow outputHelper;
     private final static FoDEnums.DastAutomatedFileTypes dastFileType = FoDEnums.DastAutomatedFileTypes.WorkflowDrivenMacro;
 

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/FoDDastLegacyScanStartCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/cli/cmd/FoDDastLegacyScanStartCommand.java
@@ -18,8 +18,8 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fortify.cli.common.exception.FcliSimpleException;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
@@ -49,7 +49,7 @@ import picocli.CommandLine.Option;
 
 @Command(name = FoDOutputHelperMixins.StartLegacy.CMD_NAME, hidden = true)
 public class FoDDastLegacyScanStartCommand extends AbstractFoDScanStartCommand {
-    private static final Log LOG = LogFactory.getLog(FoDDastLegacyScanStartCommand.class);
+    private static final Logger LOG = LoggerFactory.getLogger(FoDDastLegacyScanStartCommand.class);
     DateTimeFormatter dtf = DateTimeFormatter.ofPattern("MM/dd/yyyy HH:mm");
 
     @Getter @Mixin private OutputHelperMixins.Start outputHelper;

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/mast_scan/cli/cmd/FoDMastScanSetupCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/mast_scan/cli/cmd/FoDMastScanSetupCommand.java
@@ -15,8 +15,8 @@ package com.fortify.cli.fod.mast_scan.cli.cmd;
 import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -47,7 +47,7 @@ import picocli.CommandLine.Option;
 @Command(name = OutputHelperMixins.Setup.CMD_NAME, hidden = false) @CommandGroup("*-scan-setup")
 @DisableTest(TestType.CMD_DEFAULT_TABLE_OPTIONS_PRESENT)
 public class FoDMastScanSetupCommand extends AbstractFoDScanSetupCommand<FoDScanConfigMobileDescriptor> implements IRecordTransformer, IActionCommandResultSupplier {
-    private static final Log LOG = LogFactory.getLog(FoDMastScanSetupCommand.class);
+    private static final Logger LOG = LoggerFactory.getLogger(FoDMastScanSetupCommand.class);
     DateTimeFormatter dtf = DateTimeFormatter.ofPattern("MM/dd/yyyy HH:mm");
     @Getter @Mixin private OutputHelperMixins.Start outputHelper;
 

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/mast_scan/cli/cmd/FoDMastScanStartCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/mast_scan/cli/cmd/FoDMastScanStartCommand.java
@@ -17,8 +17,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fortify.cli.common.cli.mixin.CommonOptionMixins;
 import com.fortify.cli.common.exception.FcliSimpleException;
@@ -48,7 +48,7 @@ import picocli.CommandLine.Option;
 
 @Command(name = OutputHelperMixins.Start.CMD_NAME)
 public class FoDMastScanStartCommand extends AbstractFoDScanStartCommand {
-    private static final Log LOG = LogFactory.getLog(FoDMastScanStartCommand.class);
+    private static final Logger LOG = LoggerFactory.getLogger(FoDMastScanStartCommand.class);
     DateTimeFormatter dtf = DateTimeFormatter.ofPattern("MM/dd/yyyy HH:mm");
 
     @Getter @Mixin private OutputHelperMixins.Start outputHelper;

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/oss_scan/cli/cmd/FoDOssComponentsListCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/oss_scan/cli/cmd/FoDOssComponentsListCommand.java
@@ -17,8 +17,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -46,7 +46,7 @@ import picocli.CommandLine.Option;
 @Command(name = "list-components", aliases = "lsc")
 @CommandGroup("oss-components")
 public final class FoDOssComponentsListCommand extends AbstractFoDJsonNodeOutputCommand {
-    private static final Log LOG = LogFactory.getLog(FoDOssComponentsListCommand.class);
+    private static final Logger LOG = LoggerFactory.getLogger(FoDOssComponentsListCommand.class);
     @Getter
     @Mixin
     private OutputHelperMixins.TableWithQuery outputHelper;

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/release/cli/cmd/FoDReleaseCreateCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/release/cli/cmd/FoDReleaseCreateCommand.java
@@ -17,8 +17,8 @@ import static com.fortify.cli.common.util.DisableTest.TestType.MULTI_OPT_PLURAL_
 import java.util.ArrayList;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -59,7 +59,7 @@ import picocli.CommandLine.Option;
 
 @Command(name = OutputHelperMixins.Create.CMD_NAME)
 public class FoDReleaseCreateCommand extends AbstractFoDJsonNodeOutputCommand implements IRecordTransformer, IActionCommandResultSupplier {
-    private static final Log LOG = LogFactory.getLog(FoDReleaseCreateCommand.class);
+    private static final Logger LOG = LoggerFactory.getLogger(FoDReleaseCreateCommand.class);
     @Getter @Mixin private OutputHelperMixins.Create outputHelper;
     @Mixin private FoDDelimiterMixin delimiterMixin; // Is automatically injected in resolver mixins
     @Mixin private FoDReleaseByQualifiedNameResolverMixin.PositionalParameter releaseNameResolver;

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/release/helper/FoDReleaseAssessmentTypeHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/release/helper/FoDReleaseAssessmentTypeHelper.java
@@ -16,8 +16,8 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -34,7 +34,7 @@ import kong.unirest.UnirestInstance;
 import lombok.Getter;
 
 public final class FoDReleaseAssessmentTypeHelper {
-    private static final Log LOG = LogFactory.getLog(FoDReleaseAssessmentTypeHelper.class);
+    private static final Logger LOG = LoggerFactory.getLogger(FoDReleaseAssessmentTypeHelper.class);
     @Getter
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private FoDReleaseAssessmentTypeHelper() {}

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/release/helper/FoDReleaseHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/release/helper/FoDReleaseHelper.java
@@ -18,8 +18,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -41,7 +41,7 @@ import kong.unirest.UnirestInstance;
 import lombok.Getter;
 
 public class FoDReleaseHelper {
-    private static final Log LOG = LogFactory.getLog(FoDReleaseHelper.class);
+    private static final Logger LOG = LoggerFactory.getLogger(FoDReleaseHelper.class);
     @Getter private static ObjectMapper objectMapper = new ObjectMapper();
 
     private static String[] defaultFields = {"releaseId", "releaseName", "applicationName", "microserviceName"};

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/cli/cmd/FoDSastScanSetupCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/cli/cmd/FoDSastScanSetupCommand.java
@@ -14,8 +14,8 @@ package com.fortify.cli.fod.sast_scan.cli.cmd;
 
 import java.util.Objects;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -51,7 +51,7 @@ import picocli.CommandLine.Option;
 @Command(name = OutputHelperMixins.Setup.CMD_NAME, hidden = false) @CommandGroup("*-scan-setup")
 @DisableTest(TestType.CMD_DEFAULT_TABLE_OPTIONS_PRESENT)
 public class FoDSastScanSetupCommand extends AbstractFoDScanSetupCommand<FoDScanConfigSastDescriptor> implements IRecordTransformer {
-    private static final Log LOG = LogFactory.getLog(FoDSastScanSetupCommand.class);
+    private static final Logger LOG = LoggerFactory.getLogger(FoDSastScanSetupCommand.class);
     @Getter @Mixin private OutputHelperMixins.Setup outputHelper;
 
     @Option(names = {"--technology-stack"}, required = true, defaultValue = "Auto Detect")


### PR DESCRIPTION
This PR replaces all usages of org.apache.commons.logging.Log and LogFactory with org.slf4j.Logger and LoggerFactory in the fcli-fod module.

**fix: Migrate from commons-logging to SLF4j for logging consistency**

