### PR TITLE
Updates to fod sast-scan setup to keep existing settings

### DIFF
--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/cli/cmd/FoDSastScanSetupCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/cli/cmd/FoDSastScanSetupCommand.java
@@ -166,12 +166,16 @@ public class FoDSastScanSetupCommand extends AbstractFoDScanSetupCommand<FoDScan
             try {
                 FoDLookupDescriptor lookupDescriptor = FoDLookupHelper.getDescriptor(unirest, FoDLookupType.LanguageLevels, String.valueOf(technologyStackId), languageLevel, true);
                 if (lookupDescriptor != null && lookupDescriptor.getValue() != null) {
-                    return Integer.valueOf(lookupDescriptor.getValue());
+                    try {
+                        return Integer.valueOf(lookupDescriptor.getValue());
+                    } catch (NumberFormatException ex) {
+                        throw new FcliTechnicalException("Failed to parse language level ID from lookup descriptor value: " + lookupDescriptor.getValue(), ex);
+                    }
                 }
                 // If lookup returns null, the language level is invalid - return null instead of falling back to currentSetup
                 return null;
             } catch (JsonProcessingException ex) {
-                throw new FcliTechnicalException(ex.getMessage());
+                throw new FcliTechnicalException("Error processing technology stack lookup", ex);
             }
         } else if (currentSetup != null && currentSetup.getLanguageLevelId() != null 
                    && currentSetup.getTechnologyStackId() != null 

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/cli/cmd/FoDSastScanSetupCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/cli/cmd/FoDSastScanSetupCommand.java
@@ -117,49 +117,37 @@ public class FoDSastScanSetupCommand extends AbstractFoDScanSetupCommand<FoDScan
         LOG.info("Configuring release to use entitlement " + entitlementIdToUse);
 
         // Determine technology stack / language level IDs:
-        // Always lookup the configured technology stack (including the default "Auto Detect"),
-        // so the associated numeric id (e.g. 32) is used when the user did not explicitly pass the option.
+        // Technology stack always has a value (defaults to "Auto Detect" if not specified),
+        // so we always look it up to get the numeric ID.
         Integer technologyStackId = getTechnologyStackId(unirest);
-
-        Integer languageLevelId;
-        if (languageLevel != null && languageLevel.length() > 0) {
-            languageLevelId = getLanguageLevelId(unirest, technologyStackId);
-        } else if (currentSetup != null && currentSetup.getLanguageLevelId() != null) {
-            languageLevelId = currentSetup.getLanguageLevelId();
-        } else {
-            languageLevelId = null;
-        }
+        Integer languageLevelId = getLanguageLevelId(unirest, technologyStackId, currentSetup);
 
         var builder = FoDScanConfigSastSetupRequest.builder()
                 .entitlementId(entitlementIdToUse)
                 .assessmentTypeId(assessmentTypeId)
                 .entitlementFrequencyType(entitlementFrequencyTypeMixin.getEntitlementFrequencyType().name())
                 .technologyStackId(technologyStackId)
-                .languageLevelId(languageLevelId)
                 .auditPreferenceType(auditPreferenceType.name())
                 .includeThirdPartyLibraries(includeThirdPartyLibraries)
                 .useSourceControl(useSourceControl);
 
-        // OSS value priority: CLI option (if specified) > existing setup value
-        Boolean ossValue = null;
-        if (performOpenSourceAnalysis != null) {
-            ossValue = performOpenSourceAnalysis;
-        } else if (currentSetup != null && currentSetup.getPerformOpenSourceAnalysis() != null) {
-            ossValue = currentSetup.getPerformOpenSourceAnalysis();
+        // Only set languageLevelId if not null
+        if (languageLevelId != null) {
+            builder.languageLevelId(languageLevelId);
         }
-        if (ossValue != null) {
-            builder.performOpenSourceAnalysis(ossValue);
+
+        // OSS value priority: CLI option (if specified) > existing setup value
+        if (performOpenSourceAnalysis != null) {
+            builder.performOpenSourceAnalysis(performOpenSourceAnalysis);
+        } else if (currentSetup != null && currentSetup.getPerformOpenSourceAnalysis() != null) {
+            builder.performOpenSourceAnalysis(currentSetup.getPerformOpenSourceAnalysis());
         }
 
         // Aviator value priority: CLI option (if specified) > existing setup value
-        Boolean aviatorValue = null;
         if (useAviator != null) {
-            aviatorValue = useAviator;
+            builder.includeFortifyAviator(useAviator);
         } else if (currentSetup != null && currentSetup.getIncludeFortifyAviator() != null) {
-            aviatorValue = currentSetup.getIncludeFortifyAviator();
-        }
-        if (aviatorValue != null) {
-            builder.includeFortifyAviator(aviatorValue);
+            builder.includeFortifyAviator(currentSetup.getIncludeFortifyAviator());
         }
 
         FoDScanConfigSastSetupRequest setupSastScanRequest = builder.build();
@@ -167,18 +155,31 @@ public class FoDSastScanSetupCommand extends AbstractFoDScanSetupCommand<FoDScan
         return FoDScanConfigSastHelper.setupScan(unirest, releaseDescriptor, setupSastScanRequest).asJsonNode();
     }
 
-    private Integer getLanguageLevelId(UnirestInstance unirest, Integer technologyStackId) {
-        Integer languageLevelId = null;
-        FoDLookupDescriptor lookupDescriptor = null;
-        if (languageLevel != null && languageLevel.length() > 0) {
+    private Integer getLanguageLevelId(UnirestInstance unirest, Integer technologyStackId, FoDScanConfigSastDescriptor currentSetup) {
+        // If technologyStackId is null, languageLevelId will be null
+        if (technologyStackId == null) {
+            return null;
+        }
+        
+        // Priority: CLI option > existing setup value (only if tech stack unchanged) > null
+        if (languageLevel != null && !languageLevel.isEmpty()) {
             try {
-                lookupDescriptor = FoDLookupHelper.getDescriptor(unirest, FoDLookupType.LanguageLevels, String.valueOf(technologyStackId), languageLevel, true);
+                FoDLookupDescriptor lookupDescriptor = FoDLookupHelper.getDescriptor(unirest, FoDLookupType.LanguageLevels, String.valueOf(technologyStackId), languageLevel, true);
+                if (lookupDescriptor != null && lookupDescriptor.getValue() != null) {
+                    return Integer.valueOf(lookupDescriptor.getValue());
+                }
+                // If lookup returns null, the language level is invalid - return null instead of falling back to currentSetup
+                return null;
             } catch (JsonProcessingException ex) {
                 throw new FcliTechnicalException(ex.getMessage());
             }
-            if (lookupDescriptor != null) languageLevelId = Integer.valueOf(lookupDescriptor.getValue());
+        } else if (currentSetup != null && currentSetup.getLanguageLevelId() != null 
+                   && currentSetup.getTechnologyStackId() != null 
+                   && currentSetup.getTechnologyStackId().equals(technologyStackId)) {
+            // Only use existing language level if technology stack hasn't changed
+            return currentSetup.getLanguageLevelId();
         }
-        return languageLevelId;
+        return null;
     }
 
     private Integer getTechnologyStackId(UnirestInstance unirest) {

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/cli/cmd/FoDSastScanSetupCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/cli/cmd/FoDSastScanSetupCommand.java
@@ -58,16 +58,16 @@ public class FoDSastScanSetupCommand extends AbstractFoDScanSetupCommand<FoDScan
     private String technologyStack;
     @Option(names = {"--language-level"})
     private String languageLevel;
-    @Option(names = {"--oss"})
-    private final Boolean performOpenSourceAnalysis = false;
+    @Option(names = {"--oss"}, negatable = true)
+    private Boolean performOpenSourceAnalysis;
     @Option(names = {"--audit-preference"}, required = true)
     private FoDEnums.AuditPreferenceTypes auditPreferenceType;
     @Option(names = {"--include-third-party-libs"})
     private final Boolean includeThirdPartyLibraries = false;
     @Option(names = {"--use-source-control"})
     private final Boolean useSourceControl = false;
-    @Option(names={"--use-aviator"})
-    private Boolean useAviator = false;
+    @Option(names = {"--use-aviator"}, negatable = true)
+    private Boolean useAviator;
 
     // TODO We don't actually use a progress writer, but for now we can't
     //      remove the --progress option to maintain backward compatibility.
@@ -116,26 +116,59 @@ public class FoDSastScanSetupCommand extends AbstractFoDScanSetupCommand<FoDScan
         validateEntitlement(currentSetup, entitlementIdToUse, relId, atd);
         LOG.info("Configuring release to use entitlement " + entitlementIdToUse);
 
-        var technologyStackId = getTechnologyStackId(unirest);
-        var languageLevelId = getLanguageLevelId(unirest, technologyStackId);
+        // Determine technology stack / language level IDs:
+        // Always lookup the configured technology stack (including the default "Auto Detect"),
+        // so the associated numeric id (e.g. 32) is used when the user did not explicitly pass the option.
+        Integer technologyStackId = getTechnologyStackId(unirest);
 
-        FoDScanConfigSastSetupRequest setupSastScanRequest = FoDScanConfigSastSetupRequest.builder()
+        Integer languageLevelId;
+        if (languageLevel != null && languageLevel.length() > 0) {
+            languageLevelId = getLanguageLevelId(unirest, technologyStackId);
+        } else if (currentSetup != null && currentSetup.getLanguageLevelId() != null) {
+            languageLevelId = currentSetup.getLanguageLevelId();
+        } else {
+            languageLevelId = null;
+        }
+
+        var builder = FoDScanConfigSastSetupRequest.builder()
                 .entitlementId(entitlementIdToUse)
                 .assessmentTypeId(assessmentTypeId)
                 .entitlementFrequencyType(entitlementFrequencyTypeMixin.getEntitlementFrequencyType().name())
                 .technologyStackId(technologyStackId)
                 .languageLevelId(languageLevelId)
-                .performOpenSourceAnalysis(performOpenSourceAnalysis)
                 .auditPreferenceType(auditPreferenceType.name())
                 .includeThirdPartyLibraries(includeThirdPartyLibraries)
-                .useSourceControl(useSourceControl)
-                .includeFortifyAviator(useAviator).build();
+                .useSourceControl(useSourceControl);
+
+        // OSS value priority: CLI option (if specified) > existing setup value
+        Boolean ossValue = null;
+        if (performOpenSourceAnalysis != null) {
+            ossValue = performOpenSourceAnalysis;
+        } else if (currentSetup != null && currentSetup.getPerformOpenSourceAnalysis() != null) {
+            ossValue = currentSetup.getPerformOpenSourceAnalysis();
+        }
+        if (ossValue != null) {
+            builder.performOpenSourceAnalysis(ossValue);
+        }
+
+        // Aviator value priority: CLI option (if specified) > existing setup value
+        Boolean aviatorValue = null;
+        if (useAviator != null) {
+            aviatorValue = useAviator;
+        } else if (currentSetup != null && currentSetup.getIncludeFortifyAviator() != null) {
+            aviatorValue = currentSetup.getIncludeFortifyAviator();
+        }
+        if (aviatorValue != null) {
+            builder.includeFortifyAviator(aviatorValue);
+        }
+
+        FoDScanConfigSastSetupRequest setupSastScanRequest = builder.build();
 
         return FoDScanConfigSastHelper.setupScan(unirest, releaseDescriptor, setupSastScanRequest).asJsonNode();
     }
 
     private Integer getLanguageLevelId(UnirestInstance unirest, Integer technologyStackId) {
-        Integer languageLevelId = 0;
+        Integer languageLevelId = null;
         FoDLookupDescriptor lookupDescriptor = null;
         if (languageLevel != null && languageLevel.length() > 0) {
             try {
@@ -156,8 +189,14 @@ public class FoDSastScanSetupCommand extends AbstractFoDScanSetupCommand<FoDScan
         } catch (JsonProcessingException ex) {
             throw new FcliTechnicalException(ex.getMessage());
         }
-        // TODO return 0 or null, or throw exception?
-        return lookupDescriptor==null ? 0 : Integer.valueOf(lookupDescriptor.getValue());
+        if (lookupDescriptor == null) {
+            return null;
+        }
+        try {
+            return Integer.valueOf(lookupDescriptor.getValue());
+        } catch (NumberFormatException ex) {
+            throw new FcliTechnicalException("Failed to parse technology stack ID from lookup descriptor value: " + lookupDescriptor.getValue(), ex);
+        }
     }
 
     private void validateEntitlement(FoDScanConfigSastDescriptor currentSetup, Integer entitlementIdToUse, String relId, FoDReleaseAssessmentTypeDescriptor atd) {

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/helper/FoDScanConfigSastDescriptor.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/helper/FoDScanConfigSastDescriptor.java
@@ -34,4 +34,5 @@ public class FoDScanConfigSastDescriptor extends JsonNodeHolder {
     private String languageLevel;
     private Boolean performOpenSourceAnalysis;
     private String auditPreferenceType;
+    private Boolean includeFortifyAviator;
 }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/helper/FoDScanConfigSastSetupRequest.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/sast_scan/helper/FoDScanConfigSastSetupRequest.java
@@ -12,6 +12,7 @@
  */
 package com.fortify.cli.fod.sast_scan.helper;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.formkiq.graalvm.annotations.Reflectable;
 
 import lombok.AllArgsConstructor;
@@ -21,6 +22,7 @@ import lombok.NoArgsConstructor;
 
 @Reflectable @NoArgsConstructor @AllArgsConstructor
 @Data @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FoDScanConfigSastSetupRequest {
     private Integer assessmentTypeId;
     private String entitlementFrequencyType;


### PR DESCRIPTION
Minor updates the `fod sast-scan setup` command so that "aviator" and "oss" settings are not overwritten when they are not supplied. In order to remain backwards compatible existing `-use-aviator` and `--oss` have been kept and been made "negatable" so that `--no-use-aviator` and `--no-oss` are also available.

Tidied up and hardened technology stack/language level based on Copilot suggestions.