### PR TITLE
Updates to `fod sast-scan setup` to keep existing settings

### DIFF
--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/cli/cmd/FoDSastScanSetupCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/cli/cmd/FoDSastScanSetupCommand.java
@@ -59,7 +59,9 @@ public class FoDSastScanSetupCommand extends AbstractFoDScanSetupCommand<FoDScan
     @Option(names = {"--language-level"})
     private String languageLevel;
     @Option(names = {"--oss"})
-    private final Boolean performOpenSourceAnalysis = false;
+    private Boolean performOpenSourceAnalysis;
+    @Option(names = {"--no-oss"})
+    private Boolean noPerformOpenSourceAnalysis;
     @Option(names = {"--audit-preference"}, required = true)
     private FoDEnums.AuditPreferenceTypes auditPreferenceType;
     @Option(names = {"--include-third-party-libs"})
@@ -67,7 +69,9 @@ public class FoDSastScanSetupCommand extends AbstractFoDScanSetupCommand<FoDScan
     @Option(names = {"--use-source-control"})
     private final Boolean useSourceControl = false;
     @Option(names={"--use-aviator"})
-    private Boolean useAviator = false;
+    private Boolean useAviator;
+    @Option(names={"--no-aviator"})
+    private Boolean noUseAviator;
 
     // TODO We don't actually use a progress writer, but for now we can't
     //      remove the --progress option to maintain backward compatibility.
@@ -116,26 +120,70 @@ public class FoDSastScanSetupCommand extends AbstractFoDScanSetupCommand<FoDScan
         validateEntitlement(currentSetup, entitlementIdToUse, relId, atd);
         LOG.info("Configuring release to use entitlement " + entitlementIdToUse);
 
-        var technologyStackId = getTechnologyStackId(unirest);
-        var languageLevelId = getLanguageLevelId(unirest, technologyStackId);
+        // Determine technology stack / language level IDs:
+        // Always lookup the configured technology stack (including the default "Auto Detect"),
+        // so the associated numeric id (e.g. 32) is used when the user did not explicitly pass the option.
+        Integer technologyStackId = getTechnologyStackId(unirest);
 
-        FoDScanConfigSastSetupRequest setupSastScanRequest = FoDScanConfigSastSetupRequest.builder()
+        Integer languageLevelId;
+        if (languageLevel != null && languageLevel.length() > 0) {
+            languageLevelId = getLanguageLevelId(unirest, technologyStackId);
+        } else if (currentSetup != null && currentSetup.getLanguageLevelId() != null) {
+            languageLevelId = currentSetup.getLanguageLevelId();
+        } else {
+            languageLevelId = null;
+        }
+
+        if (performOpenSourceAnalysis != null && noPerformOpenSourceAnalysis != null) {
+            throw new FcliSimpleException("Cannot specify both --oss and --no-oss");
+        }
+        if (useAviator != null && noUseAviator != null) {
+            throw new FcliSimpleException("Cannot specify both --use-aviator and --no-aviator");
+        }
+
+        var builder = FoDScanConfigSastSetupRequest.builder()
                 .entitlementId(entitlementIdToUse)
                 .assessmentTypeId(assessmentTypeId)
                 .entitlementFrequencyType(entitlementFrequencyTypeMixin.getEntitlementFrequencyType().name())
                 .technologyStackId(technologyStackId)
                 .languageLevelId(languageLevelId)
-                .performOpenSourceAnalysis(performOpenSourceAnalysis)
                 .auditPreferenceType(auditPreferenceType.name())
                 .includeThirdPartyLibraries(includeThirdPartyLibraries)
