### PR TITLE
fix: correct FoD session login credential grouping and tenant option usage

### DIFF
--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/cli/cmd/FoDSessionLoginCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/cli/cmd/FoDSessionLoginCommand.java
@@ -28,7 +28,7 @@ import lombok.Getter;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 
-@Command(name = OutputHelperMixins.Login.CMD_NAME, sortOptions = false)
+@Command(name = OutputHelperMixins.Login.CMD_NAME, sortOptions = false, preprocessor = FoDSessionTenantIgnoringPreprocessor.class)
 public class FoDSessionLoginCommand extends AbstractSessionLoginCommand<FoDSessionDescriptor> {
     @Getter @Mixin private OutputHelperMixins.Login outputHelper;
     @Getter private FoDSessionHelper sessionHelper = FoDSessionHelper.instance();

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/cli/cmd/FoDSessionTenantIgnoringPreprocessor.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/cli/cmd/FoDSessionTenantIgnoringPreprocessor.java
@@ -34,6 +34,11 @@ import picocli.CommandLine.Model.CommandSpec;
 public final class FoDSessionTenantIgnoringPreprocessor implements IParameterPreprocessor {
     @Override
     public boolean preprocess(Stack<String> args, CommandSpec commandSpec, ArgSpec argSpec, Map<String, Object> info) {
+        // TODO Given that we have CommandSpec and ArgSpec available, can we use these to obtain option names
+        //      and aliases, rather than hardcoding/duplicating them here?
+        // TODO If we ever need similar functionality in other places, maybe better to change this into a
+        //      generic, annotation-driven processor, i.e., put some annotation on option fields to indicate
+        //      that the option should be ignored if some criteria are met?
         if ( argSpec!=null || args==null || args.isEmpty() ) {
             return false;
         }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/cli/cmd/FoDSessionTenantIgnoringPreprocessor.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/cli/cmd/FoDSessionTenantIgnoringPreprocessor.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.fod._common.session.cli.cmd;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+
+import picocli.CommandLine.IParameterPreprocessor;
+import picocli.CommandLine.Model.ArgSpec;
+import picocli.CommandLine.Model.CommandSpec;
+
+/**
+ * Removes --tenant/-t from command line arguments when client credentials are used.
+ * This allows tenant to stay mandatory in the user credential argument group while
+ * accepting tenant as a no-op for client credential authentication.
+ * 
+ * @author Sangamesh Vijayakumar
+ */
+public final class FoDSessionTenantIgnoringPreprocessor implements IParameterPreprocessor {
+    @Override
+    public boolean preprocess(Stack<String> args, CommandSpec commandSpec, ArgSpec argSpec, Map<String, Object> info) {
+        if ( argSpec!=null || args==null || args.isEmpty() ) {
+            return false;
+        }
+
+        var cliArgs = new ArrayList<>(args);
+        if ( !hasClientCredentials(cliArgs) ) {
+            return false;
+        }
+
+        var filtered = filterOutTenantOptions(cliArgs);
+        if ( filtered.size()!=cliArgs.size() ) {
+            args.clear();
+            args.addAll(filtered);
+        }
+        return false;
+    }
+
+    private static boolean hasClientCredentials(List<String> cliArgs) {
+        return cliArgs.stream().anyMatch(a -> "--client-id".equals(a)
+                || a.startsWith("--client-id=")
+                || "--client-secret".equals(a)
+                || a.startsWith("--client-secret="));
+    }
+
+    private static List<String> filterOutTenantOptions(List<String> cliArgs) {
+        var result = new ArrayList<String>();
+        for ( int i = 0; i < cliArgs.size(); i++ ) {
+            var arg = cliArgs.get(i);
+            if ( "--tenant".equals(arg) || "-t".equals(arg) ) {
+                if ( i+1 < cliArgs.size() && !cliArgs.get(i+1).startsWith("-") ) {
+                    i++; // Skip explicit tenant value.
+                }
+                continue;
+            }
+            if ( arg.startsWith("--tenant=") || arg.startsWith("-t=") ) {
+                continue;
+            }
+            result.add(arg);
+        }
+        return result;
+    }
+}

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/cli/cmd/FoDSessionTenantIgnoringPreprocessor.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/cli/cmd/FoDSessionTenantIgnoringPreprocessor.java
@@ -58,6 +58,10 @@ public final class FoDSessionTenantIgnoringPreprocessor implements IParameterPre
                 || a.startsWith("--client-secret="));
     }
 
+    private static boolean isCompactTenantOption(String arg) {
+        return arg.startsWith("-t") && arg.length() > 2 && !arg.startsWith("--");
+    }
+
     private static List<String> filterOutTenantOptions(List<String> cliArgs) {
         var result = new ArrayList<String>();
         for ( int i = 0; i < cliArgs.size(); i++ ) {
@@ -68,7 +72,7 @@ public final class FoDSessionTenantIgnoringPreprocessor implements IParameterPre
                 }
                 continue;
             }
-            if ( arg.startsWith("--tenant=") || arg.startsWith("-t=") ) {
+            if ( arg.startsWith("--tenant=") || arg.startsWith("-t=") || isCompactTenantOption(arg) ) {
                 continue;
             }
             result.add(arg);

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/cli/cmd/FoDSessionTenantIgnoringPreprocessor.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/cli/cmd/FoDSessionTenantIgnoringPreprocessor.java
@@ -17,6 +17,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Stack;
 
+import com.formkiq.graalvm.annotations.Reflectable;
+
 import picocli.CommandLine.IParameterPreprocessor;
 import picocli.CommandLine.Model.ArgSpec;
 import picocli.CommandLine.Model.CommandSpec;
@@ -28,6 +30,7 @@ import picocli.CommandLine.Model.CommandSpec;
  * 
  * @author Sangamesh Vijayakumar
  */
+@Reflectable
 public final class FoDSessionTenantIgnoringPreprocessor implements IParameterPreprocessor {
     @Override
     public boolean preprocess(Stack<String> args, CommandSpec commandSpec, ArgSpec argSpec, Map<String, Object> info) {

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/cli/mixin/FoDSessionLoginOptions.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/cli/mixin/FoDSessionLoginOptions.java
@@ -82,17 +82,17 @@ public class FoDSessionLoginOptions {
     }
 
     public final boolean hasUserCredentials() {
-        return getUserCredentialOptions()!=null;
+        var userCredentialOptions = getUserCredentialOptions();
+        return userCredentialOptions!=null
+                && StringUtils.isNotBlank(userCredentialOptions.getTenant())
+                && StringUtils.isNotBlank(userCredentialOptions.getUser())
+                && userCredentialOptions.getPassword()!=null
+                && userCredentialOptions.getPassword().length > 0;
     }
 
     public final BasicFoDUserCredentials getUserCredentials() {
         var u = getUserCredentialOptions();
-        var t = Optional.ofNullable(u).map(FoDUserCredentialOptions::getTenant).orElse(null);
-        if (u == null || StringUtils.isBlank(t) || StringUtils.isBlank(u.getUser()) || u.getPassword() == null) {
-            throw new FcliSimpleException(
-                    "--tenant, --user and --password must all be specified for user credential authentication");
-        }
-        return BasicFoDUserCredentials.builder().tenant(t).user(u.getUser()).password(u.getPassword()).build();
+        return BasicFoDUserCredentials.builder().tenant(u.getTenant()).user(u.getUser()).password(u.getPassword()).build();
     }
     
     public final boolean hasClientCredentials() {

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/cli/mixin/FoDSessionLoginOptions.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/cli/mixin/FoDSessionLoginOptions.java
@@ -43,18 +43,21 @@ public class FoDSessionLoginOptions {
         @Getter private FoDCredentialOptions credentialOptions = new FoDCredentialOptions();
         @Option(names="--scopes", defaultValue="api-tenant", split=",")
         @Getter private String[] scopes;
-        @Option(names = {"-t", "--tenant"}, required = false)
-        @MaskValue(sensitivity = LogSensitivityLevel.low, description = "FOD TENANT")
-        @Getter private String tenant; // Optional: required only for user credentials
     }
     
     public static class FoDCredentialOptions {
         @ArgGroup(exclusive = false, multiplicity = "1", order = 1) 
-        @Getter private UserCredentialOptions userCredentialOptions = new UserCredentialOptions();
+        @Getter private FoDUserCredentialOptions userCredentialOptions = new FoDUserCredentialOptions();
         @ArgGroup(exclusive = false, multiplicity = "1", order = 2) 
         @Getter private FoDClientCredentialOptions clientCredentialOptions = new FoDClientCredentialOptions();
     }
     
+    public static class FoDUserCredentialOptions extends UserCredentialOptions {
+        @Option(names = {"-t", "--tenant"}, required = true)
+        @MaskValue(sensitivity = LogSensitivityLevel.low, description = "FOD TENANT")
+        @Getter private String tenant;
+    }
+
     public static class FoDClientCredentialOptions implements IFoDClientCredentials {
         @Option(names = {"--client-id"}, required = true)
         @MaskValue(sensitivity = LogSensitivityLevel.medium, description = "FOD CLIENT ID")
@@ -64,7 +67,7 @@ public class FoDSessionLoginOptions {
         @Getter private String clientSecret;
     }
 
-    public UserCredentialOptions getUserCredentialOptions() {
+    public FoDUserCredentialOptions getUserCredentialOptions() {
         return Optional.ofNullable(authOptions)
                 .map(FoDAuthOptions::getCredentialOptions)
                 .map(FoDCredentialOptions::getUserCredentialOptions)
@@ -84,9 +87,10 @@ public class FoDSessionLoginOptions {
 
     public final BasicFoDUserCredentials getUserCredentials() {
         var u = getUserCredentialOptions();
-        var t = Optional.ofNullable(authOptions).map(FoDAuthOptions::getTenant).orElse(null);
-        if ( u==null || StringUtils.isBlank(t) || StringUtils.isBlank(u.getUser()) || u.getPassword()==null ) {
-            throw new FcliSimpleException("--tenant, --user and --password must all be specified for user credential authentication");
+        var t = Optional.ofNullable(u).map(FoDUserCredentialOptions::getTenant).orElse(null);
+        if (u == null || StringUtils.isBlank(t) || StringUtils.isBlank(u.getUser()) || u.getPassword() == null) {
+            throw new FcliSimpleException(
+                    "--tenant, --user and --password must all be specified for user credential authentication");
         }
         return BasicFoDUserCredentials.builder().tenant(t).user(u.getUser()).password(u.getPassword()).build();
     }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/cli/mixin/FoDSessionLoginOptions.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/cli/mixin/FoDSessionLoginOptions.java
@@ -16,7 +16,6 @@ import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 
-import com.fortify.cli.common.exception.FcliSimpleException;
 import com.fortify.cli.common.log.LogSensitivityLevel;
 import com.fortify.cli.common.log.MaskValue;
 import com.fortify.cli.common.rest.cli.mixin.UrlConfigOptions;
@@ -137,9 +136,6 @@ public class FoDSessionLoginOptions {
             public Builder user(String user){ this.user=user; return this; }
             public Builder password(char[] password){ this.password=password; return this; }
             public BasicFoDUserCredentials build(){
-                if ( StringUtils.isBlank(tenant) || StringUtils.isBlank(user) || password==null || password.length==0 ) {
-                    throw new FcliSimpleException("--tenant, --user and --password must all be specified for user credential authentication");
-                }
                 return new BasicFoDUserCredentials(this);
             }
         }

--- a/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
+++ b/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
@@ -115,7 +115,7 @@ fcli.fod.session.login.usage.description.2 = %nTo avoid having to remember the v
   DEV_FOD_TENANT environment variables, and then use the --env-prefix=PROD or --env-prefix=DEV option to \
   select from which environment variables the default values should be retrieved.
 fcli.fod.session.login.url = FoD URL, for example https://emea.fortify.com/.
-fcli.fod.session.login.tenant = FoD tenant; required when authenticating with user credentials, ignored for client credentials.
+fcli.fod.session.login.tenant = FoD tenant; required, but ignored for client credentials.
 fcli.fod.session.login.user = FoD user.
 fcli.fod.session.login.password = FoD password.
 fcli.fod.session.login.client-id = FoD client id.

--- a/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
+++ b/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
@@ -115,7 +115,7 @@ fcli.fod.session.login.usage.description.2 = %nTo avoid having to remember the v
   DEV_FOD_TENANT environment variables, and then use the --env-prefix=PROD or --env-prefix=DEV option to \
   select from which environment variables the default values should be retrieved.
 fcli.fod.session.login.url = FoD URL, for example https://emea.fortify.com/.
-fcli.fod.session.login.tenant = FoD tenant; required, but ignored for client credentials.
+fcli.fod.session.login.tenant = FoD tenant; required when authenticating with user credentials, ignored for client credentials.
 fcli.fod.session.login.user = FoD user.
 fcli.fod.session.login.password = FoD password.
 fcli.fod.session.login.client-id = FoD client id.

--- a/fcli-core/fcli-fod/src/test/java/com/fortify/cli/fod/_common/session/cli/cmd/FoDSessionTenantIgnoringPreprocessorTest.java
+++ b/fcli-core/fcli-fod/src/test/java/com/fortify/cli/fod/_common/session/cli/cmd/FoDSessionTenantIgnoringPreprocessorTest.java
@@ -28,6 +28,7 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.MissingParameterException;
 import picocli.CommandLine.Mixin;
+import picocli.CommandLine.UnmatchedArgumentException;
 
 class FoDSessionTenantIgnoringPreprocessorTest {
     @Test
@@ -47,6 +48,29 @@ class FoDSessionTenantIgnoringPreprocessorTest {
     }
 
     @Test
+    void shouldIgnoreCompactTenantWhenClientCredentialsProvided() {
+        var cmd = parse("-tacme", "--client-id", "id", "--client-secret", "secret");
+
+        assertTrue(cmd.loginOptions.hasClientCredentials());
+        assertFalse(cmd.loginOptions.hasUserCredentials());
+    }
+
+    @Test
+    void shouldIgnoreAllSupportedTenantSyntaxWhenClientCredentialsProvided() {
+        assertClientCredentialsOnly("-t", "acme");
+        assertClientCredentialsOnly("-t=acme");
+        assertClientCredentialsOnly("-tacme");
+        assertClientCredentialsOnly("--tenant", "acme");
+        assertClientCredentialsOnly("--tenant=acme");
+    }
+
+    @Test
+    void shouldRejectInvalidLongTenantSyntax() {
+        assertThrows(UnmatchedArgumentException.class,
+                () -> parse("--tenanttenant-value", "--client-id", "id", "--client-secret", "secret"));
+    }
+
+    @Test
     void shouldFailUserCredentialsWithoutTenant() {
         var ex = assertThrows(MissingParameterException.class,
                 () -> parse("--user", "bob", "--password", "pw"));
@@ -60,6 +84,19 @@ class FoDSessionTenantIgnoringPreprocessorTest {
 
         assertTrue(cmd.loginOptions.hasUserCredentials());
         assertDoesNotThrow(() -> cmd.loginOptions.getUserCredentials());
+    }
+
+    private static void assertClientCredentialsOnly(String... tenantArgs) {
+        var args = new ArrayList<String>();
+        Collections.addAll(args, tenantArgs);
+        args.add("--client-id");
+        args.add("id");
+        args.add("--client-secret");
+        args.add("secret");
+
+        var cmd = parse(args.toArray(String[]::new));
+        assertTrue(cmd.loginOptions.hasClientCredentials());
+        assertFalse(cmd.loginOptions.hasUserCredentials());
     }
 
     private static TestFoDLoginCommand parse(String... args) {

--- a/fcli-core/fcli-fod/src/test/java/com/fortify/cli/fod/_common/session/cli/cmd/FoDSessionTenantIgnoringPreprocessorTest.java
+++ b/fcli-core/fcli-fod/src/test/java/com/fortify/cli/fod/_common/session/cli/cmd/FoDSessionTenantIgnoringPreprocessorTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.fod._common.session.cli.cmd;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import com.fortify.cli.fod._common.session.cli.mixin.FoDSessionLoginOptions;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.MissingParameterException;
+import picocli.CommandLine.Mixin;
+
+class FoDSessionTenantIgnoringPreprocessorTest {
+    @Test
+    void shouldAllowClientCredentialsWithoutTenant() {
+        var cmd = parse("--client-id", "id", "--client-secret", "secret");
+
+        assertTrue(cmd.loginOptions.hasClientCredentials());
+        assertFalse(cmd.loginOptions.hasUserCredentials());
+    }
+
+    @Test
+    void shouldIgnoreTenantWhenClientCredentialsProvided() {
+        var cmd = parse("--tenant", "acme", "--client-id", "id", "--client-secret", "secret");
+
+        assertTrue(cmd.loginOptions.hasClientCredentials());
+        assertFalse(cmd.loginOptions.hasUserCredentials());
+    }
+
+    @Test
+    void shouldFailUserCredentialsWithoutTenant() {
+        var ex = assertThrows(MissingParameterException.class,
+                () -> parse("--user", "bob", "--password", "pw"));
+
+        assertTrue(ex.getMessage().toLowerCase().contains("tenant"));
+    }
+
+    @Test
+    void shouldAllowUserCredentialsWithTenant() {
+        var cmd = parse("--tenant", "acme", "--user", "bob", "--password", "pw");
+
+        assertTrue(cmd.loginOptions.hasUserCredentials());
+        assertDoesNotThrow(() -> cmd.loginOptions.getUserCredentials());
+    }
+
+    private static TestFoDLoginCommand parse(String... args) {
+        var cmd = new TestFoDLoginCommand();
+        var fullArgs = new ArrayList<String>();
+        fullArgs.add("--url");
+        fullArgs.add("https://example.org");
+        Collections.addAll(fullArgs, args);
+        new CommandLine(cmd).parseArgs(fullArgs.toArray(String[]::new));
+        return cmd;
+    }
+
+    @Command(name = "test-fod-login", preprocessor = FoDSessionTenantIgnoringPreprocessor.class)
+    static final class TestFoDLoginCommand {
+        @Mixin private FoDSessionLoginOptions loginOptions;
+    }
+}


### PR DESCRIPTION
The `--tenant` option was not displayed as mandatory for the `fcli fod session login` command when using the `username/password` option group. It is now required when `username` and `password` are provided, but not when using the `client-id` and `client-token` options.