### PR TITLE
chore: Add validation for --aviator-app-mapping option

### DIFF
--- a/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/actions/zip/bulkaudit.yaml
+++ b/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/actions/zip/bulkaudit.yaml
@@ -97,16 +97,12 @@ steps:
       module: ssc
 
   # Validate --aviator-app-mapping value
-  - if: ${!('app'.equals(cli['aviator-app-mapping']) || 'version'.equals(cli['aviator-app-mapping']))}
-    do:
-      - log.progress: "ERROR: Invalid --aviator-app-mapping value '${cli['aviator-app-mapping']}'. Valid values are: app, version"
-      - throw: "Invalid --aviator-app-mapping value '${cli['aviator-app-mapping']}'. Valid values are: app, version"
+  - if: ${!(cli['aviator-app-mapping'] matches 'app|version')}
+    throw: "Invalid --aviator-app-mapping value '${cli['aviator-app-mapping']}'. Valid values are: app, version"
 
   # Validate that at least one of --tag-mapping or --add-aviator-tags is specified
   - if: ${(cli['tag-mapping'] == null || cli['tag-mapping'] == '') && !cli['add-aviator-tags']}
-    do:
-      - log.progress: "ERROR: Either --tag-mapping or --add-aviator-tags must be specified."
-      - throw: "Either --tag-mapping or --add-aviator-tags must be specified."
+    throw: "Either --tag-mapping or --add-aviator-tags must be specified."
 
   - log.progress: "Using Aviator app mapping: ${cli['aviator-app-mapping']}"
 

--- a/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/actions/zip/bulkaudit.yaml
+++ b/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/actions/zip/bulkaudit.yaml
@@ -96,6 +96,12 @@ steps:
   - var.set:
       module: ssc
 
+  # Validate --aviator-app-mapping value
+  - if: ${!('app'.equals(cli['aviator-app-mapping']) || 'version'.equals(cli['aviator-app-mapping']))}
+    do:
+      - log.progress: "ERROR: Invalid --aviator-app-mapping value '${cli['aviator-app-mapping']}'. Valid values are: app, version"
+      - throw: "Invalid --aviator-app-mapping value '${cli['aviator-app-mapping']}'. Valid values are: app, version"
+
   # Validate that at least one of --tag-mapping or --add-aviator-tags is specified
   - if: ${(cli['tag-mapping'] == null || cli['tag-mapping'] == '') && !cli['add-aviator-tags']}
     do:


### PR DESCRIPTION
Added Missing Validation logic for option ` --aviator-app-mapping option`

```txt
> java -jar '.\fcli.jar' ssc action run bulkaudit --add-aviator-tags -n --aviator-app-mapping fff
FcliActionStepException: Invalid --aviator-app-mapping value 'fff'. Valid values are: app, version
        at com.fortify.cli.common.action.runner.processor.ActionStepProcessorThrow.process(ActionStepProcessorThrow.java:48)
```