### PR TITLE
ssc session login displays incorrect output

### DIFF
--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/helper/SSCTokenHelper.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/helper/SSCTokenHelper.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import com.fortify.cli.common.exception.FcliSimpleException;
 import com.fortify.cli.common.http.proxy.helper.ProxyHelper;
 import com.fortify.cli.common.json.JsonHelper;
 import com.fortify.cli.common.rest.unirest.UnexpectedHttpResponseException;
@@ -175,16 +176,19 @@ public class SSCTokenHelper {
                     .getBody().getData();
             result.setToken(token);
             return result;
-        } catch ( UnexpectedHttpResponseException e ) {
-            if ( e.getStatus()==404 || e.getStatus()==401 ) {
+        } catch (UnexpectedHttpResponseException e) {
+            if (e.getStatus() == 404) {
                 // Older SSC versions don't support this endpoint, so we create an SSCTokenData instance
                 // containing just the token itself.
                 var result = new SSCTokenData();
                 result.setToken(token);
                 return result; 
+            } else if (e.getStatus() == 401) {
+                throw new FcliSimpleException("Authentication failed due to invalid token. Please try with a valid token.");
             } else {
-                throw e;
+                throw new FcliSimpleException("Error connecting to SSC for token validation.", e);
             }
+
         }
     }
     


### PR DESCRIPTION
fix: validate token during SSC session creation (fixes #878)

<img width="1520" height="77" alt="image" src="https://github.com/user-attachments/assets/2077f2d0-4e46-4bdb-909d-8cbe5faf8092" />


Show a clear error message if an invalid SSC token is provided during session creation, instead of prompting for login.
