### PR TITLE
Fix: FoD user role lookup: show role name and validate on create/update

### DIFF
--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/access_control/cli/cmd/FoDUserCreateCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/access_control/cli/cmd/FoDUserCreateCommand.java
@@ -15,17 +15,18 @@ package com.fortify.cli.fod.access_control.cli.cmd;
 import java.util.ArrayList;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fortify.cli.common.cli.util.CommandGroup;
 import com.fortify.cli.common.cli.util.EnvSuffix;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.output.transform.IActionCommandResultSupplier;
-import com.fortify.cli.common.output.transform.IRecordTransformer;
 import com.fortify.cli.common.variable.DefaultVariablePropertyName;
 import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDJsonNodeOutputCommand;
 import com.fortify.cli.fod.access_control.helper.FoDUserCreateRequest;
 import com.fortify.cli.fod.access_control.helper.FoDUserGroupHelper;
 import com.fortify.cli.fod.access_control.helper.FoDUserHelper;
 import com.fortify.cli.fod.app.helper.FoDAppHelper;
+import com.fortify.cli.fod.rest.lookup.helper.FoDLookupDescriptor;
 
 import kong.unirest.UnirestInstance;
 import lombok.Getter;
@@ -36,7 +37,7 @@ import picocli.CommandLine.Parameters;
 
 @Command(name = "create-user") @CommandGroup("user")
 @DefaultVariablePropertyName("userId")
