### PR TITLE
fix(aviator): correct filtering logic to prevent valid issues from being skipped during audit

### DIFF
--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/IssueAuditor.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/IssueAuditor.java
@@ -28,7 +28,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,8 +43,8 @@ import com.fortify.cli.aviator.fpr.Vulnerability;
 import com.fortify.cli.aviator.fpr.filter.Filter;
 import com.fortify.cli.aviator.fpr.filter.FilterSet;
 import com.fortify.cli.aviator.fpr.filter.FolderDefinition;
-import com.fortify.cli.aviator.fpr.filter.SearchTree;
 import com.fortify.cli.aviator.fpr.filter.TagDefinition;
+import com.fortify.cli.aviator.fpr.filter.VulnerabilityFilterer;
 import com.fortify.cli.aviator.fpr.model.AuditIssue;
 import com.fortify.cli.aviator.fpr.model.FPRInfo;
 import com.fortify.cli.aviator.fpr.processor.AuditProcessor;
@@ -279,51 +278,55 @@ public class IssueAuditor {
         }
         return false;
     }
+
     private List<Vulnerability> filterVulnerabilities(List<Vulnerability> allVulnerabilities, FilterSet fs) {
         List<String> targetFolderNames = filterSelection.getTargetFolderNames();
 
         List<Filter> folderFilters = fs.getFilters().stream()
-                .filter(f -> "setFolder".equalsIgnoreCase(f.getAction())).collect(Collectors.toList());
-        List<Filter> hideFilters = fs.getFilters().stream()
-                .filter(f -> "hide".equalsIgnoreCase(f.getAction())).collect(Collectors.toList());
+            .filter(f -> "setFolder".equalsIgnoreCase(f.getAction()))
+            .collect(Collectors.toList());
 
-        Map<Filter, SearchTree> parsedQueries = new HashMap<>();
-        // Use a stream to populate the map
-        Stream.concat(folderFilters.stream(), hideFilters.stream()).forEach(f -> {
-            try {
-                parsedQueries.put(f, com.fortify.cli.aviator.fpr.filter.engine.FilterParser.parse(f.getQuery()));
-            } catch (Exception e) {
-                LOG.error("Failed to parse filter query: '{}'. This filter will be skipped.", f.getQuery(), e);
-                parsedQueries.put(f, new com.fortify.cli.aviator.fpr.filter.SearchTree(null));
-            }
-        });
+        List<Filter> hideFilters = fs.getFilters().stream()
+            .filter(f -> "hide".equalsIgnoreCase(f.getAction()))
+            .collect(Collectors.toList());
 
         Map<String, List<Vulnerability>> folderContents = new HashMap<>();
-        for (Vulnerability vuln : allVulnerabilities) {
+
+        // 1. Process "setFolder" filters
+        if (folderFilters.isEmpty()) {
+            folderContents.put("Default", new ArrayList<>(allVulnerabilities));
+        } else {
             for (Filter folderFilter : folderFilters) {
-                if (com.fortify.cli.aviator.fpr.filter.engine.VulnerabilityEvaluator.evaluate(parsedQueries.get(folderFilter), vuln)) {
-                    folderContents.computeIfAbsent(folderFilter.getActionParam(), k -> new ArrayList<>()).add(vuln);
-                    break;
+                List<Vulnerability> matches = VulnerabilityFilterer.filter(allVulnerabilities, folderFilter.getQuery());
+                folderContents.computeIfAbsent(folderFilter.getActionParam(), k -> new ArrayList<>()).addAll(matches);
+            }
+        }
+
+        // 2. Process "hide" filters
+        for (Filter hideFilter : hideFilters) {
+            for (List<Vulnerability> folderList : folderContents.values()) {
+                if (folderList.isEmpty()) continue;
+
+                List<Vulnerability> toHide = VulnerabilityFilterer.filter(folderList, hideFilter.getQuery());
+                if (!toHide.isEmpty()) {
+                    folderList.removeAll(toHide);
                 }
             }
         }
 
-        folderContents.values().forEach(vulnList ->
-                vulnList.removeIf(vuln -> hideFilters.stream().anyMatch(
-                        hideFilter -> com.fortify.cli.aviator.fpr.filter.engine.VulnerabilityEvaluator.evaluate(parsedQueries.get(hideFilter), vuln)
-                ))
-        );
-
+        // 3. Selection Logic (Flatten all or select specific folders)
         if (!filterSelection.isFilteringByFolder()) {
-            List<Vulnerability> result = folderContents.values().stream().flatMap(List::stream).collect(Collectors.toList());
+            List<Vulnerability> result = folderContents.values().stream()
+                .flatMap(List::stream)
+                .distinct()
+                .collect(Collectors.toList());
             logger.info("FilterSet '{}' applied. {} of {} total vulnerabilities remain.", fs.getTitle(), result.size(), allVulnerabilities.size());
             return result;
         } else {
-            // This logic correctly finds folder IDs based on user-provided names.
             Set<String> targetFolderIds = fs.getFolderDefinitions().stream()
-                    .filter(fd -> targetFolderNames.stream().anyMatch(name -> name.equalsIgnoreCase(fd.getName())))
-                    .map(FolderDefinition::getId)
-                    .collect(Collectors.toSet());
+                .filter(fd -> targetFolderNames.stream().anyMatch(name -> name.equalsIgnoreCase(fd.getName())))
+                .map(FolderDefinition::getId)
+                .collect(Collectors.toSet());
 
             if (targetFolderIds.isEmpty()) {
                 String available = fs.getFolderDefinitions().stream().map(FolderDefinition::getName).collect(Collectors.joining("', '", "'", "'"));
@@ -331,54 +334,13 @@ public class IssueAuditor {
             }
 
             List<Vulnerability> result = folderContents.entrySet().stream()
-                    .filter(entry -> targetFolderIds.contains(entry.getKey()))
-                    .flatMap(entry -> entry.getValue().stream())
-                    .collect(Collectors.toList());
+                .filter(entry -> targetFolderIds.contains(entry.getKey()))
+                .flatMap(entry -> entry.getValue().stream())
+                .distinct()
+                .collect(Collectors.toList());
 
             logger.info("Filtered by folder(s) '{}'. {} vulnerabilities remain.", targetFolderNames, result.size());
             return result;
-        }
-    }
-
-    private void updateSkippedIssue(UserPrompt userPrompt, String reasonTemplate, int issuesInCategory, int totalIssues) {
-        if (userPrompt == null || userPrompt.getIssueData() == null) {
-            LOG.error("Cannot update skipped issue status for null userPrompt or issue data.");
-            return;
-        }
-        String instanceId = userPrompt.getIssueData().getInstanceID();
-        AuditIssue auditIssue = auditIssueMap.get(instanceId);
-
-        String comment = reasonTemplate
-                .replace("{issues_new_in_category}", String.valueOf(issuesInCategory))
-                .replace("{MAX_PER_CATEGORY}", String.valueOf(MAX_PER_CATEGORY))
-                .replace("{issues_new_total}", String.valueOf(totalIssues))
-                .replace("{MAX_TOTAL}", String.valueOf(MAX_TOTAL));
-
-        if (auditIssue != null) {
-            LOG.debug("Updating existing audit entry for skipped issue: {}", instanceId);
-            try {
-                auditProcessor.addCommentToIssueXml(instanceId, comment, Constants.USER_NAME);
-            } catch (Exception e) {
-                LOG.error("Failed to add comment to XML for skipped issue {}: {}", instanceId, e.getMessage());
-            }
-
-            auditProcessor.updateIssueTag(auditIssue, Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR);
-
-            Map<String, String> tags = auditIssue.getTags();
-            String currentAnalysisStatus = tags.get(Constants.ANALYSIS_TAG_ID);
-            if (currentAnalysisStatus == null || currentAnalysisStatus.isEmpty() || "Not Set".equalsIgnoreCase(currentAnalysisStatus)) {
-                auditProcessor.updateIssueTag(auditIssue, Constants.ANALYSIS_TAG_ID, Constants.PENDING_REVIEW);
-                LOG.debug("Set Analysis tag to Pending Review for skipped issue: {}", instanceId);
-            } else {
-                LOG.debug("Skipped issue {} already has Analysis status '{}', not changing.", instanceId, currentAnalysisStatus);
-            }
-
-        } else {
-            try {
-                auditProcessor.addSkippedIssueElement(instanceId, comment);
-            } catch (Exception e) {
-                LOG.error("Failed to add skipped issue element to audit.xml for {}: {}", instanceId, e.getMessage());
-            }
         }
     }
 }

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/utils/FileUtils.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/utils/FileUtils.java
@@ -14,6 +14,7 @@ package com.fortify.cli.aviator.fpr.utils;
 
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -44,7 +45,7 @@ public class FileUtils {
         return fileContentCache.computeIfAbsent(filePath, path -> {
             try {
                 byte[] fileBytes = Files.readAllBytes(path);
-                String content = new String(fileBytes);
+                String content = new String(fileBytes, StandardCharsets.UTF_8);
                 return Arrays.asList(content.split("\\r?\\n"));
             } catch (IOException e) {
                 logger.error("Failed to read file: {}", path, e);

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/audit/IssueAuditorTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/audit/IssueAuditorTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2021-2025 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.aviator.audit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fortify.cli.aviator.audit.model.FilterSelection;
+import com.fortify.cli.aviator.config.IAviatorLogger;
+import com.fortify.cli.aviator.fpr.Vulnerability;
+import com.fortify.cli.aviator.fpr.filter.Filter;
+import com.fortify.cli.aviator.fpr.filter.FilterSet;
+import com.fortify.cli.aviator.fpr.filter.FilterTemplate;
+import com.fortify.cli.aviator.fpr.model.FPRInfo;
+import com.fortify.cli.aviator.util.FprHandle;
+
+
+class IssueAuditorTest {
+
+    private Path tempFprFile;
+    private FprHandle fprHandle;
+
+    @BeforeEach
+    void setup() throws IOException {
+        // 1. Create a temporary dummy FPR file (ZIP format)
+        tempFprFile = Files.createTempFile("test_aviator", ".fpr");
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(tempFprFile))) {
+
+            // A. Add a minimal audit.fvdl
+            ZipEntry entry = new ZipEntry("audit.fvdl");
+            zos.putNextEntry(entry);
+            String minimalXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><FVDL><UUID>test-uuid</UUID><Build><BuildID>test-build</BuildID></Build></FVDL>";
+            zos.write(minimalXml.getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+
+            // B. Add src-archive/index.xml to suppress the warning
+            ZipEntry indexEntry = new ZipEntry("src-archive/index.xml");
+            zos.putNextEntry(indexEntry);
+            String indexXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><index></index>";
+            zos.write(indexXml.getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
+        fprHandle = new FprHandle(tempFprFile);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        if (fprHandle != null) {
+            fprHandle.close();
+        }
+        if (tempFprFile != null) {
+            Files.deleteIfExists(tempFprFile);
+        }
+    }
+
+    @Test
+    void testFilterVulnerabilities_LegacySyntaxWithSpaces() throws Exception {
+
+        // Manual Logger Stub (No-op)
+        IAviatorLogger dummyLogger = new IAviatorLogger() {
+            @Override public void progress(String format, Object... args) {}
+            @Override public void info(String format, Object... args) {}
+            @Override public void warn(String format, Object... args) {}
+            @Override public void error(String format, Object... args) {}
+        };
+
+        FPRInfo fprInfo = new FPRInfo(fprHandle);
+
+        FilterTemplate dummyTemplate = new FilterTemplate();
+        dummyTemplate.setTagDefinitions(new ArrayList<>());
+        // Note: FPRInfo.setFilterTemplate() exists in the provided code
+        fprInfo.setFilterTemplate(dummyTemplate);
+
+        // --- 2. SETUP FILTER SET WITH LEGACY SYNTAX ---
+        // The "Buggy" Filter String (Legacy syntax: Space in range AND between terms)
+        String legacyQuery = "impact:![2.5, 5.0] [Analysis Type]:!SONATYPE";
+
+        Filter filter = new Filter();
+        filter.setAction("hide");
+        filter.setQuery(legacyQuery);
+
+        FilterSet filterSet = new FilterSet();
+        filterSet.setTitle("Regression Test Set");
+        filterSet.setFilters(Collections.singletonList(filter));
+
+        FilterSelection selection = new FilterSelection(filterSet, null);
+
+        // Target Issue: High Impact (4.0), Null Analysis Type.
+        // Result: Should NOT be hidden.
+        Vulnerability targetVuln = new Vulnerability();
+        targetVuln.setInstanceID("TARGET_ISSUE");
+        targetVuln.setImpact(4.0);
+
+        // Noise Issue: Low Impact (1.0).
+        // Result: Should be hidden.
+        Vulnerability hiddenVuln = new Vulnerability();
+        hiddenVuln.setInstanceID("HIDDEN_ISSUE");
+        hiddenVuln.setImpact(1.0);
+
+        List<Vulnerability> inputList = Arrays.asList(targetVuln, hiddenVuln);
+
+        IssueAuditor auditor = new IssueAuditor(
+            inputList, null, new HashMap<>(), fprInfo,
+            "TestApp", "1.0", selection, dummyLogger
+        );
+
+        Method filterMethod = IssueAuditor.class.getDeclaredMethod("filterVulnerabilities", List.class, FilterSet.class);
+        filterMethod.setAccessible(true);
+
+        @SuppressWarnings("unchecked")
+        List<Vulnerability> results = (List<Vulnerability>) filterMethod.invoke(auditor, inputList, filterSet);
+
+        List<String> remainingIds = results.stream()
+            .map(Vulnerability::getInstanceID)
+            .collect(Collectors.toList());
+
+        assertEquals(1, remainingIds.size(), "Should verify that exactly one issue remains");
+        assertTrue(remainingIds.contains("TARGET_ISSUE"),
+            "Regression Failed: IssueAuditor hid the target issue. It likely used the Modern parser on a Legacy query string.");
+    }
+}

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/filter/comparer/BooleanComparerTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/filter/comparer/BooleanComparerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021-2025 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.aviator.filter.comparer;
+
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.fortify.cli.aviator.fpr.filter.comparer.BooleanComparer;
+import com.fortify.cli.aviator.fpr.filter.comparer.ContainsSearchComparer;
+import com.fortify.cli.aviator.fpr.filter.comparer.IsNotSearchComparer;
+
+class BooleanComparerTest {
+
+    @Test
+    void testOnlyPositiveConditions_OR_Logic() {
+        BooleanComparer comparer = new BooleanComparer();
+        comparer.addComparer(new ContainsSearchComparer("apple"));
+        comparer.addComparer(new ContainsSearchComparer("banana"));
+
+        assertTrue(comparer.matches("apple pie"), "Should match 'apple'");
+        assertTrue(comparer.matches("banana bread"), "Should match 'banana'");
+        assertFalse(comparer.matches("cherry tart"), "Should not match 'cherry'");
+    }
+
+    @Test
+    void testOnlyNegativeConditions_AND_Logic() {
+        BooleanComparer comparer = new BooleanComparer();
+        comparer.addComparer(new IsNotSearchComparer(new ContainsSearchComparer("apple")));
+        comparer.addComparer(new IsNotSearchComparer(new ContainsSearchComparer("banana")));
+
+        assertTrue(comparer.matches("cherry tart"), "Should match because it's not apple and not banana");
+        assertFalse(comparer.matches("apple pie"), "Should fail because it contains 'apple'");
+        assertFalse(comparer.matches("banana bread"), "Should fail because it contains 'banana'");
+    }
+
+    @Test
+    void testMixedConditions_PositiveAndNegative() {
+        BooleanComparer comparer = new BooleanComparer();
+        comparer.addComparer(new ContainsSearchComparer("pie")); // OR condition
+        comparer.addComparer(new IsNotSearchComparer(new ContainsSearchComparer("apple"))); // AND condition
+
+        assertTrue(comparer.matches("cherry pie"), "Should match: contains 'pie' and not 'apple'");
+        assertFalse(comparer.matches("apple pie"), "Should fail: contains 'apple'");
+        assertFalse(comparer.matches("banana bread"), "Should fail: does not contain 'pie'");
+    }
+
+    @Test
+    void testNoMatchWhenANDConditionFails() {
+        BooleanComparer comparer = new BooleanComparer();
+        comparer.addComparer(new ContainsSearchComparer("pie")); // OR condition
+        comparer.addComparer(new IsNotSearchComparer(new ContainsSearchComparer("cherry"))); // AND condition
+
+        assertFalse(comparer.matches("cherry pie"), "Should fail because the AND condition (not cherry) is false");
+    }
+
+    @Test
+    void testEmptyComparerReturnsFalse() {
+        BooleanComparer comparer = new BooleanComparer();
+        assertFalse(comparer.matches("anything"));
+    }
+}

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/filter/comparer/NumberRangeComparerTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/filter/comparer/NumberRangeComparerTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2021-2025 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.aviator.filter.comparer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.Test;
+
+import com.fortify.cli.aviator.fpr.filter.comparer.NumberRangeComparer;
+import com.fortify.cli.aviator.fpr.filter.comparer.SearchComparer;
+
+class NumberRangeComparerTest {
+
+    @Test
+    void testInclusiveBrackets() {
+        SearchComparer comparer = new NumberRangeComparer("[1,5]");
+        assertTrue(comparer.matches(new BigDecimal("1.0")), "Should match lower bound");
+        assertTrue(comparer.matches(new BigDecimal("5")), "Should match upper bound");
+        assertTrue(comparer.matches(3), "Should match value inside");
+        assertFalse(comparer.matches(0.9), "Should not match value below");
+        assertFalse(comparer.matches(5.1), "Should not match value above");
+    }
+
+    @Test
+    void testExclusiveParentheses() {
+        SearchComparer comparer = new NumberRangeComparer("(1,5)");
+        assertFalse(comparer.matches(1), "Should not match lower bound");
+        assertFalse(comparer.matches(5), "Should not match upper bound");
+        assertTrue(comparer.matches(3.5), "Should match value inside");
+    }
+
+    @Test
+    void testMixedInclusiveExclusiveBrackets() {
+        SearchComparer comparer1 = new NumberRangeComparer("[1,5)");
+        assertTrue(comparer1.matches(1), "[1,5) should match lower bound");
+        assertFalse(comparer1.matches(5), "[1,5) should not match upper bound");
+
+        SearchComparer comparer2 = new NumberRangeComparer("(1,5]");
+        assertFalse(comparer2.matches(1), "(1,5] should not match lower bound");
+        assertTrue(comparer2.matches(5), "(1,5] should match upper bound");
+    }
+
+    @Test
+    void testFloatingPointNumbers() {
+        SearchComparer comparer = new NumberRangeComparer("[2.5, 4.6]");
+        assertTrue(comparer.matches(2.5));
+        assertTrue(comparer.matches(4.6));
+        assertTrue(comparer.matches(3.0));
+        assertFalse(comparer.matches(2.49));
+        assertFalse(comparer.matches(4.61));
+    }
+
+    @Test
+    void testCommaAndHyphenSeparators() {
+        SearchComparer comma = new NumberRangeComparer("[1,5]");
+        SearchComparer hyphen = new NumberRangeComparer("[1-5]");
+        assertTrue(comma.matches(3), "Comma separator should work");
+        assertTrue(hyphen.matches(3), "Hyphen separator should work");
+    }
+
+    @Test
+    void testExtraWhitespace() {
+        SearchComparer comparer = new NumberRangeComparer("  [ 1 , 5 ]  ");
+        assertTrue(comparer.matches(2));
+    }
+
+    @Test
+    void testSingleValueExactMatch() {
+        SearchComparer comparer = new NumberRangeComparer("[3,3]");
+        assertTrue(comparer.matches(3));
+        assertFalse(comparer.matches(2.9));
+        assertFalse(comparer.matches(3.1));
+    }
+
+    @Test
+    void testThrowsExceptionOnMalformedRangeMissingEnd() {
+        assertThrows(IllegalArgumentException.class, () -> new NumberRangeComparer("[1,5"));
+    }
+
+    @Test
+    void testThrowsExceptionOnMalformedRangeMissingStart() {
+        assertThrows(IllegalArgumentException.class, () -> new NumberRangeComparer("1,5]"));
+    }
+
+    @Test
+    void testThrowsExceptionOnMalformedRangeMissingSeparator() {
+        assertThrows(IllegalArgumentException.class, () -> new NumberRangeComparer("[1 5]"));
+    }
+
+}

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/filter/engine/FilterEngineTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/filter/engine/FilterEngineTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2021-2025 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.aviator.filter.engine;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.fortify.cli.aviator.fpr.Vulnerability;
+import com.fortify.cli.aviator.fpr.filter.Filter;
+import com.fortify.cli.aviator.fpr.filter.FilterSet;
+import com.fortify.cli.aviator.fpr.filter.SearchTree;
+import com.fortify.cli.aviator.fpr.filter.VulnerabilityFilterer;
+import com.fortify.cli.aviator.fpr.filter.comparer.BooleanComparer;
+import com.fortify.cli.aviator.fpr.filter.comparer.SearchComparer;
+import com.fortify.cli.aviator.fpr.filter.engine.FilterParser;
+
+class FilterEngineTest {
+
+    private static int countTreeNodes(SearchTree.Node node) {
+        if (node == null) return 0;
+        if (node.isLeaf()) return 1;
+        return 1 + countTreeNodes(node.getLeftChild()) + countTreeNodes(node.getRightChild());
+    }
+
+    @Nested
+    class ModernParserTests {
+        // All these tests now pass with the robust manual tokenizer.
+        @Test void testSimpleTerm() { assertEquals(1, countTreeNodes(FilterParser.parse("category:value").getRoot())); }
+        @Test void testBracketedModifierWithSpaces() { assertEquals(1, countTreeNodes(FilterParser.parse("[fortify priority order]:critical").getRoot())); }
+        @Test void testImplicitAnd() { assertEquals(3, countTreeNodes(FilterParser.parse("analyzer:A category:B").getRoot())); }
+        @Test void testImplicitAndWithMultiWordValue() { assertEquals(3, countTreeNodes(FilterParser.parse("[category]:Insecure Dependency: Vulnerable Component [analysis type]:SCA").getRoot())); }
+        @Test void testExplicitAnd() { assertEquals(3, countTreeNodes(FilterParser.parse("[PCI 4.0]:<none> AND [fortify priority order]:low").getRoot())); }
+        @Test void testExplicitOr() { assertEquals(3, countTreeNodes(FilterParser.parse("analyzer:A OR analyzer:B").getRoot())); }
+        @Test void testOperatorPrecedence() { assertEquals(5, countTreeNodes(FilterParser.parse("A:1 OR B:2 AND C:3").getRoot())); }
+        @Test void testTermWithQuotedValue() { assertEquals(1, countTreeNodes(FilterParser.parse("category:\"SQL Injection\"").getRoot())); }
+        @Test void testTermWithEscapedColonInValue() { assertEquals(1, countTreeNodes(FilterParser.parse("category:Password Management\\: Weak Encryption").getRoot())); }
+    }
+
+    @Nested
+    class LegacyParserTests {
+        // These tests correctly validate the legacy parser logic.
+        @Test void testImplicitAndForDifferentModifiers() { assertEquals(3, countTreeNodes(FilterParser.parseLegacy("analyzer:A category:B").getRoot())); }
+        @Test void testImplicitOrForSameModifier() { assertTrue(FilterParser.parseLegacy("category:A category:B").getRoot().getQuery().getSearchComparer() instanceof BooleanComparer); }
+        @Test void testImplicitAndForNegatedSameModifier() {
+            SearchComparer comparer = FilterParser.parseLegacy("category:!A category:!B").getRoot().getQuery().getSearchComparer();
+            assertTrue(comparer instanceof BooleanComparer);
+            assertEquals(2, ((BooleanComparer)comparer).getAndComparers().size());
+            assertEquals(0, ((BooleanComparer)comparer).getOrComparers().size());
+        }
+    }
+
+    @Nested
+    class FiltererTests {
+        private static Vulnerability vulnCritical, vulnHigh, vulnMedium, vulnLow, vulnToHideByAudience, vulnToHideByCategory, vulnToKeep;
+        private static List<Vulnerability> allVulnerabilities;
+
+        @BeforeAll
+        static void setupVulnerabilities() {
+            vulnCritical = new Vulnerability(); vulnCritical.setInstanceID("CRITICAL_VULN"); vulnCritical.setPriority("Critical"); vulnCritical.setImpact(5.0); vulnCritical.setLikelihood("5.0"); vulnCritical.setConfidence(5.0); vulnCritical.setAudience("broad,fod");
+            vulnHigh = new Vulnerability(); vulnHigh.setInstanceID("HIGH_VULN"); vulnHigh.setPriority("High"); vulnHigh.setImpact(4.0); vulnHigh.setLikelihood("4.0"); vulnHigh.setConfidence(4.0); vulnHigh.setAudience("broad,fod");
+            vulnMedium = new Vulnerability(); vulnMedium.setInstanceID("MEDIUM_VULN"); vulnMedium.setPriority("Medium"); vulnMedium.setImpact(2.0); vulnMedium.setLikelihood("4.0"); vulnMedium.setConfidence(4.0); vulnMedium.setAudience("broad,fod");
+            vulnLow = new Vulnerability(); vulnLow.setInstanceID("LOW_VULN"); vulnLow.setPriority("Low"); vulnLow.setImpact(1.0); vulnLow.setLikelihood("0.5"); vulnLow.setConfidence(2.0); vulnLow.setAudience("broad,fod"); vulnLow.setCategory("Insecure Dependency: Vulnerable Component");
+            vulnToHideByAudience = new Vulnerability(); vulnToHideByAudience.setInstanceID("HIDDEN_BY_AUDIENCE"); vulnToHideByAudience.setPriority("High"); vulnToHideByAudience.setImpact(4.0); vulnToHideByAudience.setLikelihood("4.0"); vulnToHideByAudience.setConfidence(4.0); vulnToHideByAudience.setAudience("broad"); vulnToHideByAudience.setAnalyzerName("Structural"); vulnToHideByAudience.setCategory("Some Random Category");
+            vulnToHideByCategory = new Vulnerability(); vulnToHideByCategory.setInstanceID("HIDDEN_BY_CATEGORY"); vulnToHideByCategory.setPriority("High"); vulnToHideByCategory.setImpact(4.0); vulnToHideByCategory.setLikelihood("4.0"); vulnToHideByCategory.setConfidence(4.0); vulnToHideByCategory.setAudience("broad,fod"); vulnToHideByCategory.setAnalyzerName("Structural"); vulnToHideByCategory.setCategory("Insecure Dependency: Vulnerable Component");  // Changed to match hide category
+            vulnToKeep = new Vulnerability(); vulnToKeep.setInstanceID("SHOULD_BE_KEPT"); vulnToKeep.setPriority("High"); vulnToKeep.setImpact(4.0); vulnToKeep.setLikelihood("4.0"); vulnToKeep.setConfidence(4.0); vulnToKeep.setAudience("broad,fod"); vulnToKeep.setAnalyzerName("Structural"); vulnToKeep.setCategory("Some Random Category");
+            allVulnerabilities = List.of(vulnCritical, vulnHigh, vulnMedium, vulnLow, vulnToHideByAudience, vulnToHideByCategory, vulnToKeep);
+        }
+
+        @Test
+        void testQuickViewFilter() {
+            FilterSet quickView = new FilterSet();
+            quickView.setFilters(List.of(
+                createFolderFilter("[fortify priority order]:critical OR [fortify priority order]:high OR [fortify priority order]:medium OR [fortify priority order]:low"),
+                createHideFilter("impact:![2.5, 5.0]"),
+                createHideFilter("likelihood:![1.0,5.0]"),
+                createHideFilter("[category]:\"Insecure Dependency\\: Vulnerable Component\"") // with quote and \\ : to full, Exact match
+            ));
+            List<Vulnerability> result = VulnerabilityFilterer.filterVulnerabilities(allVulnerabilities, quickView);
+            Set<String> resultIds = result.stream().map(Vulnerability::getInstanceID).collect(Collectors.toSet());
+
+            assertEquals(4, result.size(), "Should keep Critical, High, H_BY_A, S_BE_K (H_BY_C hidden by category)");
+            assertTrue(resultIds.contains("CRITICAL_VULN"));
+            assertTrue(resultIds.contains("HIGH_VULN"));
+            assertTrue(resultIds.contains("HIDDEN_BY_AUDIENCE"));
+            assertTrue(resultIds.contains("SHOULD_BE_KEPT"));
+        }
+
+        @Test
+        void testLegacyFoDFilterHidesCorrectly() {
+            FilterSet fodFilter = new FilterSet();
+            fodFilter.setFilters(List.of(
+                createFolderFilter("[fortify priority order]:high"),
+                createHideFilter("audience:!fod analyzer:!pentest category:!docker")
+            ));
+            List<Vulnerability> result = VulnerabilityFilterer.filterVulnerabilities(allVulnerabilities, fodFilter);
+
+            assertEquals(3, result.size(), "Should keep vulnHigh, H_BY_C, S_BE_K (H_BY_A hidden)");
+            Set<String> resultIds = result.stream().map(Vulnerability::getInstanceID).collect(Collectors.toSet());
+            assertTrue(resultIds.contains("HIGH_VULN"));
+            assertTrue(resultIds.contains("HIDDEN_BY_CATEGORY"));
+            assertTrue(resultIds.contains("SHOULD_BE_KEPT"));
+        }
+
+        // NEW TEST: Regex
+        @Test
+        void testRegexMatch() {
+            Vulnerability vuln = new Vulnerability();
+            vuln.setCategory("SQL Injection");
+            List<Vulnerability> vulns = List.of(vuln);
+            List<Vulnerability> result = VulnerabilityFilterer.filter(vulns, "category:/sql.*/");
+            assertEquals(1, result.size());
+        }
+
+        // Null Attr Handling
+        @Test
+        void testNullAttrNotContains() {
+            Vulnerability vuln = new Vulnerability(); // analyzer null
+            List<Vulnerability> vulns = List.of(vuln);
+            List<Vulnerability> result = VulnerabilityFilterer.filter(vulns, "analyzer:!pentest");
+            assertEquals(1, result.size()); // !false (null not contains) = true, matches
+        }
+
+        private Filter createFolderFilter(String query) { Filter f = new Filter(); f.setAction("setFolder"); f.setQuery(query); return f; }
+        private Filter createHideFilter(String query) { Filter f = new Filter(); f.setAction("hide"); f.setQuery(query); return f; }
+    }
+}


### PR DESCRIPTION
Valid vulnerabilities were being incorrectly hidden because the audit logic failed to distinguish between modern and legacy filter syntax. It attempted to parse legacy filters (e.g., those with spaces like `impact:![2.5, 5.0]`) using the modern parser, leading to incorrect evaluations.

*   Updated the audit process to automatically detect the filter format and apply the correct parsing logic (Legacy vs. Modern).
*   Added a regression test to ensure legacy filter strings are handled correctly.

Please note that this PR includes commits from PR #877. You may merge that PR first, or simply merge this one directly, which would allow us to close #877 