### PR TITLE
feat: Add --force-delete option to sc-dast scan delete

### DIFF
--- a/fcli-core/fcli-sc-dast/src/main/java/com/fortify/cli/sc_dast/scan/cli/cmd/action/AbstractSCDastScanActionCommand.java
+++ b/fcli-core/fcli-sc-dast/src/main/java/com/fortify/cli/sc_dast/scan/cli/cmd/action/AbstractSCDastScanActionCommand.java
@@ -43,11 +43,20 @@ public abstract class AbstractSCDastScanActionCommand extends AbstractSCDastScan
         SCDastScanDescriptor descriptor = scanResolver.getScanDescriptor(unirest);
         ObjectNode body = new ObjectMapper().createObjectNode()
                 .put("scanActionType", getAction().name());
-        unirest.post("/api/v2/scans/{id}/scan-action")
-            .routeParam("id", descriptor.getId())
-            .body(body)
+        var request = unirest.post("/api/v2/scans/{id}/scan-action")
+            .routeParam("id", descriptor.getId());
+        request = updateRequest(request);
+        request.body(body)
             .asString().getBody(); // TODO Does SC DAST return proper HTTP codes if there are any errors, or should we parse the response?
         return descriptor.asJsonNode();
+    }
+
+    /**
+     * Subclasses can override this method to add query parameters or other
+     * modifications to the request before it is sent.
+     */
+    protected kong.unirest.core.HttpRequestWithBody updateRequest(kong.unirest.core.HttpRequestWithBody request) {
+        return request;
     }
     
     @Override

--- a/fcli-core/fcli-sc-dast/src/main/java/com/fortify/cli/sc_dast/scan/cli/cmd/action/AbstractSCDastScanActionCommand.java
+++ b/fcli-core/fcli-sc-dast/src/main/java/com/fortify/cli/sc_dast/scan/cli/cmd/action/AbstractSCDastScanActionCommand.java
@@ -12,6 +12,9 @@
  */
 package com.fortify.cli.sc_dast.scan.cli.cmd.action;
 
+import java.util.Collections;
+import java.util.Map;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -45,18 +48,18 @@ public abstract class AbstractSCDastScanActionCommand extends AbstractSCDastScan
                 .put("scanActionType", getAction().name());
         var request = unirest.post("/api/v2/scans/{id}/scan-action")
             .routeParam("id", descriptor.getId());
-        request = updateRequest(request);
+        getQueryParameters().forEach(request::queryString);
         request.body(body)
             .asString().getBody(); // TODO Does SC DAST return proper HTTP codes if there are any errors, or should we parse the response?
         return descriptor.asJsonNode();
     }
 
     /**
-     * Subclasses can override this method to add query parameters or other
-     * modifications to the request before it is sent.
+     * Subclasses can override this method to provide additional query parameters
+     * for the scan-action request.
      */
-    protected kong.unirest.core.HttpRequestWithBody updateRequest(kong.unirest.core.HttpRequestWithBody request) {
-        return request;
+    protected Map<String, Object> getQueryParameters() {
+        return Collections.emptyMap();
     }
     
     @Override

--- a/fcli-core/fcli-sc-dast/src/main/java/com/fortify/cli/sc_dast/scan/cli/cmd/action/SCDastScanDeleteCommand.java
+++ b/fcli-core/fcli-sc-dast/src/main/java/com/fortify/cli/sc_dast/scan/cli/cmd/action/SCDastScanDeleteCommand.java
@@ -12,9 +12,11 @@
  */
 package com.fortify.cli.sc_dast.scan.cli.cmd.action;
 
+import java.util.Collections;
+import java.util.Map;
+
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 
-import kong.unirest.core.HttpRequestWithBody;
 import lombok.Getter;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
@@ -32,10 +34,10 @@ public class SCDastScanDeleteCommand extends AbstractSCDastScanActionCommand {
     }
 
     @Override
-    protected HttpRequestWithBody updateRequest(HttpRequestWithBody request) {
+    protected Map<String, Object> getQueryParameters() {
         if (forceDelete) {
-            request.queryString("forceDelete", "true");
+            return Map.of("forceDelete", "true");
         }
-        return request;
+        return Collections.emptyMap();
     }
 }

--- a/fcli-core/fcli-sc-dast/src/main/java/com/fortify/cli/sc_dast/scan/cli/cmd/action/SCDastScanDeleteCommand.java
+++ b/fcli-core/fcli-sc-dast/src/main/java/com/fortify/cli/sc_dast/scan/cli/cmd/action/SCDastScanDeleteCommand.java
@@ -14,16 +14,28 @@ package com.fortify.cli.sc_dast.scan.cli.cmd.action;
 
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 
+import kong.unirest.core.HttpRequestWithBody;
 import lombok.Getter;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
 
 @Command(name = OutputHelperMixins.Delete.CMD_NAME)
 public class SCDastScanDeleteCommand extends AbstractSCDastScanActionCommand {
-@Getter @Mixin private OutputHelperMixins.Delete outputHelper;
-    
+    @Getter @Mixin private OutputHelperMixins.Delete outputHelper;
+    @Option(names = {"--force-delete", "-f"}, description = "Force deletion of the scan by adding forceDelete=true query parameter")
+    private boolean forceDelete;
+
     @Override
     protected SCDastScanAction getAction() {
         return SCDastScanAction.DeleteScan;
+    }
+
+    @Override
+    protected HttpRequestWithBody updateRequest(HttpRequestWithBody request) {
+        if (forceDelete) {
+            request.queryString("forceDelete", "true");
+        }
+        return request;
     }
 }


### PR DESCRIPTION
The goal is to match the functionality offered on the GUI for deleting scans that are problematic (i.e. FailedToPause, etc...), see ForceDelete option below: 
 
<img width="359" height="183" alt="image" src="https://github.com/user-attachments/assets/ebf04959-5d99-4814-8796-c346a1ffb03e" />

## Summary
- Adds `--force-delete` / `-f` option to `fcli sc-dast scan delete` command
- When specified, appends `forceDelete=true` query parameter to the scan-action API call (`/api/v2/scans/<id>?forceDelete=true`)
- Adds a protected `updateRequest()` hook in `AbstractSCDastScanActionCommand` so subclasses can customize HTTP requests

## Test plan
- [ ] Run `fcli sc-dast scan delete <id>` without `--force-delete` — should behave as before
- [ ] Run `fcli sc-dast scan delete <id> --force-delete` — should include `?forceDelete=true` in the API call
- [ ] Run `fcli sc-dast scan delete <id> -f` — same as above using short flag
- [ ] Verify other scan action commands (pause, resume, complete, etc.) are unaffected