-public class FoDUserCreateCommand extends AbstractFoDJsonNodeOutputCommand implements IRecordTransformer, IActionCommandResultSupplier {
+public class FoDUserCreateCommand extends AbstractFoDJsonNodeOutputCommand implements IActionCommandResultSupplier {
     @Getter @Mixin private OutputHelperMixins.TableNoQuery outputHelper;
 
     @EnvSuffix("NAME") @Parameters(index = "0", descriptionKey = "user-name")
@@ -60,13 +61,14 @@ public class FoDUserCreateCommand extends AbstractFoDJsonNodeOutputCommand imple
     public JsonNode getJsonNode(UnirestInstance unirest) {
         validate();
 
+        FoDLookupDescriptor roleDescriptor = FoDUserHelper.getRoleDescriptor(unirest, roleNameOrId);
         FoDUserCreateRequest userCreateRequest = FoDUserCreateRequest.builder()
                 .userName(userName)
                 .email(email)
                 .firstName(firstName)
                 .lastName(lastName)
                 .phoneNumber(phoneNumber)
-                .roleId(FoDUserHelper.getRoleId(unirest, roleNameOrId))
+                .roleId(Integer.parseInt(roleDescriptor.getValue()))
                 .build();
 
         if (userGroups != null && userGroups.size() > 0) {
@@ -76,16 +78,13 @@ public class FoDUserCreateCommand extends AbstractFoDJsonNodeOutputCommand imple
             userCreateRequest.setApplicationIds(FoDAppHelper.getApplicationsNode(unirest, applications));
         }
 
-        return FoDUserHelper.createUser(unirest, userCreateRequest).asJsonNode();
+        ObjectNode objectNode = FoDUserHelper.createUser(unirest, userCreateRequest).asObjectNode();
+        objectNode.put("roleName", roleDescriptor.getText());
+        return objectNode;
     }
 
     private void validate() {
 
-    }
-
-    @Override
-    public JsonNode transformRecord(JsonNode record) {
-        return FoDUserHelper.renameFields(record);
     }
 
     @Override

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/access_control/cli/cmd/FoDUserUpdateCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/access_control/cli/cmd/FoDUserUpdateCommand.java
@@ -73,18 +73,17 @@ public class FoDUserUpdateCommand extends AbstractFoDJsonNodeOutputCommand imple
     public JsonNode getJsonNode(UnirestInstance unirest) {
         validate();
 
-        int roleId = 0;
         FoDUserDescriptor userDescriptor = userResolver.getUserDescriptor(unirest);
-        if (roleNameOrId != null && !roleNameOrId.isEmpty()) {
-            roleId = FoDUserHelper.getRoleId(unirest, roleNameOrId);
-        }
+        int roleId = (roleNameOrId != null && !roleNameOrId.isEmpty())
+                ? Integer.parseInt(FoDUserHelper.getRoleDescriptor(unirest, roleNameOrId).getValue())
+                : userDescriptor.getRoleId();
 
         FoDUserUpdateRequest userUpdateRequest = FoDUserUpdateRequest.builder()
                 .email(StringUtils.isNotBlank(email) ? email : userDescriptor.getEmail())
                 .firstName(StringUtils.isNotBlank(firstName) ? firstName : userDescriptor.getFirstName())
                 .lastName(StringUtils.isNotBlank(lastName) ? lastName : userDescriptor.getLastName())
                 .phoneNumber(StringUtils.isNotBlank(phoneNumber) ? phoneNumber : userDescriptor.getPhoneNumber())
-                .roleId(roleId > 0 ? roleId : userDescriptor.getRoleId())
+                .roleId(roleId)
                 .passwordNeverExpires(passwordNeverExpires)
                 .isSuspended(isSuspended)
                 .mustChange(mustChange).build();

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/access_control/helper/FoDUserHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/access_control/helper/FoDUserHelper.java
@@ -14,7 +14,6 @@ package com.fortify.cli.fod.access_control.helper;
 
 import java.util.ArrayList;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -35,6 +34,8 @@ import com.fortify.cli.fod.rest.lookup.helper.FoDLookupType;
 import kong.unirest.GetRequest;
 import kong.unirest.UnirestInstance;
 import lombok.Getter;
+import lombok.SneakyThrows;
+
 
 // TODO Methods are relatively long, consider splitting if possible
 public class FoDUserHelper {
@@ -155,19 +156,9 @@ public class FoDUserHelper {
         return userDescriptor;
     }
 
-    public static Integer getRoleId(UnirestInstance unirest, String roleNameOrId) {
-        int roleId = 0;
-        try {
-            roleId = Integer.parseInt(roleNameOrId);
-        } catch (NumberFormatException nfe) {
-            try {
-                FoDLookupDescriptor lookupDescriptor = FoDLookupHelper.getDescriptor(unirest, FoDLookupType.Roles, roleNameOrId, true);
-                roleId = Integer.valueOf(lookupDescriptor.getValue());
-            } catch (JsonProcessingException e) {
-                throw new FcliSimpleException("Unable to find role with name: " + roleNameOrId);
-            }
-        }
-        return roleId;
+    @SneakyThrows
+    public static FoDLookupDescriptor getRoleDescriptor(UnirestInstance unirest, String roleNameOrId) {
+        return FoDLookupHelper.getDescriptor(unirest, FoDLookupType.Roles, roleNameOrId, true);
     }
 
     public static JsonNode getUsersNode(UnirestInstance unirest, ArrayList<String> users) {

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/rest/lookup/helper/FoDLookupHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/rest/lookup/helper/FoDLookupHelper.java
@@ -12,8 +12,8 @@
  */
 package com.fortify.cli.fod.rest.lookup.helper;
 
-import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -38,45 +38,48 @@ public class FoDLookupHelper {
 
     public static final FoDLookupDescriptor getDescriptor(UnirestInstance unirestInstance, FoDLookupType type,
                                                         String text, boolean failIfNotFound) throws JsonProcessingException {
-        FoDLookupDescriptor currentLookup = null;
         GetRequest request = unirestInstance.get(FoDUrls.LOOKUP_ITEMS).queryString("type",
                 type.name());
         JsonNode items = request.asObject(ObjectNode.class).getBody().get("items");
         List<FoDLookupDescriptor> lookupList = objectMapper.readValue(objectMapper.writeValueAsString(items),
                 new TypeReference<List<FoDLookupDescriptor>>() {
                 });
-        Iterator<FoDLookupDescriptor> lookupIterator = lookupList.iterator();
-        while (lookupIterator.hasNext()) {
-            currentLookup = lookupIterator.next();
-            if (currentLookup.getText().equals(text)) {
+        FoDLookupDescriptor foundLookup = null;
+        for (FoDLookupDescriptor current : lookupList) {
+            if (current.getText().equals(text) || current.getValue().equals(text)) {
+                foundLookup = current;
                 break;
             }
         }
-        if (currentLookup == null && failIfNotFound) {
-            throw new FcliSimpleException("No value found for '" + text + "' in " + type.name());
+        if (foundLookup == null && failIfNotFound) {
+            var allowedValues = lookupList.stream().map(FoDLookupDescriptor::getText).collect(Collectors.joining(", "));
+            throw new FcliSimpleException(String.format("No value found for '%s' in %s (case-sensitive). Allowed values: %s", text, type.name(), allowedValues));
         }
-        return currentLookup;
+        return foundLookup;
     }
 
     public static final FoDLookupDescriptor getDescriptor(UnirestInstance unirestInstance, FoDLookupType type,
                                                         String group, String text, boolean failIfNotFound) throws JsonProcessingException {
-        FoDLookupDescriptor currentLookup = null;
         GetRequest request = unirestInstance.get(FoDUrls.LOOKUP_ITEMS).queryString("type",
                 type.name());
         JsonNode items = request.asObject(ObjectNode.class).getBody().get("items");
         List<FoDLookupDescriptor> lookupList = objectMapper.readValue(objectMapper.writeValueAsString(items),
                 new TypeReference<List<FoDLookupDescriptor>>() {
                 });
-        Iterator<FoDLookupDescriptor> lookupIterator = lookupList.iterator();
-        while (lookupIterator.hasNext()) {
-            currentLookup = lookupIterator.next();
-            if (currentLookup.getGroup().equals(group) && currentLookup.getText().equals(text)) {
+        FoDLookupDescriptor foundLookup = null;
+        for (FoDLookupDescriptor current : lookupList) {
+            if (current.getGroup().equals(group) && current.getText().equals(text)) {
+                foundLookup = current;
                 break;
             }
         }
-        if (currentLookup == null && failIfNotFound) {
-            throw new FcliSimpleException("No value found for '" + text + "' with group '" + group + "' in " + type.name());
+        if (foundLookup == null && failIfNotFound) {
+            var allowedValues = lookupList.stream()
+                    .filter(d -> d.getGroup().equals(group))
+                    .map(FoDLookupDescriptor::getText)
+                    .collect(Collectors.joining(", "));
+            throw new FcliSimpleException(String.format("No value found for '%s' with group '%s' in %s. Allowed values: %s", text, group, type.name(), allowedValues));
         }
-        return currentLookup;
+        return foundLookup;
     }
 }


### PR DESCRIPTION
Fixed a bug where an unmatched lookup would silently return the last item instead of failing, causing incorrect role assignment. User creation and update commands now throw a clear error with allowed values when an invalid role is provided, and the role name is correctly populated in the output instead of showing as N/A.

fix:FCLI - FoD create-user accepts invalid --role(#958 )
fix:FCLI - FoD - Creating a user does not display role in the output(#790 )