### PR TITLE
fix: resolve hash inconsistency in remediation file hash generation

### DIFF
--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/utils/FileUtils.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/utils/FileUtils.java
@@ -14,6 +14,7 @@ package com.fortify.cli.aviator.fpr.utils;
 
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -44,7 +45,7 @@ public class FileUtils {
         return fileContentCache.computeIfAbsent(filePath, path -> {
             try {
                 byte[] fileBytes = Files.readAllBytes(path);
-                String content = new String(fileBytes);
+                String content = new String(fileBytes, StandardCharsets.UTF_8);
                 return Arrays.asList(content.split("\\r?\\n"));
             } catch (IOException e) {
                 logger.error("Failed to read file: {}", path, e);


### PR DESCRIPTION
Fixes an issue where SHA-256 file hashes were inconsistent when running the same code on different JDK distributions/ build on different platforms

The `FileUtils.readFileWithFallback()` method was using new `String(fileBytes)` without explicitly specifying a charset. This relied on the platform default charset, which differs between JDK distributions and operating systems