### PR TITLE
Fix console error message formatting

### DIFF
--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/util/ConsoleHelper.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/util/ConsoleHelper.java
@@ -86,6 +86,17 @@ public class ConsoleHelper {
      * Install the JAnsi console if not disabled. Safe no-op if disabled or unavailable.
      */
     public static final void installAnsiConsole() {
+        if (PlatformHelper.isWindows()) {
+            if (System.getProperty("jansi.passthrough") == null) {
+                System.setProperty("jansi.passthrough", "true");
+            }
+            if (System.getProperty("jansi.strip") == null) {
+                System.setProperty("jansi.strip", "false");
+            }
+            if (System.getProperty("picocli.ansi") == null) {
+                System.setProperty("picocli.ansi", "true");
+            }
+        }
         invokeAnsiConsoleMethod("systemInstall");
     }
 


### PR DESCRIPTION
Fix: Added changes for console error message formatting.

<img width="1108" height="309" alt="image" src="https://github.com/user-attachments/assets/0ca98b36-d139-44ef-9615-351c2fea2306" />
Error message's are in red color now.