### PR TITLE
fix: Prevent Failed(No response from server) output when quota filter…

### DIFF
--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/_common/exception/AviatorQuotaFilterException.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/_common/exception/AviatorQuotaFilterException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.aviator._common.exception;
+
+/**
+ * Exception thrown when quota-based filtering results in zero issues to audit.
+ * This is not a technical error but a business logic outcome indicating that
+ * all issues were filtered out based on quota and priority constraints.
+ */
+public class AviatorQuotaFilterException extends AviatorSimpleException {
+    public AviatorQuotaFilterException(String message) {
+        super(message);
+    }
+}

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/IssueAuditor.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/IssueAuditor.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fortify.cli.aviator._common.exception.AviatorQuotaFilterException;
 import com.fortify.cli.aviator._common.exception.AviatorSimpleException;
 import com.fortify.cli.aviator._common.exception.AviatorTechnicalException;
 import com.fortify.cli.aviator.audit.model.AuditOutcome;
@@ -162,7 +163,12 @@ public class IssueAuditor {
                 logger.progress("Audit completed");
             } catch (ExecutionException e) {
                 Throwable cause = e.getCause();
-                if (cause instanceof AviatorSimpleException) {
+                // Handle quota filtering exception (all issues filtered out)
+                if (cause instanceof AviatorQuotaFilterException) {
+                    logger.progress("All issues filtered out due to quota constraints: %s", cause.getMessage());
+                    // Update totalIssuesToAudit to reflect actual auditable count (0)
+                    totalIssuesToAudit = 0;
+                } else if (cause instanceof AviatorSimpleException) {
                     throw (AviatorSimpleException) cause;
                 } else if (cause instanceof AviatorTechnicalException) {
                     throw (AviatorTechnicalException) cause;

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/grpc/AviatorStreamProcessor.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/grpc/AviatorStreamProcessor.java
@@ -41,6 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fortify.aviator.grpc.*;
+import com.fortify.cli.aviator._common.exception.AviatorQuotaFilterException;
 import com.fortify.cli.aviator._common.exception.AviatorSimpleException;
 import com.fortify.cli.aviator._common.exception.AviatorTechnicalException;
 import com.fortify.cli.aviator.audit.QuotaBasedFilter;
@@ -211,6 +212,23 @@ class AviatorStreamProcessor implements AutoCloseable {
                             return; // Exit gracefully without propagating exception
                         }
                         resultFuture.completeExceptionally(new AviatorTechnicalException("Interrupted during request processing", e));
+                    } catch (AviatorQuotaFilterException e) {
+                        // Special handling for quota filtering that results in zero issues
+                        logger.info("All issues filtered out by quota constraints, closing stream gracefully");
+
+                        // Clean up stream resources BEFORE completing exceptionally
+                        stopPingPong();
+                        if (requestHandler != null && !requestHandler.isCompleted()) {
+                            requestHandler.complete();
+                        }
+                        streamLatch.countDown();
+
+                        // Complete the future exceptionally so IssueAuditor can handle it
+                        if (!resultFuture.isDone()) {
+                            resultFuture.completeExceptionally(e);
+                        }
+
+                        logger.info("Stream closed successfully after quota filtering");
                     } catch (Exception e) {
                         // Only propagate exceptions if the stream hasn't completed successfully
                         if (requestHandler != null && !requestHandler.isCompleted() && !resultFuture.isDone()) {
@@ -545,12 +563,12 @@ class AviatorStreamProcessor implements AutoCloseable {
 
         int currentQueueSize = processingQueue.size();
         if (currentQueueSize <= currentStreamState.quota) {
-            logger.info("Queue size ({}) within quota ({}), no filtering needed",
+            logger.progress("Queue size %d within quota %d, no filtering needed",
                 currentQueueSize, currentStreamState.quota);
             return;
         }
 
-        logger.warn("Queue size ({}) exceeds reserved quota ({}). Applying priority-based filtering.",
+        logger.progress("Queue size %d exceeds reserved quota %d. Applying priority-based filtering.",
             currentQueueSize, currentStreamState.quota);
 
         List<UserPrompt> allPrompts = new ArrayList<>();
@@ -586,6 +604,22 @@ class AviatorStreamProcessor implements AutoCloseable {
             });
 
         currentStreamState.actualIssuesCount = filteredPrompts.size();
+
+        // Check if filtering resulted in zero issues
+        if (filteredPrompts.isEmpty()) {
+            String reason;
+            if (customPriorityMap != null) {
+                reason = String.format("0 issues to audit as per --folder-priority-order %s",
+                    currentStreamState.customPriorityOrder);
+            } else {
+                reason = "0 issues to audit after quota-based filtering";
+            }
+
+            logger.progress("Quota filtering resulted in 0 issues to audit. Reason: %s", reason);
+            logger.info("Aborting audit - all {} issues were filtered out", currentQueueSize);
+
+            throw new AviatorQuotaFilterException(reason);
+        }
 
         int excludedCount = currentQueueSize - filteredPrompts.size();
         if (filteredPrompts.size() < currentStreamState.quota && customPriorityMap != null) {


### PR DESCRIPTION
When quota-based filtering (via --folder-priority-order) resulted in zero auditable issues, the client output is Failed(No response from server). 

In this scenario output  will  "Skipped" with the reason that "No issues to audit" 

Changes:
- Add AviatorQuotaFilterException for zero-issue quota filter scenario
- Add dedicated catch block in AviatorStreamProcessor for cleanup:
  - Stops ping-pong keepalive (stopPingPong())
  - Completes request handler (requestHandler.complete())
  - Counts down stream latch (streamLatch.countDown())
- Add exception handler in IssueAuditor to set totalIssuesToAudit=0

Result:
- Client exits cleanly within 1-2 seconds
- Displays: SKIPPED (0 issues to audit as per --folder-priority-order [...])
- No resource leaks or hanging threads