### PR TITLE
chore: Update Aviator product names for SAST and DAST commands

### DIFF
--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/AuditProcessor.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/AuditProcessor.java
@@ -406,7 +406,7 @@ public class AuditProcessor {
         tagHistory.appendChild(editTime);
 
         Element username = auditDoc.createElementNS(AUDIT_NAMESPACE_URI, "Username");
-        username.setTextContent("Fortify Aviator");
+        username.setTextContent(Constants.USER_NAME);
         tagHistory.appendChild(username);
 
         clientAuditTrail.appendChild(tagHistory);
@@ -460,7 +460,7 @@ public class AuditProcessor {
         commentElement.appendChild(contentElement);
 
         Element usernameElement = auditDoc.createElementNS(AUDIT_NAMESPACE_URI, "Username");
-        usernameElement.setTextContent("Fortify Aviator");
+        usernameElement.setTextContent(Constants.USER_NAME);
         commentElement.appendChild(usernameElement);
 
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/util/Constants.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/util/Constants.java
@@ -45,7 +45,7 @@ public class Constants {
     public static final String FOD_TAG_ID = "604f0fbe-b5fe-47cd-a9cb-587ad8ebe93a";
 
     // User Names
-    public static final String USER_NAME = "AppSec Aviator for Vulnerability Remediation";
+    public static final String USER_NAME = "AppSec Aviator";
 
     // Other Constants
     public static final String AUDIT_NAMESPACE_URI = "xmlns://www.fortify.com/schema/audit";

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/util/Constants.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/util/Constants.java
@@ -45,7 +45,7 @@ public class Constants {
     public static final String FOD_TAG_ID = "604f0fbe-b5fe-47cd-a9cb-587ad8ebe93a";
 
     // User Names
-    public static final String USER_NAME = "Fortify Aviator";
+    public static final String USER_NAME = "AppSec Aviator for Vulnerability Remediation";
 
     // Other Constants
     public static final String AUDIT_NAMESPACE_URI = "xmlns://www.fortify.com/schema/audit";
@@ -55,8 +55,8 @@ public class Constants {
     //Limiting Constants
     public static final int MAX_PER_CATEGORY = 500;
     public static final int MAX_TOTAL = 2500;
-    public static final String MAX_PER_CATEGORY_EXCEEDED = "Fortify detected {issues_new_in_category} new issues in this (sub)category. Fortify Aviator auditing was limited to the first {MAX_PER_CATEGORY}.";
-    public static final String MAX_TOTAL_EXCEEDED = "Fortify detected {issues_new_total} new issues. Fortify Aviator auditing was limited to {MAX_TOTAL} issues in total, while ensuring that representative issues in each category were audited.";
+    public static final String MAX_PER_CATEGORY_EXCEEDED = "Fortify detected {issues_new_in_category} new issues in this (sub)category. AppSec Aviator for Vulnerability Remediation auditing was limited to the first {MAX_PER_CATEGORY}.";
+    public static final String MAX_TOTAL_EXCEEDED = "Fortify detected {issues_new_total} new issues. AppSec Aviator for Vulnerability Remediation auditing was limited to {MAX_TOTAL} issues in total, while ensuring that representative issues in each category were audited.";
 
     // Operation constants for error messages
     public static final String OP_CREATE_APP = "application creation";

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/util/FprHandle.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/util/FprHandle.java
@@ -95,9 +95,9 @@ public final class FprHandle implements AutoCloseable {
     public void validate() {
         if (!Files.exists(getPath("/audit.fvdl"))) {
             if (Files.exists(getPath("/webinspect.xml"))) {
-                throw new AviatorSimpleException("Invalid FPR: The provided file is a DAST (WebInspect) scan result. Fortify Aviator requires an FPR from a SAST scan.");
+                throw new AviatorSimpleException("Invalid FPR: The provided file is a DAST (WebInspect) scan result. AppSec Aviator for Vulnerability Remediation requires an FPR from a SAST scan.");
             }
-            throw new AviatorSimpleException("Invalid FPR: The file does not contain 'audit.fvdl' and does not appear to be a valid SAST scan result.");
+            throw new AviatorSimpleException("Invalid FPR: The file does not contain 'audit.fvdl' and does not appear to be a valid SAST scan result for AppSec Aviator for Vulnerability Remediation.");
         }
         if (!hasSource()) {
             throw new AviatorSimpleException("Invalid FPR: Source code is missing or incomplete. The 'src-archive' directory must contain 'index.xml' and at least one source file.");

--- a/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/helper/AviatorSSCCustomTagHelper.java
+++ b/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/helper/AviatorSSCCustomTagHelper.java
@@ -97,7 +97,7 @@ public class AviatorSSCCustomTagHelper {
         ObjectNode tagNode = JsonHelper.getObjectMapper().createObjectNode();
         tagNode.put("name", tagDef.getName());
         tagNode.put("guid", tagDef.getGuid());
-        tagNode.put("description", "Custom tag for Fortify Aviator.");
+        tagNode.put("description", "Custom tag for AppSec Aviator integration.");
         tagNode.put("valueType", "LIST");
         tagNode.put("customTagType", "CUSTOM");
         ArrayNode values = tagNode.putArray("valueList");

--- a/fcli-core/fcli-aviator/src/main/resources/com/fortify/cli/aviator/i18n/AviatorMessages.properties
+++ b/fcli-core/fcli-aviator/src/main/resources/com/fortify/cli/aviator/i18n/AviatorMessages.properties
@@ -8,70 +8,70 @@ usage.description =
 delim = Change the default delimiter character when using options that accept \
   "application:version" as an argument or parameter.
 fcli.ssc.appversion.resolver.nameOrId = Application version id or <application>:<version> name.
-aviator.admin-config.name.arggroup = SAST Aviator administrator configuration name options%n
+aviator.admin-config.name.arggroup = AppSec Aviator administrator configuration name options%n
 
 # fcli aviator
-fcli.aviator.usage.header = Interact with SAST Aviator.
+fcli.aviator.usage.header = Interact with AppSec Aviator.
 
 # fcli aviator admin-config
-fcli.aviator.admin-config.usage.header = Manage SAST Aviator administrator configurations (start here).
-fcli.aviator.admin-config.admin-config = Name of the SAST Aviator administrator configuration to use. Default value: ${DEFAULT-VALUE}.
-fcli.aviator.admin-config.create.usage.header = Create an administrator configuration for interacting with SAST Aviator.
-fcli.aviator.admin-config.create.url = SAST Aviator URL.
-fcli.aviator.admin-config.create.tenant = SAST Aviator tenant.
+fcli.aviator.admin-config.usage.header = Manage AppSec Aviator administrator configurations (start here).
+fcli.aviator.admin-config.admin-config = Name of the AppSec Aviator administrator configuration to use. Default value: ${DEFAULT-VALUE}.
+fcli.aviator.admin-config.create.usage.header = Create an administrator configuration for interacting with AppSec Aviator.
+fcli.aviator.admin-config.create.url = AppSec Aviator URL.
+fcli.aviator.admin-config.create.tenant = AppSec Aviator tenant.
 fcli.aviator.admin-config.create.private-key = RSA private key. Can be specified as one of:\
   \n   file:<local file containing key>\
   \n   string:<key string value>\
   \n   env:<env-var name containing key>\
   \n  If no prefix is given, <local file> is assumed.\
   \n  Key must be in PEM format.
-fcli.aviator.admin-config.create.admin-config = Name for this SAST Aviator administrator configuration. Default value: ${DEFAULT-VALUE}.
-fcli.aviator.admin-config.delete.usage.header = Delete an SAST Aviator administrator configuration.
-fcli.aviator.admin-config.delete.admin-config = Name of the SAST Aviator administrator configuration to be deleted. Default value: ${DEFAULT-VALUE}.
-fcli.aviator.admin-config.list.usage.header = List available SAST Aviator administrator configurations.
+fcli.aviator.admin-config.create.admin-config = Name for this AppSec Aviator administrator configuration. Default value: ${DEFAULT-VALUE}.
+fcli.aviator.admin-config.delete.usage.header = Delete an AppSec Aviator administrator configuration.
+fcli.aviator.admin-config.delete.admin-config = Name of the AppSec Aviator administrator configuration to be deleted. Default value: ${DEFAULT-VALUE}.
+fcli.aviator.admin-config.list.usage.header = List available AppSec Aviator administrator configurations.
 
 # fcli aviator session
-fcli.aviator.session.usage.header = Manage SAST Aviator user sessions (start here).
-fcli.aviator.session.option.aviator-session = Name of the SAST Aviator user session to use. Default value: ${DEFAULT-VALUE}.
-fcli.aviator.session.login.usage.header = Create a user session for interacting with SAST Aviator.
-fcli.aviator.session.login.url = SAST Aviator URL.
-fcli.aviator.session.login.token = SAST Aviator user access token. Can be specified as one of:\
+fcli.aviator.session.usage.header = Manage AppSec Aviator user sessions (start here).
+fcli.aviator.session.option.aviator-session = Name of the AppSec Aviator user session to use. Default value: ${DEFAULT-VALUE}.
+fcli.aviator.session.login.usage.header = Create a user session for interacting with AppSec Aviator.
+fcli.aviator.session.login.url = AppSec Aviator URL.
+fcli.aviator.session.login.token = AppSec Aviator user access token. Can be specified as one of:\
   \n   file:<local file containing token>\
   \n   string:<token string value>\
   \n   env:<env-var name containing token>\
   \n  If no prefix is given, <local file> is assumed.\
   \n  For security reasons, avoid specifying sensitive tokens directly\
   \n  on the command line (using string:). Prefer using files or env:.
-fcli.aviator.session.logout.usage.header = Terminate an SAST Aviator user session.
-fcli.aviator.session.list.usage.header = List active and expired SAST Aviator user sessions.
+fcli.aviator.session.logout.usage.header = Terminate an AppSec Aviator user session.
+fcli.aviator.session.list.usage.header = List active and expired AppSec Aviator user sessions.
 
 # fcli aviator app
-fcli.aviator.app.usage.header = Manage SAST Aviator applications.
-fcli.aviator.app.usage.description = Commands for managing Aviator applications. These commands require an administrator configuration. Use 'fcli aviator admin-config create' to create a configuration.
+fcli.aviator.app.usage.header = Manage AppSec Aviator applications.
+fcli.aviator.app.usage.description = Commands for managing AppSec Aviator applications. These commands require an administrator configuration. Use 'fcli aviator admin-config create' to create a configuration.
 
-fcli.aviator.app.create.usage.header = Create a new SAST Aviator application.
-fcli.aviator.app.create.usage.description = Creates a new Aviator application within the tenant specified in the admin configuration.
+fcli.aviator.app.create.usage.header = Create a new AppSec Aviator application.
+fcli.aviator.app.create.usage.description = Creates a new AppSec Aviator application within the tenant specified in the admin configuration.
 fcli.aviator.app.create.name = Name of the application to create.
 
-fcli.aviator.app.delete.usage.header = Delete an SAST Aviator application.
-fcli.aviator.app.delete.usage.description = Deletes an Aviator application by its ID from the tenant specified in the admin configuration.
+fcli.aviator.app.delete.usage.header = Delete an AppSec Aviator application.
+fcli.aviator.app.delete.usage.description = Deletes an AppSec Aviator application by its ID from the tenant specified in the admin configuration.
 fcli.aviator.app.delete.applicationId = ID of the application to delete.
 
-fcli.aviator.app.get.usage.header = Get an SAST Aviator application.
-fcli.aviator.app.get.usage.description = Retrieves details for a specific Aviator application by its ID.
+fcli.aviator.app.get.usage.header = Get an AppSec Aviator application.
+fcli.aviator.app.get.usage.description = Retrieves details for a specific AppSec Aviator application by its ID.
 fcli.aviator.app.get.applicationId = ID of the application to retrieve.
 
-fcli.aviator.app.list.usage.header = List SAST Aviator applications.
-fcli.aviator.app.list.usage.description = Lists all Aviator applications for the tenant specified in the admin configuration.
+fcli.aviator.app.list.usage.header = List AppSec Aviator applications.
+fcli.aviator.app.list.usage.description = Lists all AppSec Aviator applications for the tenant specified in the admin configuration.
 
-fcli.aviator.app.update.usage.header = Update an SAST Aviator application.
-fcli.aviator.app.update.usage.description = Updates an existing Aviator application, identified by its ID. Currently, this only supports renaming the application.
+fcli.aviator.app.update.usage.header = Update an AppSec Aviator application.
+fcli.aviator.app.update.usage.description = Updates an existing AppSec Aviator application, identified by its ID. Currently, this only supports renaming the application.
 fcli.aviator.app.update.applicationId = ID of the application to update.
 fcli.aviator.app.update.name = The new name for the application.
 
 # fcli aviator token
-fcli.aviator.token.usage.header = Manage SAST Aviator access tokens.
-fcli.aviator.token.usage.description = Commands for creating, deleting, revoking, listing, and validating SAST Aviator access tokens. These commands require an administrator configuration.
+fcli.aviator.token.usage.header = Manage AppSec Aviator access tokens.
+fcli.aviator.token.usage.description = Commands for creating, deleting, revoking, listing, and validating AppSec Aviator access tokens. These commands require an administrator configuration.
 
 fcli.aviator.token.create.usage.header = Create a user access token.
 fcli.aviator.token.create.usage.description = Creates a new access token for a user within the tenant specified in the admin configuration.
@@ -93,62 +93,63 @@ fcli.aviator.token.list.usage.description = Retrieves a list of access tokens. C
 fcli.aviator.token.list.email = User's email address to  Filter the list for tokens associated with this email address (optional).
 
 fcli.aviator.token.validate.usage.header = Validate a user access token.
-fcli.aviator.token.validate.usage.description = Validates an access token, checking its authenticity and status against the SAST Aviator service.
+fcli.aviator.token.validate.usage.description = Validates an access token, checking its authenticity and status against the AppSec Aviator service.
 
 # fcli aviator entitlement
-fcli.aviator.entitlement.usage.header = Manage Aviator entitlements.
-fcli.aviator.entitlement.usage.description = Commands for managing SAST and DAST Aviator entitlements. These commands require an administrator configuration.
+fcli.aviator.entitlement.usage.header = Manage AppSec Aviator entitlements.
+fcli.aviator.entitlement.usage.description = Commands for managing AppSec Aviator for Vulnerability Remediation and \
+  AppSec Aviator for DAST Automation entitlements. These commands require an administrator configuration.
 
-fcli.aviator.entitlement.list.usage.header = (DEPRECATED) List SAST entitlements for a tenant.
+fcli.aviator.entitlement.list.usage.header = (DEPRECATED) List AppSec Aviator for Vulnerability Remediation entitlements for a tenant.
 fcli.aviator.entitlement.list.usage.description = This command is deprecated, please use 'fcli aviator entitlement list-sast' instead. \
-  Retrieves a list of SAST entitlements for the tenant specified in the admin configuration.
+  Retrieves a list of AppSec Aviator for Vulnerability Remediation entitlements for the tenant specified in the admin configuration.
 
-fcli.aviator.entitlement.list-sast.usage.header = List SAST entitlements for a tenant.
-fcli.aviator.entitlement.list-sast.usage.description = Retrieves a list of SAST entitlements for the tenant specified in the admin configuration.
+fcli.aviator.entitlement.list-sast.usage.header = List AppSec Aviator for Vulnerability Remediation entitlements for a tenant.
+fcli.aviator.entitlement.list-sast.usage.description = Retrieves a list of AppSec Aviator for Vulnerability Remediation entitlements for the tenant specified in the admin configuration.
 
-fcli.aviator.entitlement.list-dast.usage.header = List DAST entitlements for a tenant.
-fcli.aviator.entitlement.list-dast.usage.description = Retrieves a list of DAST entitlements with credit balance details for the tenant specified in the admin configuration.
+fcli.aviator.entitlement.list-dast.usage.header = List AppSec Aviator for DAST Automation entitlements for a tenant.
+fcli.aviator.entitlement.list-dast.usage.description = Retrieves a list of AppSec Aviator for DAST Automation entitlements with credit balance details for the tenant specified in the admin configuration.
 
 # fcli aviator ssc
-fcli.aviator.ssc.usage.header = Use SAST Aviator with SSC.
-fcli.aviator.ssc.audit.usage.header = Audit an SSC application version using SAST Aviator.
-fcli.aviator.ssc.audit.usage.description = Downloads the FPR from an SSC application version, audits it with SAST Aviator, and uploads the result back to SSC. \
+fcli.aviator.ssc.usage.header = Use AppSec Aviator with SSC.
+fcli.aviator.ssc.audit.usage.header = Audit an SSC application version using AppSec Aviator for Vulnerability Remediation.
+fcli.aviator.ssc.audit.usage.description = Downloads the FPR from an SSC application version, audits it with AppSec Aviator for Vulnerability Remediation, and uploads the result back to SSC. \
   This command requires an active user session. Use 'fcli aviator session login' to create a session. \
   This command doesn't wait for SSC to finish processing the audited FPR file; please use the 'fcli ssc artifact wait-for' \
   command to wait until the audited FPR file has been processed by SSC.
-fcli.aviator.ssc.audit.app = SAST Aviator application name to associate with the audit. If not provided, the SAST/FPR Build ID of the ssc application is used.
+fcli.aviator.ssc.audit.app = AppSec Aviator application name to associate with the audit. If not provided, the SAST/FPR Build ID of the SSC application is used.
 fcli.aviator.ssc.audit.tag-mapping = Custom tag mapping for audit results.
 fcli.aviator.ssc.audit.filterset = Name or ID of the FilterSet to apply.
 fcli.aviator.ssc.audit.no-filterset = Do not apply any filter sets, including the default enabled filter set from the FPR.
 fcli.aviator.ssc.audit.folder = Filter issues by a comma-separated list of specific folder names from the selected FilterSet (e.g., 'Hot,Critical'). This option requires a FilterSet to be active.
-fcli.aviator.ssc.audit.skip-if-exceeding-quota = Skip audit if the number of open issues exceeds the available Aviator quota. When skipped, a summary with top unaudited categories is shown.
-fcli.aviator.ssc.audit.test-exceeding-quota = Check whether the number of open issues exceeds the available Aviator quota and report the result without performing an audit.
-fcli.aviator.ssc.audit.default-quota-fallback = (Internal) When the Aviator application does not exist, use the tenant default quota instead of reporting app not found. Used by bulk audit.
+fcli.aviator.ssc.audit.skip-if-exceeding-quota = Skip audit if the number of open issues exceeds the available AppSec Aviator for Vulnerability Remediation quota. When skipped, a summary with top unaudited categories is shown.
+fcli.aviator.ssc.audit.test-exceeding-quota = Check whether the number of open issues exceeds the available AppSec Aviator for Vulnerability Remediation quota and report the result without performing an audit.
+fcli.aviator.ssc.audit.default-quota-fallback = (Internal) When the AppSec Aviator application does not exist, use the tenant default quota instead of reporting app not found. Used by bulk audit.
 fcli.aviator.ssc.audit.folder-priority-order = Custom priority order for folder-based filtering when quota is exceeded (comma-separated, highest priority first). Example: Critical,High,Medium,Low. If not specified, uses default priority order.
 fcli.aviator.ssc.audit.refresh = By default, this command will refresh the  source application version's metrics when copying from it. \
   Note that for large applications this can lead to an error if the timeout expires.
 fcli.aviator.ssc.audit.refresh-timeout = Time-out, for example 30s (30 seconds), 5m (5 minutes), 1h (1 hour). Default value: ${DEFAULT-VALUE}
 
-fcli.aviator.ssc.apply-remediations.usage.header = Apply auto-remediations from an Aviator-processed artifact to source code.
-fcli.aviator.ssc.apply-remediations.usage.description = Downloads FPR artifact(s) and applies Aviator-generated remediations to the specified source directory. \
+fcli.aviator.ssc.apply-remediations.usage.header = Apply remediations from an AppSec Aviator-processed artifact to source code.
+fcli.aviator.ssc.apply-remediations.usage.description = Downloads FPR artifact(s) and applies remediations generated by AppSec Aviator for Vulnerability Remediation to the specified source directory. \
   Exactly one of --artifact-id, --latest, or --all must be specified. \
   This command requires an active user session. Use 'fcli aviator session login' to create a session. \
   %n%nExamples: \
   %n%n Apply remediations from a known artifact by ID: \
   %n   fcli aviator ssc apply-remediations --artifact-id 12345 \
-  %n%n Apply remediations from the latest Aviator-processed artifact for an application version: \
+  %n%n Apply remediations from the latest AppSec Aviator-processed artifact for an application version: \
   %n   fcli aviator ssc apply-remediations --av "MyApp:1.0" --latest \
   %n%n Apply remediations from the latest artifact, restricting to those uploaded in the last 7 days: \
   %n   fcli aviator ssc apply-remediations --av "MyApp:1.0" --latest --since 7d \
-  %n%n Apply remediations across all Aviator-processed artifacts for an application version: \
+  %n%n Apply remediations across all AppSec Aviator-processed artifacts for an application version: \
   %n   fcli aviator ssc apply-remediations --av "MyApp:1.0" --all \
   %n%n Apply remediations across all artifacts uploaded in the last 2 weeks: \
   %n   fcli aviator ssc apply-remediations --av "MyApp:1.0" --all --since 2w \
   %n%n Apply remediations from the latest artifact using a custom source directory: \
   %n   fcli aviator ssc apply-remediations --av "MyApp:1.0" --latest --source-dir /path/to/src
 fcli.aviator.ssc.apply-remediations.artifact-id = Specific artifact ID to process. Mutually exclusive with --latest and --all.
-fcli.aviator.ssc.apply-remediations.latest = Automatically select the most recent Aviator-processed artifact. Requires --av/--appversion. Mutually exclusive with --artifact-id and --all.
-fcli.aviator.ssc.apply-remediations.all = Apply remediations from all Aviator-processed artifacts for the given application version, \
+fcli.aviator.ssc.apply-remediations.latest = Automatically select the most recent AppSec Aviator-processed artifact. Requires --av/--appversion. Mutually exclusive with --artifact-id and --all.
+fcli.aviator.ssc.apply-remediations.all = Apply remediations from all AppSec Aviator-processed artifacts for the given application version, \
   in chronological order. Aggregates remediation statistics across all artifacts. \
   Requires --av/--appversion. Mutually exclusive with --artifact-id and --latest.
 fcli.aviator.ssc.apply-remediations.source-dir = Source code directory where remediations will be applied. Defaults to current directory.
@@ -156,10 +157,10 @@ fcli.aviator.ssc.apply-remediations.since = Filter artifacts by upload date. Sup
   or absolute dates (e.g. 2025-01-01, 2025-01-01T10:30:00, 2025-01-01T10:30:00Z). \
   Can only be used with --latest or --all; not compatible with --artifact-id.
 
-fcli.aviator.ssc.prepare.usage.header = (PREVIEW) Prepare an SSC instance for Aviator integration.
-fcli.aviator.ssc.prepare.usage.description = This command ensures that the Aviator-specific custom tags ('Aviator prediction',`Aviator status`) \
+fcli.aviator.ssc.prepare.usage.header = (PREVIEW) Prepare an SSC instance for AppSec Aviator integration.
+fcli.aviator.ssc.prepare.usage.description = This command ensures that the AppSec Aviator-specific custom tags ('Aviator prediction',`Aviator status`) \
   exist in SSC and are associated with the specified issue templates and/or application versions. \
-  This is necessary to prevent SSC from stripping Aviator audit data from uploaded FPR files. \
+  This is necessary to prevent SSC from stripping AppSec Aviator audit data from uploaded FPR files. \
   At least one update option must be specified. \
   %n%nNOTE\: This command is considered preview functionality as it will likely change in a future fcli version \
   to re-use generic tag update functionality that is planned for the fcli ssc module.
@@ -169,9 +170,9 @@ fcli.aviator.ssc.prepare.appversion = Update a single application version by its
 fcli.aviator.ssc.prepare.all-appversions = Update all application versions on the SSC instance.
 
 #fcli aviator fod
-fcli.aviator.fod.usage.header = Use SAST Aviator with FoD.
-fcli.aviator.fod.apply-remediations.usage.header = Apply remediations on the user source code proposed by latest scan for release Id.
-fcli.aviator.fod.apply-remediations.usage.description = Downloads the FPR from an Fod Release ID, apply the remediations proposed by SAST Aviator on the user's source code directory.\
+fcli.aviator.fod.usage.header = Use AppSec Aviator with FoD.
+fcli.aviator.fod.apply-remediations.usage.header = Apply AppSec Aviator for Vulnerability Remediation remediations to source code from a FoD release.
+fcli.aviator.fod.apply-remediations.usage.description = Downloads the FPR from a FoD Release ID and applies remediations proposed by AppSec Aviator for Vulnerability Remediation to the user's source code directory.\
   This command requires an active user session. Use 'fcli aviator session login' to create a session. \
 #fcli.aviator.fod.apply-remediations.releaseId = Downloads the FPR based on the release ID
 fcli.fod.release.resolver.name-or-id = Release id or <application>[:<microservice>]:<release> name.

--- a/fcli-core/fcli-common/src/main/resources/com/fortify/cli/common/i18n/FortifyCLIMessages.properties
+++ b/fcli-core/fcli-common/src/main/resources/com/fortify/cli/common/i18n/FortifyCLIMessages.properties
@@ -132,10 +132,10 @@ progress=Configure progress output. Allowed values: ${COMPLETION-CANDIDATES}. De
   ${DEFAULT-VALUE}. Proper output of single-line and ansi depends on console capabilities.
 
 # Login and connection options
-aviator.user-session.name.arggroup = Aviator user session name options%n
-aviator.admin-session.name.arggroup = Aviator administrator session name options%n
-aviator-session = Name of the Aviator user session to use for executing this command. Default value: ${DEFAULT-VALUE}.
-aviator-admin-session = Name of the Aviator administrator session to use for executing this command. Default value: ${DEFAULT-VALUE}.
+aviator.user-session.name.arggroup = AppSec Aviator user session name options%n
+aviator.admin-session.name.arggroup = AppSec Aviator administrator session name options%n
+aviator-session = Name of the AppSec Aviator user session to use for executing this command. Default value: ${DEFAULT-VALUE}.
+aviator-admin-session = Name of the AppSec Aviator administrator session to use for executing this command. Default value: ${DEFAULT-VALUE}.
 ssc.session.name.arggroup = SSC session name options%n
 ssc-session = Name of the SSC session to use for executing this command. Default value: ${DEFAULT-VALUE}.
 fod.session.name.arggroup = FoD session name options%n

--- a/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
+++ b/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
@@ -563,7 +563,7 @@ fcli.fod.sast-scan.setup.include-third-party-libs = (LEGACY) Indicates if third 
 fcli.fod.sast-scan.setup.use-source-control = (LEGACY) Indicates if source control should be used.
 fcli.fod.sast-scan.setup.skip-if-exists = Skip setup if a scan has already been set up. If not specified, any existing scan \
   setup will be replaced based on the given setup options.
-fcli.fod.sast-scan.setup.use-aviator = Use Fortify Aviator to audit results and provide enhanced remediation guidance.
+fcli.fod.sast-scan.setup.use-aviator = Use AppSec Aviator for Vulnerability Remediation to audit results and provide enhanced remediation guidance.
 fcli.fod.sast-scan.import.usage.header = Import existing SAST scan results (from an FPR file).
 fcli.fod.sast-scan.import.usage.description = As FoD doesn't return a scan id for imported scans, the output of this command cannot be used with commands that expect a scan id, like the wait-for command.
 fcli.fod.sast-scan.import.file = FPR file containing existing SAST scan results to be imported.
@@ -1006,8 +1006,8 @@ fcli.fod.attribute.update.values = List of picklist values (only for Picklist da
 
 
 # fcli fod aviator
-fcli.fod.aviator.usage.header = Manage FoD Aviator operations.
-fcli.fod.aviator.apply-remediations.usage.header = Apply Aviator auto-remediations to source code.
+fcli.fod.aviator.usage.header = Manage FoD AppSec Aviator operations.
+fcli.fod.aviator.apply-remediations.usage.header = Apply AppSec Aviator for Vulnerability Remediation auto-remediations to source code.
 fcli.fod.aviator.apply-remediations.source-dir = Directory containing source code to apply remediations to. Default value: ${DEFAULT-VALUE}.
 
 

--- a/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/actions/zip/bulkaudit.yaml
+++ b/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/actions/zip/bulkaudit.yaml
@@ -2,19 +2,19 @@
 
 author: Fortify
 usage:
-  header: (PREVIEW) Perform SAST Aviator audits of SSC application versions in bulk.
+  header: (PREVIEW) Perform AppSec Aviator for Vulnerability Remediation audits of SSC application versions in bulk.
   description: |
     This action identifies SSC application versions with pending audit issues and
-    automatically submits them for auditing by Fortify SAST Aviator. The action
+    automatically submits them for auditing by AppSec Aviator for Vulnerability Remediation. The action
     intelligently filters to only process versions with actual pending audit issues,
     while ignoring versions for which audit information needs to be refreshed.
 
-    For application versions that don't already exist in Aviator, the action will
+    For application versions that don't already exist in AppSec Aviator, the action will
     automatically create them before submitting for audit.
 
     By default (--aviator-app-mapping=app), SSC project versions map to a single
-    Aviator application per SSC project. Set --aviator-app-mapping=version to map
-    each SSC project version to its own Aviator application (project_name__version_name).
+    AppSec Aviator application per SSC project. Set --aviator-app-mapping=version to map
+    each SSC project version to its own AppSec Aviator application (project_name__version_name).
 
     When quota limits are exceeded for any application, issues are prioritized by
     folder using either the default order (Critical > High > Medium > Low) or a
@@ -23,11 +23,11 @@ usage:
 
     Either --tag-mapping or --add-aviator-tags must be specified. The default tag
     mapping leaves unsure issues unaudited, causing indefinite reselection. Use
-    a custom mapping file or 'fcli ssc aviator prepare' to configure Aviator-specific
+    a custom mapping file or 'fcli aviator ssc prepare' to configure AppSec Aviator-specific
     issue templates.
 
-    This action assumes active sessions with SSC, Aviator (user role for auditing),
-    and Aviator (admin role for application listing and creation).
+    This action assumes active sessions with SSC, AppSec Aviator (user role for auditing),
+    and AppSec Aviator (admin role for application listing and creation).
 
 config:
   output: immediate
@@ -45,7 +45,7 @@ cli.options:
     type: int
   aviator-app-mapping:
     names: --aviator-app-mapping
-    description: "Controls how SSC project versions map to Aviator applications. 'app' (default) maps one Aviator app per SSC project; 'version' maps one Aviator app per SSC project version (using project_name__version_name)."
+    description: "Controls how SSC project versions map to AppSec Aviator applications. 'app' (default) maps one AppSec Aviator app per SSC project; 'version' maps one AppSec Aviator app per SSC project version (using project_name__version_name)."
     required: false
     default: app
   filter:
@@ -60,13 +60,13 @@ cli.options:
     default: ""
   dry-run:
     names: --dry-run, -n
-    description: "Show what aviator commands would be executed without actually running them. Default: false"
+    description: "Show what fcli aviator commands would be executed without actually running them. Default: false"
     required: false
     default: false
     type: boolean
   tag-mapping:
     names: --tag-mapping, -t
-    description: "Path to tag mapping YAML file. This custom mapping ensures that SAST Aviator 'Unsure' audit results are properly handled. Required unless --add-aviator-tags is specified."
+    description: "Path to tag mapping YAML file. This custom mapping ensures that AppSec Aviator for Vulnerability Remediation 'Unsure' audit results are properly handled. Required unless --add-aviator-tags is specified."
     required: false
   add-aviator-tags:
     names: --add-aviator-tags
@@ -87,13 +87,13 @@ cli.options:
     default: "60s"
   skip-if-exceeding-quota:
     names: --skip-if-exceeding-quota
-    description: "Skip audit if the number of open issues exceeds the available Aviator quota. When skipped, a summary with top unaudited categories is shown. Default: false"
+    description: "Skip audit if the number of open issues exceeds the available AppSec Aviator for Vulnerability Remediation quota. When skipped, a summary with top unaudited categories is shown. Default: false"
     required: false
     default: false
     type: boolean
   test-exceeding-quota:
     names: --test-exceeding-quota
-    description: "Check whether the number of open issues exceeds the available Aviator quota and report the result without performing an audit. Default: false"
+    description: "Check whether the number of open issues exceeds the available AppSec Aviator for Vulnerability Remediation quota and report the result without performing an audit. Default: false"
     required: false
     default: false
     type: boolean
@@ -128,10 +128,10 @@ steps:
       - log.progress: "ERROR: --dry-run and --skip-if-exceeding-quota cannot be used together. --dry-run prevents server interaction, but --skip-if-exceeding-quota requires quota retrieval."
       - throw: "--dry-run and --skip-if-exceeding-quota cannot be used together. --dry-run prevents server interaction, but --skip-if-exceeding-quota requires quota retrieval."
 
-  - log.progress: "Using Aviator app mapping: ${cli['aviator-app-mapping']}"
+  - log.progress: "Using AppSec Aviator app mapping: ${cli['aviator-app-mapping']}"
 
   # Get existing Aviator applications
-  - log.progress: Retrieving existing Aviator applications...
+  - log.progress: Retrieving existing AppSec Aviator applications...
   - run.fcli:
       aviator_apps:
         cmd: aviator app ls -o json
@@ -355,7 +355,7 @@ steps:
                 # would be exceeded, skip the version entirely (don't create, don't audit).
                 - if: ${!skip_this_version && cli['skip-if-exceeding-quota'] && !app_known_in_aviator}
                   do:
-                    - log.progress: Pre-checking default quota for new app ${project.aviator_app_name}...
+                    - log.progress: Pre-checking default AppSec Aviator quota for new app ${project.aviator_app_name}...
 
                     - if: ${cli['tag-mapping'] != null && cli['tag-mapping'] != ''}
                       run.fcli:
@@ -376,7 +376,7 @@ steps:
                     # If pre-check shows quota exceeded, skip this version entirely
                     - if: ${quota_precheck.exitCode == 0 && quota_precheck.records != null && quota_precheck.records.size() > 0 && quota_precheck.records[0].__action__ != null && quota_precheck.records[0].__action__ == 'QUOTA_EXCEEDED'}
                       do:
-                        - log.progress: Default quota exceeded for ${project.aviator_app_name} - skipping app creation and audit
+                        - log.progress: Default AppSec Aviator quota exceeded for ${project.aviator_app_name} - skipping app creation and audit
                         - var.set:
                             skip_this_version: true
                             stats.quota_skipped: ${stats.quota_skipped + 1}
@@ -427,14 +427,14 @@ steps:
                     # Prepare Aviator tags if requested
                     - if: ${cli['add-aviator-tags']}
                       do:
-                        - log.progress: Preparing Aviator tags for ${project.project_name}:${project.version_name}
+                        - log.progress: Preparing AppSec Aviator tags for ${project.project_name}:${project.version_name}
                         - run.fcli:
                             prepare_tags:
                               cmd: aviator ssc prepare --av "${project.id}"
                               status.check: false
                         - if: ${prepare_tags.exitCode != 0}
                           do:
-                            - log.warn: Aviator tag preparation failed for ${project.project_name}:${project.version_name}
+                            - log.warn: AppSec Aviator tag preparation failed for ${project.project_name}:${project.version_name}
 
                     # Run audit if app is ready
                     - if: ${app_ready}


### PR DESCRIPTION
Updates all customer-facing Aviator strings in CLI help, message bundles, SSC bulk audit action, and runtime labels to the new AppSec Aviator naming. Command namespaces (e.g. fcli aviator) are unchanged.