-                .useSourceControl(useSourceControl)
-                .includeFortifyAviator(useAviator).build();
+                .useSourceControl(useSourceControl);
+
+        // Final OSS value priority: explicit --oss > explicit --no-oss > existing setup value
+        Boolean ossValue = null;
+        if (performOpenSourceAnalysis != null) {
+            ossValue = performOpenSourceAnalysis;
+        } else if (noPerformOpenSourceAnalysis != null) {
+            ossValue = Boolean.FALSE;
+        } else if (currentSetup != null && currentSetup.getPerformOpenSourceAnalysis() != null) {
+            ossValue = currentSetup.getPerformOpenSourceAnalysis();
+        }
+        if (ossValue != null) {
+            builder.performOpenSourceAnalysis(ossValue);
+        }
+
+        // Final Aviator value priority: explicit --use-aviator > explicit --no-aviator > existing setup value
+        Boolean aviatorValue = null;
+        if (useAviator != null) {
+            aviatorValue = useAviator;
+        } else if (noUseAviator != null) {
+            aviatorValue = Boolean.FALSE;
+        } else if (currentSetup != null && currentSetup.getIncludeFortifyAviator() != null) {
+            aviatorValue = currentSetup.getIncludeFortifyAviator();
+        }
+        if (aviatorValue != null) {
+            builder.includeFortifyAviator(aviatorValue);
+        }
+
+        FoDScanConfigSastSetupRequest setupSastScanRequest = builder.build();
 
         return FoDScanConfigSastHelper.setupScan(unirest, releaseDescriptor, setupSastScanRequest).asJsonNode();
     }
 
     private Integer getLanguageLevelId(UnirestInstance unirest, Integer technologyStackId) {
-        Integer languageLevelId = 0;
+        Integer languageLevelId = null;
         FoDLookupDescriptor lookupDescriptor = null;
         if (languageLevel != null && languageLevel.length() > 0) {
             try {
@@ -156,8 +204,8 @@ public class FoDSastScanSetupCommand extends AbstractFoDScanSetupCommand<FoDScan
         } catch (JsonProcessingException ex) {
             throw new FcliTechnicalException(ex.getMessage());
         }
-        // TODO return 0 or null, or throw exception?
-        return lookupDescriptor==null ? 0 : Integer.valueOf(lookupDescriptor.getValue());
+        // Return null when not found so the field can be omitted from the request JSON
+        return lookupDescriptor==null ? null : Integer.valueOf(lookupDescriptor.getValue());
     }
 
     private void validateEntitlement(FoDScanConfigSastDescriptor currentSetup, Integer entitlementIdToUse, String relId, FoDReleaseAssessmentTypeDescriptor atd) {

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/cli/cmd/FoDSastScanSetupCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/cli/cmd/FoDSastScanSetupCommand.java
@@ -151,7 +151,8 @@ public class FoDSastScanSetupCommand extends AbstractFoDScanSetupCommand<FoDScan
                 .includeThirdPartyLibraries(includeThirdPartyLibraries)
                 .useSourceControl(useSourceControl);
 
-        // Final OSS value priority: explicit --oss > explicit --no-oss > existing setup value
+        // Only one of --oss or --no-oss can be specified at a time.
+        // OSS value priority: if explicit --oss is specified, use it; else if explicit --no-oss is specified, use it; else use existing setup value.
         Boolean ossValue = null;
         if (performOpenSourceAnalysis != null) {
             ossValue = performOpenSourceAnalysis;
@@ -164,7 +165,8 @@ public class FoDSastScanSetupCommand extends AbstractFoDScanSetupCommand<FoDScan
             builder.performOpenSourceAnalysis(ossValue);
         }
 
-        // Final Aviator value priority: explicit --use-aviator > explicit --no-aviator > existing setup value
+        // Only one of --use-aviator or --no-aviator can be specified at a time (see lines 140-141).
+        // Final Aviator value priority: explicit --use-aviator if specified, otherwise explicit --no-aviator if specified, otherwise existing setup value
         Boolean aviatorValue = null;
         if (useAviator != null) {
             aviatorValue = useAviator;
@@ -204,9 +206,14 @@ public class FoDSastScanSetupCommand extends AbstractFoDScanSetupCommand<FoDScan
         } catch (JsonProcessingException ex) {
             throw new FcliTechnicalException(ex.getMessage());
         }
-        // Return null when not found so the field can be omitted from the request JSON
-        return lookupDescriptor==null ? null : Integer.valueOf(lookupDescriptor.getValue());
-    }
+        if (lookupDescriptor == null) {
+            return null;
+        }
+        try {
+            return Integer.valueOf(lookupDescriptor.getValue());
+        } catch (NumberFormatException ex) {
+            throw new FcliTechnicalException("Failed to parse technology stack ID from lookup descriptor value: " + lookupDescriptor.getValue(), ex);
+        }
 
     private void validateEntitlement(FoDScanConfigSastDescriptor currentSetup, Integer entitlementIdToUse, String relId, FoDReleaseAssessmentTypeDescriptor atd) {
         // validate entitlement specified or currently in use against assessment type found

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/helper/FoDScanConfigSastDescriptor.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/helper/FoDScanConfigSastDescriptor.java
@@ -34,4 +34,5 @@ public class FoDScanConfigSastDescriptor extends JsonNodeHolder {
     private String languageLevel;
     private Boolean performOpenSourceAnalysis;
     private String auditPreferenceType;
+    private Boolean includeFortifyAviator;
 }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/helper/FoDScanConfigSastSetupRequest.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/helper/FoDScanConfigSastSetupRequest.java
@@ -12,6 +12,7 @@
  */
 package com.fortify.cli.fod.sast_scan.helper;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.formkiq.graalvm.annotations.Reflectable;
 
 import lombok.AllArgsConstructor;
@@ -21,6 +22,7 @@ import lombok.NoArgsConstructor;
 
 @Reflectable @NoArgsConstructor @AllArgsConstructor
 @Data @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FoDScanConfigSastSetupRequest {
     private Integer assessmentTypeId;
     private String entitlementFrequencyType;

--- a/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
+++ b/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
@@ -564,6 +564,8 @@ fcli.fod.sast-scan.setup.use-source-control = (LEGACY) Indicates if source contr
 fcli.fod.sast-scan.setup.skip-if-exists = Skip setup if a scan has already been set up. If not specified, any existing scan \
   setup will be replaced based on the given setup options.
 fcli.fod.sast-scan.setup.use-aviator = Use Fortify Aviator to audit results and provide enhanced remediation guidance. 
+fcli.fod.sast-scan.setup.no-oss = Do not perform Open Source Analysis scan.
+fcli.fod.sast-scan.setup.no-aviator = Do not include Fortify Aviator for remediation guidance.
 fcli.fod.sast-scan.import.usage.header = Import existing SAST scan results (from an FPR file).
 fcli.fod.sast-scan.import.usage.description = As FoD doesn't return a scan id for imported scans, the output of this command cannot be used with commands that expect a scan id, like the wait-for command.
 fcli.fod.sast-scan.import.file = FPR file containing existing SAST scan results to be imported.


### PR DESCRIPTION
Minor updates the `fod sast-scan setup` command so that "aviator" and "oss" settings are not overwritten when they are not supplied. In order to remain backwards compatible existing `--use-aviator` and `--oss` have been kept and new options `--no-aviator` and `-no-oss` added to explicitly remove these settings.