### PR TITLE
Added --validate option to validate session live status for FoD and SSC

### DIFF
--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/action/cli/cmd/AbstractActionSignCommand.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/action/cli/cmd/AbstractActionSignCommand.java
@@ -43,7 +43,7 @@ import picocli.CommandLine.Option;
 public class AbstractActionSignCommand extends AbstractOutputCommand implements IJsonNodeSupplier, IActionCommandResultSupplier {
     private static final ObjectMapper objectMapper = JsonHelper.getObjectMapper();
     private static final Logger LOG = LoggerFactory.getLogger(AbstractActionSignCommand.class);
-    @Getter @Mixin OutputHelperMixins.TableNoQuery outputHelper;
+    @Getter @Mixin private OutputHelperMixins.TableNoQuery outputHelper;
     @Option(names = "--in", required=true, descriptionKey="fcli.action.sign.in") 
     private Path actionFileToSign;
     @Option(names = "--out", required=true, descriptionKey="fcli.action.sign.out")

--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/session/cli/mixin/ValidateSessionOptionMixin.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/session/cli/mixin/ValidateSessionOptionMixin.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.common.session.cli.mixin;
+
+import java.util.function.Consumer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import picocli.CommandLine.Option;
+
+public class ValidateSessionOptionMixin {
+    @Option(names = {"--validate"}, required = false, descriptionKey = "fcli.session.validate")
+    private boolean validate;
+    
+    public void validateIfNeeded(ArrayNode result, Consumer<JsonNode> validator) {
+        if (validate) {
+            result.forEach(validator);
+        }
+    }
+}

--- a/fcli-core/fcli-common/src/main/resources/com/fortify/cli/common/i18n/FortifyCLIMessages.properties
+++ b/fcli-core/fcli-common/src/main/resources/com/fortify/cli/common/i18n/FortifyCLIMessages.properties
@@ -144,6 +144,7 @@ url = Base URL for accessing the remote system.
 k = Disable SSL checks.
 connect-timeout = Connection timeout for this session, for example 30s (30 seconds), 5m (5 minutes). Default value: ${default-connect-timeout}. 
 socket-timeout = Socket timeout for this session, for example 30s (30 seconds), 5m (5 minutes). Default value: ${default-socket-timeout}.
+fcli.session.validate = Verify the actual session status against the server.
 
 #################################################################################################################
 # The following are technical properties that shouldn't be internationalized ####################################

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/cli/cmd/FoDSessionListCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/cli/cmd/FoDSessionListCommand.java
@@ -15,12 +15,14 @@ package com.fortify.cli.fod._common.session.cli.cmd;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fortify.cli.common.exception.FcliSimpleException;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.session.cli.cmd.AbstractSessionListCommand;
 import com.fortify.cli.common.session.cli.mixin.ValidateSessionOptionMixin;
 import com.fortify.cli.fod._common.session.helper.FoDSessionDescriptor;
 import com.fortify.cli.fod._common.session.helper.FoDSessionHelper;
-import com.fortify.cli.fod._common.session.helper.oauth.FoDOAuthHelper;
+import com.fortify.cli.fod._common.session.helper.FoDSessionValidationHelper;
+import com.fortify.cli.fod._common.session.helper.FoDSessionValidationHelper.SessionStatus;
 
 import lombok.Getter;
 import picocli.CommandLine.Command;
@@ -35,21 +37,36 @@ public class FoDSessionListCommand extends AbstractSessionListCommand<FoDSession
     @Override
     public JsonNode getJsonNode() {
         var result = (ArrayNode)super.getJsonNode();
-        validateSessionOption.validateIfNeeded(result, this::validateSession);
+        validateSessionOption.validateIfNeeded(result, this::enrichSessionNode);
         return result;
     }
 
-    private void validateSession(JsonNode sessionNode) {
+    private void enrichSessionNode(JsonNode sessionNode) {
         if ( sessionNode instanceof ObjectNode session ) {
             var sessionName = session.path("name").asText(null);
             var descriptor = sessionName==null ? null : getSessionHelper().get(sessionName, false);
             var tokenResponse = descriptor==null ? null : descriptor.getCachedTokenResponse();
             var accessToken = tokenResponse==null ? null : tokenResponse.getAccessToken();
-            var isValid = accessToken!=null && FoDOAuthHelper.validateToken(descriptor.getUrlConfig(), accessToken);
-            session.put("expired", isValid ? "No" : "Yes");
-            if ( !isValid ) {
-                session.put("expires", "N/A");
+            if ( descriptor==null || accessToken==null ) {
+                applySessionStatus(session, new SessionStatus(false, null));
+                return;
             }
+            try {
+                var status = FoDSessionValidationHelper.checkTokenStatus(descriptor.getUrlConfig(), accessToken);
+                applySessionStatus(session, status);
+            } catch ( FcliSimpleException e ) {
+                session.put("expired", "Unknown");
+                session.put("expires", "Unknown");
+            }
+        }
+    }
+
+    private void applySessionStatus(ObjectNode session, SessionStatus status) {
+        session.put("expired", status.valid() ? "No" : "Yes");
+        if ( !status.valid() ) {
+            session.put("expires", "N/A");
+        } else {
+            session.put("expires", session.has("expires") ? session.get("expires").asText() : "Unknown");
         }
     }
 }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/cli/cmd/FoDSessionListCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/cli/cmd/FoDSessionListCommand.java
@@ -12,10 +12,15 @@
  */
 package com.fortify.cli.fod._common.session.cli.cmd;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.session.cli.cmd.AbstractSessionListCommand;
+import com.fortify.cli.common.session.cli.mixin.ValidateSessionOptionMixin;
 import com.fortify.cli.fod._common.session.helper.FoDSessionDescriptor;
 import com.fortify.cli.fod._common.session.helper.FoDSessionHelper;
+import com.fortify.cli.fod._common.session.helper.oauth.FoDOAuthHelper;
 
 import lombok.Getter;
 import picocli.CommandLine.Command;
@@ -24,5 +29,27 @@ import picocli.CommandLine.Mixin;
 @Command(name = OutputHelperMixins.List.CMD_NAME, sortOptions = false)
 public class FoDSessionListCommand extends AbstractSessionListCommand<FoDSessionDescriptor> {
     @Getter @Mixin private OutputHelperMixins.List outputHelper;
+    @Mixin private ValidateSessionOptionMixin validateSessionOption;
     @Getter private FoDSessionHelper sessionHelper = FoDSessionHelper.instance();
+
+    @Override
+    public JsonNode getJsonNode() {
+        var result = (ArrayNode)super.getJsonNode();
+        validateSessionOption.validateIfNeeded(result, this::validateSession);
+        return result;
+    }
+
+    private void validateSession(JsonNode sessionNode) {
+        if ( sessionNode instanceof ObjectNode session ) {
+            var sessionName = session.path("name").asText(null);
+            var descriptor = sessionName==null ? null : getSessionHelper().get(sessionName, false);
+            var tokenResponse = descriptor==null ? null : descriptor.getCachedTokenResponse();
+            var accessToken = tokenResponse==null ? null : tokenResponse.getAccessToken();
+            var isValid = accessToken!=null && FoDOAuthHelper.validateToken(descriptor.getUrlConfig(), accessToken);
+            session.put("expired", isValid ? "No" : "Yes");
+            if ( !isValid ) {
+                session.put("expires", "N/A");
+            }
+        }
+    }
 }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/helper/FoDSessionValidationHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/helper/FoDSessionValidationHelper.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.fod._common.session.helper;
+
+import com.fortify.cli.common.exception.FcliSimpleException;
+import com.fortify.cli.common.rest.unirest.UnexpectedHttpResponseException;
+import com.fortify.cli.common.rest.unirest.UnirestHelper;
+import com.fortify.cli.common.rest.unirest.config.IUrlConfig;
+import com.fortify.cli.fod._common.session.helper.oauth.FoDTokenCreateResponse;
+
+import kong.unirest.UnirestInstance;
+
+public class FoDSessionValidationHelper {
+    public static record SessionStatus(boolean valid, FoDTokenCreateResponse tokenData) {}
+
+    public static SessionStatus checkTokenStatus(IUrlConfig urlConfig, String accessToken) {
+        try ( UnirestInstance unirest = UnirestHelper.createUnirestInstance() ) {
+            unirest.config().setDefaultHeader("Authorization", "Bearer " + accessToken);
+            try {
+                unirest.get("/api/v3/me").asString();
+                var tokenData = new FoDTokenCreateResponse();
+                tokenData.setAccessToken(accessToken);
+                return new SessionStatus(true, tokenData);
+            } catch ( UnexpectedHttpResponseException e ) {
+                if ( e.getStatus()==401 ) {
+                    return new SessionStatus(false, null);
+                } else {
+                    throw new FcliSimpleException("Unable to verify session status: FoD returned HTTP "+e.getStatus(), e);
+                }
+            }
+        } catch ( FcliSimpleException e ) {
+            throw e;
+        } catch ( Exception e ) {
+            throw new FcliSimpleException("Unable to connect to FoD to verify session status", e);
+        }
+    }
+}

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/helper/FoDSessionValidationHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/helper/FoDSessionValidationHelper.java
@@ -13,9 +13,14 @@
 package com.fortify.cli.fod._common.session.helper;
 
 import com.fortify.cli.common.exception.FcliSimpleException;
+import com.fortify.cli.common.http.proxy.helper.ProxyHelper;
 import com.fortify.cli.common.rest.unirest.UnexpectedHttpResponseException;
 import com.fortify.cli.common.rest.unirest.UnirestHelper;
 import com.fortify.cli.common.rest.unirest.config.IUrlConfig;
+import com.fortify.cli.common.rest.unirest.config.UnirestJsonHeaderConfigurer;
+import com.fortify.cli.common.rest.unirest.config.UnirestUnexpectedHttpResponseConfigurer;
+import com.fortify.cli.common.rest.unirest.config.UnirestUrlConfigConfigurer;
+import com.fortify.cli.fod._common.rest.FoDUrls;
 import com.fortify.cli.fod._common.session.helper.oauth.FoDTokenCreateResponse;
 
 import kong.unirest.UnirestInstance;
@@ -25,9 +30,13 @@ public class FoDSessionValidationHelper {
 
     public static SessionStatus checkTokenStatus(IUrlConfig urlConfig, String accessToken) {
         try ( UnirestInstance unirest = UnirestHelper.createUnirestInstance() ) {
+            UnirestUnexpectedHttpResponseConfigurer.configure(unirest);
+            UnirestUrlConfigConfigurer.configure(unirest, urlConfig);
+            ProxyHelper.configureProxy(unirest, "fod", urlConfig.getUrl());
+            UnirestJsonHeaderConfigurer.configure(unirest);
             unirest.config().setDefaultHeader("Authorization", "Bearer " + accessToken);
             try {
-                unirest.get("/api/v3/me").asString();
+                unirest.get(FoDUrls.LOOKUP_ITEMS).queryString("limit", 1).asString();
                 var tokenData = new FoDTokenCreateResponse();
                 tokenData.setAccessToken(accessToken);
                 return new SessionStatus(true, tokenData);

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/helper/oauth/FoDOAuthHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/helper/oauth/FoDOAuthHelper.java
@@ -15,35 +15,18 @@ package com.fortify.cli.fod._common.session.helper.oauth;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fortify.cli.common.http.proxy.helper.ProxyHelper;
 import com.fortify.cli.common.rest.unirest.UnirestHelper;
 import com.fortify.cli.common.rest.unirest.config.IUrlConfig;
 import com.fortify.cli.common.rest.unirest.config.UnirestJsonHeaderConfigurer;
 import com.fortify.cli.common.rest.unirest.config.UnirestUnexpectedHttpResponseConfigurer;
 import com.fortify.cli.common.rest.unirest.config.UnirestUrlConfigConfigurer;
-import com.fortify.cli.fod._common.rest.FoDUrls;
 
 import kong.unirest.UnirestInstance;
 
 // TODO Consider moving all classes in this package to a more appropriate package,
 //      for example as a sub-package of the 'rest' package.
 public class FoDOAuthHelper {
-    private static final Logger LOG = LoggerFactory.getLogger(FoDOAuthHelper.class);
-    public static final boolean validateToken(IUrlConfig urlConfig, String accessToken) {
-        try ( var unirest = UnirestHelper.createUnirestInstance() ) {
-            configureUnirest(unirest, urlConfig);
-            unirest.config().setDefaultHeader("Authorization", "Bearer " + accessToken);
-            unirest.get(FoDUrls.LOOKUP_ITEMS).queryString("limit", 1).asString();
-            return true;
-        } catch ( Exception e ) {
-            LOG.debug("Error validating FoD session token", e);
-            return false;
-        }
-    }
-
     public static final FoDTokenCreateResponse createToken(IUrlConfig urlConfig, IFoDUserCredentials uc, String... scopes) {
         Map<String,Object> formData = generateTokenRequest(uc, scopes);
     try ( var unirest = UnirestHelper.createUnirestInstance() ) {

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/helper/oauth/FoDOAuthHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/session/helper/oauth/FoDOAuthHelper.java
@@ -15,18 +15,35 @@ package com.fortify.cli.fod._common.session.helper.oauth;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fortify.cli.common.http.proxy.helper.ProxyHelper;
 import com.fortify.cli.common.rest.unirest.UnirestHelper;
 import com.fortify.cli.common.rest.unirest.config.IUrlConfig;
 import com.fortify.cli.common.rest.unirest.config.UnirestJsonHeaderConfigurer;
 import com.fortify.cli.common.rest.unirest.config.UnirestUnexpectedHttpResponseConfigurer;
 import com.fortify.cli.common.rest.unirest.config.UnirestUrlConfigConfigurer;
+import com.fortify.cli.fod._common.rest.FoDUrls;
 
 import kong.unirest.UnirestInstance;
 
 // TODO Consider moving all classes in this package to a more appropriate package,
 //      for example as a sub-package of the 'rest' package.
 public class FoDOAuthHelper {
+    private static final Logger LOG = LoggerFactory.getLogger(FoDOAuthHelper.class);
+    public static final boolean validateToken(IUrlConfig urlConfig, String accessToken) {
+        try ( var unirest = UnirestHelper.createUnirestInstance() ) {
+            configureUnirest(unirest, urlConfig);
+            unirest.config().setDefaultHeader("Authorization", "Bearer " + accessToken);
+            unirest.get(FoDUrls.LOOKUP_ITEMS).queryString("limit", 1).asString();
+            return true;
+        } catch ( Exception e ) {
+            LOG.debug("Error validating FoD session token", e);
+            return false;
+        }
+    }
+
     public static final FoDTokenCreateResponse createToken(IUrlConfig urlConfig, IFoDUserCredentials uc, String... scopes) {
         Map<String,Object> formData = generateTokenRequest(uc, scopes);
     try ( var unirest = UnirestHelper.createUnirestInstance() ) {

--- a/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
+++ b/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
@@ -130,7 +130,9 @@ fcli.fod.session.logout.fod-session = Name of the FoD session to be terminated. 
 
 fcli.fod.session.list.usage.header = List active and expired FoD sessions.
 fcli.fod.session.list.usage.description = This commands lists all FoD sessions created through the 'login' \
-  command, as long as they haven't been explicitly terminated through the 'logout' command.
+  command, as long as they haven't been explicitly terminated through the 'logout' command. Session status \
+  is shown based on locally cached token expiry data. Use '--validate' to verify the actual session \
+  status against FoD.
 
 # fcli fod rest
 fcli.fod.rest.usage.header = Interact with FoD REST API endpoints.

--- a/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
+++ b/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
@@ -129,7 +129,7 @@ fcli.fod.session.logout.usage.description = This command terminates an FoD sessi
 fcli.fod.session.logout.fod-session = Name of the FoD session to be terminated. Default value: ${DEFAULT-VALUE}.
 
 fcli.fod.session.list.usage.header = List active and expired FoD sessions.
-fcli.fod.session.list.usage.description = This commands lists all FoD sessions created through the 'login' \
+fcli.fod.session.list.usage.description = This command lists all FoD sessions created through the 'login' \
   command, as long as they haven't been explicitly terminated through the 'logout' command. Session status \
   is shown based on locally cached token expiry data. Use '--validate' to verify the actual session \
   status against FoD.

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/rest/ssc/SSCUrls.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/rest/ssc/SSCUrls.java
@@ -438,6 +438,7 @@ public class SSCUrls {
     public static final String USER_SESSION_INFO = ApiBase + "/userSession/info";
     public static final String USER_SESSION_PREFS = ApiBase + "/userSession/prefs";
     public static final String USER_SESSION_STATE = ApiBase + "/userSession/state";
+    public static final String USER_SESSION_TOKEN_DATA = ApiBase + "/userSession/tokenData";
     public static final String VALIDATE_EQUATION = ApiBase + "/validateEquation";
     public static final String VALIDATE_SEARCH_STRING = ApiBase + "/validateSearchString";
     public static final String VARIABLES = ApiBase + "/variables";

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/cli/cmd/SSCSessionListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/cli/cmd/SSCSessionListCommand.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.session.cli.cmd.AbstractSessionListCommand;
+import com.fortify.cli.common.session.cli.mixin.ValidateSessionOptionMixin;
 import com.fortify.cli.ssc._common.session.helper.SSCAndScanCentralSessionDescriptor;
 import com.fortify.cli.ssc._common.session.helper.SSCAndScanCentralSessionHelper;
 import com.fortify.cli.ssc.access_control.helper.SSCTokenHelper;
@@ -24,20 +25,17 @@ import com.fortify.cli.ssc.access_control.helper.SSCTokenHelper;
 import lombok.Getter;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
-import picocli.CommandLine.Option;
 
 @Command(name = OutputHelperMixins.List.CMD_NAME, sortOptions = false)
 public class SSCSessionListCommand extends AbstractSessionListCommand<SSCAndScanCentralSessionDescriptor> {
     @Mixin @Getter private OutputHelperMixins.List outputHelper;
-    @Option(names = {"--validate"}, required = false) private boolean validate;
+    @Mixin private ValidateSessionOptionMixin validateSessionOption;
     @Getter private SSCAndScanCentralSessionHelper sessionHelper = SSCAndScanCentralSessionHelper.instance();
 
     @Override
     public JsonNode getJsonNode() {
         var result = (ArrayNode)super.getJsonNode();
-        if ( validate ) {
-            result.forEach(this::validateSession);
-        }
+        validateSessionOption.validateIfNeeded(result, this::validateSession);
         return result;
     }
 

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/cli/cmd/SSCSessionListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/cli/cmd/SSCSessionListCommand.java
@@ -15,11 +15,14 @@ package com.fortify.cli.ssc._common.session.cli.cmd;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fortify.cli.common.exception.FcliSimpleException;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.session.cli.cmd.AbstractSessionListCommand;
 import com.fortify.cli.common.session.cli.mixin.ValidateSessionOptionMixin;
 import com.fortify.cli.ssc._common.session.helper.SSCAndScanCentralSessionDescriptor;
 import com.fortify.cli.ssc._common.session.helper.SSCAndScanCentralSessionHelper;
+import com.fortify.cli.ssc._common.session.helper.SSCSessionValidationHelper;
+import com.fortify.cli.ssc._common.session.helper.SSCSessionValidationHelper.SessionStatus;
 import com.fortify.cli.ssc.access_control.helper.SSCTokenHelper;
 
 import lombok.Getter;
@@ -35,40 +38,45 @@ public class SSCSessionListCommand extends AbstractSessionListCommand<SSCAndScan
     @Override
     public JsonNode getJsonNode() {
         var result = (ArrayNode)super.getJsonNode();
-        validateSessionOption.validateIfNeeded(result, this::validateSession);
+        validateSessionOption.validateIfNeeded(result, this::enrichSessionNode);
         return result;
     }
 
-    private void validateSession(JsonNode sessionNode) {
+    private void enrichSessionNode(JsonNode sessionNode) {
         if ( sessionNode instanceof ObjectNode session ) {
             var sessionName = session.path("name").asText(null);
             var descriptor = sessionName==null ? null : getSessionHelper().get(sessionName, false);
             var tokenData = descriptor==null ? null : descriptor.getSscTokenData();
             var token = tokenData==null ? null : tokenData.getToken();
-            var validationResult = descriptor==null || token==null
-                    ? new SSCTokenHelper.SessionValidationResult(false, null)
-                    : SSCTokenHelper.validateSession(descriptor.getSscUrlConfig(), token);
-            updateSessionNode(session, validationResult);
-            refreshSessionExpiry(sessionName, descriptor, validationResult);
-        }
-    }
-
-    private void updateSessionNode(ObjectNode session, SSCTokenHelper.SessionValidationResult validationResult) {
-        session.put("expired", validationResult.valid() ? "No" : "Yes");
-        if ( !validationResult.valid() ) {
-            session.put("expires", "N/A");
-        } else {
-            var terminalDate = validationResult.tokenData()==null ? null : validationResult.tokenData().getTerminalDate();
-            if ( terminalDate!=null ) {
-                session.put("expires", SSCTokenHelper.formatExpiryDate(terminalDate));
+            if ( descriptor==null || token==null ) {
+                applySessionStatus(session, new SessionStatus(false, null));
+                return;
+            }
+            try {
+                var status = SSCSessionValidationHelper.checkTokenStatus(descriptor.getSscUrlConfig(), token);
+                applySessionStatus(session, status);
+                persistUpdatedExpiry(sessionName, descriptor, status);
+            } catch ( FcliSimpleException e ) {
+                session.put("expired", "Unknown");
+                session.put("expires", "Unknown");
             }
         }
     }
 
-    private void refreshSessionExpiry(String sessionName, SSCAndScanCentralSessionDescriptor descriptor, SSCTokenHelper.SessionValidationResult validationResult) {
-        if ( sessionName!=null && descriptor!=null && validationResult.valid()
-                && validationResult.tokenData()!=null && validationResult.tokenData().getTerminalDate()!=null ) {
-            descriptor.setSscTokenData(validationResult.tokenData());
+    private void applySessionStatus(ObjectNode session, SessionStatus status) {
+        session.put("expired", status.valid() ? "No" : "Yes");
+        if ( !status.valid() ) {
+            session.put("expires", "N/A");
+        } else {
+            var terminalDate = status.tokenData()==null ? null : status.tokenData().getTerminalDate();
+            session.put("expires", terminalDate==null ? "Unknown" : SSCTokenHelper.formatExpiryDate(terminalDate));
+        }
+    }
+
+    private void persistUpdatedExpiry(String sessionName, SSCAndScanCentralSessionDescriptor descriptor, SessionStatus status) {
+        if ( sessionName!=null && descriptor!=null && status.valid()
+                && status.tokenData()!=null && status.tokenData().getTerminalDate()!=null ) {
+            descriptor.setSscTokenData(status.tokenData());
             getSessionHelper().save(sessionName, descriptor);
         }
     }

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/cli/cmd/SSCSessionListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/cli/cmd/SSCSessionListCommand.java
@@ -12,17 +12,66 @@
  */
 package com.fortify.cli.ssc._common.session.cli.cmd;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.session.cli.cmd.AbstractSessionListCommand;
 import com.fortify.cli.ssc._common.session.helper.SSCAndScanCentralSessionDescriptor;
 import com.fortify.cli.ssc._common.session.helper.SSCAndScanCentralSessionHelper;
+import com.fortify.cli.ssc.access_control.helper.SSCTokenHelper;
 
 import lombok.Getter;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
 
 @Command(name = OutputHelperMixins.List.CMD_NAME, sortOptions = false)
 public class SSCSessionListCommand extends AbstractSessionListCommand<SSCAndScanCentralSessionDescriptor> {
     @Mixin @Getter private OutputHelperMixins.List outputHelper;
+    @Option(names = {"--validate"}, required = false) private boolean validate;
     @Getter private SSCAndScanCentralSessionHelper sessionHelper = SSCAndScanCentralSessionHelper.instance();
+
+    @Override
+    public JsonNode getJsonNode() {
+        var result = (ArrayNode)super.getJsonNode();
+        if ( validate ) {
+            result.forEach(this::validateSession);
+        }
+        return result;
+    }
+
+    private void validateSession(JsonNode sessionNode) {
+        if ( sessionNode instanceof ObjectNode session ) {
+            var sessionName = session.path("name").asText(null);
+            var descriptor = sessionName==null ? null : getSessionHelper().get(sessionName, false);
+            var tokenData = descriptor==null ? null : descriptor.getSscTokenData();
+            var token = tokenData==null ? null : tokenData.getToken();
+            var validationResult = descriptor==null || token==null
+                    ? new SSCTokenHelper.SessionValidationResult(false, null)
+                    : SSCTokenHelper.validateSession(descriptor.getSscUrlConfig(), token);
+            updateSessionNode(session, validationResult);
+            refreshSessionExpiry(sessionName, descriptor, validationResult);
+        }
+    }
+
+    private void updateSessionNode(ObjectNode session, SSCTokenHelper.SessionValidationResult validationResult) {
+        session.put("expired", validationResult.valid() ? "No" : "Yes");
+        if ( !validationResult.valid() ) {
+            session.put("expires", "N/A");
+        } else {
+            var terminalDate = validationResult.tokenData()==null ? null : validationResult.tokenData().getTerminalDate();
+            if ( terminalDate!=null ) {
+                session.put("expires", SSCTokenHelper.formatExpiryDate(terminalDate));
+            }
+        }
+    }
+
+    private void refreshSessionExpiry(String sessionName, SSCAndScanCentralSessionDescriptor descriptor, SSCTokenHelper.SessionValidationResult validationResult) {
+        if ( sessionName!=null && descriptor!=null && validationResult.valid()
+                && validationResult.tokenData()!=null && validationResult.tokenData().getTerminalDate()!=null ) {
+            descriptor.setSscTokenData(validationResult.tokenData());
+            getSessionHelper().save(sessionName, descriptor);
+        }
+    }
 }

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/helper/SSCSessionValidationHelper.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/session/helper/SSCSessionValidationHelper.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.ssc._common.session.helper;
+
+import com.fortify.cli.common.exception.FcliSimpleException;
+import com.fortify.cli.common.json.JsonHelper;
+import com.fortify.cli.common.rest.unirest.UnexpectedHttpResponseException;
+import com.fortify.cli.common.rest.unirest.UnirestHelper;
+import com.fortify.cli.common.rest.unirest.config.IUrlConfig;
+import com.fortify.cli.ssc._common.rest.ssc.SSCUrls;
+import com.fortify.cli.ssc.access_control.helper.SSCTokenGetOrCreateResponse;
+import com.fortify.cli.ssc.access_control.helper.SSCTokenGetOrCreateResponse.SSCTokenData;
+import com.fortify.cli.ssc.access_control.helper.SSCTokenHelper;
+
+/**
+ * Provides SSC session-level status checking, separate from general token CRUD operations
+ * in {@link SSCTokenHelper}.
+ */
+public class SSCSessionValidationHelper {
+    public static record SessionStatus(boolean valid, SSCTokenData tokenData) {}
+
+    /**
+     * Checks whether the given token can authenticate against SSC.
+     * <ul>
+     *   <li>Returns {@code valid=true} with token data on success.</li>
+     *   <li>Returns {@code valid=false} on explicit authentication failure (HTTP 401/403).</li>
+     *   <li>Throws {@link FcliSimpleException} when SSC is unreachable or returns an unexpected error,
+     *       so the caller can distinguish "unknown/unreachable" from "definitely invalid".</li>
+     * </ul>
+     */
+    public static SessionStatus checkTokenStatus(IUrlConfig urlConfig, char[] token) {
+        try ( var unirest = UnirestHelper.createUnirestInstance() ) {
+            SSCTokenHelper.configureUnirest(unirest, urlConfig, token);
+            try {
+                var tokenData = unirest.post(SSCUrls.USER_SESSION_TOKEN_DATA)
+                        .body(JsonHelper.getObjectMapper().createObjectNode())
+                        .asObject(SSCTokenGetOrCreateResponse.class)
+                        .getBody().getData();
+                tokenData.setToken(token);
+                return new SessionStatus(true, tokenData);
+            } catch ( UnexpectedHttpResponseException e ) {
+                if ( e.getStatus()==401 || e.getStatus()==403 ) {
+                    return new SessionStatus(false, null);
+                } else {
+                    throw new FcliSimpleException("Unable to verify session status: SSC returned HTTP " + e.getStatus(), e);
+                }
+            }
+        } catch ( FcliSimpleException e ) {
+            throw e;
+        } catch ( Exception e ) {
+            throw new FcliSimpleException("Unable to connect to SSC to verify session status", e);
+        }
+    }
+}

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/helper/SSCTokenHelper.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/helper/SSCTokenHelper.java
@@ -20,9 +20,6 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -47,10 +44,7 @@ import kong.unirest.UnirestInstance;
 import picocli.CommandLine.Help.Ansi;
 
 public class SSCTokenHelper {
-    private static final Logger LOG = LoggerFactory.getLogger(SSCTokenHelper.class);
     private static final DateTimeFormatter EXPIRY_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss z");
-
-    public static record SessionValidationResult(boolean valid, SSCTokenData tokenData) {}
 
     public static final JsonNode transformTokenRecord(JsonNode tokenRecord) {
         if ( tokenRecord instanceof ObjectNode && tokenRecord.has("terminalDate") ) {
@@ -110,31 +104,6 @@ public class SSCTokenHelper {
     public static final SSCTokenData getTokenData(IUrlConfig urlConfig, char[] token) {
         try ( var unirest = UnirestHelper.createUnirestInstance() ) {
             return getTokenData(unirest, urlConfig, token);
-        }
-    }
-
-    public static final SessionValidationResult validateSession(IUrlConfig urlConfig, char[] token) {
-        try ( var unirest = UnirestHelper.createUnirestInstance() ) {
-            configureUnirest(unirest, urlConfig, token);
-            try {
-                var tokenData = unirest.post("/api/v1/userSession/tokenData")
-                        .body(JsonHelper.getObjectMapper().createObjectNode())
-                        .asObject(SSCTokenGetOrCreateResponse.class)
-                        .getBody().getData();
-                tokenData.setToken(token);
-                return new SessionValidationResult(true, tokenData);
-            } catch ( UnexpectedHttpResponseException e ) {
-                if ( e.getStatus()==401 || e.getStatus()==403 ) {
-                    return new SessionValidationResult(false, null);
-                } else if ( e.getStatus()==404 ) {
-                    return validateSessionByInfo(unirest, token);
-                } else {
-                    return new SessionValidationResult(false, null);
-                }
-            }
-        } catch ( Exception e ) {
-            LOG.debug("Error validating SSC session token status", e);
-            return new SessionValidationResult(false, null);
         }
     }
 
@@ -212,7 +181,7 @@ public class SSCTokenHelper {
     private static SSCTokenData getTokenData(UnirestInstance unirest, IUrlConfig urlConfig, char[] token) {
         configureUnirest(unirest, urlConfig, token);
         try {
-            var result = unirest.post("/api/v1/userSession/tokenData")
+            var result = unirest.post(SSCUrls.USER_SESSION_TOKEN_DATA)
                     .body(JsonHelper.getObjectMapper().createObjectNode())
                     .asObject(SSCTokenGetOrCreateResponse.class)
                     .getBody().getData();
@@ -231,22 +200,6 @@ public class SSCTokenHelper {
                 throw new FcliSimpleException("Error connecting to SSC for token validation.", e);
             }
 
-        }
-    }
-
-    private static SessionValidationResult validateSessionByInfo(UnirestInstance unirest, char[] token) {
-        try {
-            unirest.get(SSCUrls.USER_SESSION_INFO)
-                    .asObject(JsonNode.class)
-                    .getBody();
-            var tokenData = new SSCTokenData();
-            tokenData.setToken(token);
-            return new SessionValidationResult(true, tokenData);
-        } catch ( UnexpectedHttpResponseException e ) {
-            return new SessionValidationResult(false, null);
-        } catch ( Exception e ) {
-            LOG.debug("Error validating SSC session by user session info endpoint", e);
-            return new SessionValidationResult(false, null);
         }
     }
     

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/helper/SSCTokenHelper.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/helper/SSCTokenHelper.java
@@ -13,10 +13,15 @@
 package com.fortify.cli.ssc.access_control.helper;
 
 import java.time.Duration;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -42,6 +47,11 @@ import kong.unirest.UnirestInstance;
 import picocli.CommandLine.Help.Ansi;
 
 public class SSCTokenHelper {
+    private static final Logger LOG = LoggerFactory.getLogger(SSCTokenHelper.class);
+    private static final DateTimeFormatter EXPIRY_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss z");
+
+    public static record SessionValidationResult(boolean valid, SSCTokenData tokenData) {}
+
     public static final JsonNode transformTokenRecord(JsonNode tokenRecord) {
         if ( tokenRecord instanceof ObjectNode && tokenRecord.has("terminalDate") ) {
             Date terminalDate = JsonHelper.treeToValue(tokenRecord.get("terminalDate"), Date.class);
@@ -101,6 +111,38 @@ public class SSCTokenHelper {
         try ( var unirest = UnirestHelper.createUnirestInstance() ) {
             return getTokenData(unirest, urlConfig, token);
         }
+    }
+
+    public static final SessionValidationResult validateSession(IUrlConfig urlConfig, char[] token) {
+        try ( var unirest = UnirestHelper.createUnirestInstance() ) {
+            configureUnirest(unirest, urlConfig, token);
+            try {
+                var tokenData = unirest.post("/api/v1/userSession/tokenData")
+                        .body(JsonHelper.getObjectMapper().createObjectNode())
+                        .asObject(SSCTokenGetOrCreateResponse.class)
+                        .getBody().getData();
+                tokenData.setToken(token);
+                return new SessionValidationResult(true, tokenData);
+            } catch ( UnexpectedHttpResponseException e ) {
+                if ( e.getStatus()==401 || e.getStatus()==403 ) {
+                    return new SessionValidationResult(false, null);
+                } else if ( e.getStatus()==404 ) {
+                    return validateSessionByInfo(unirest, token);
+                } else {
+                    return new SessionValidationResult(false, null);
+                }
+            }
+        } catch ( Exception e ) {
+            LOG.debug("Error validating SSC session token status", e);
+            return new SessionValidationResult(false, null);
+        }
+    }
+
+    public static final String formatExpiryDate(Date date) {
+        if ( date==null ) {
+            return "N/A";
+        }
+        return EXPIRY_DATE_FORMATTER.format(date.toInstant().atZone(ZoneId.systemDefault()));
     }
 
     public static final <R> R run(IUrlConfig urlConfig, char[] activeToken, Function<UnirestInstance, R> f) {
@@ -189,6 +231,22 @@ public class SSCTokenHelper {
                 throw new FcliSimpleException("Error connecting to SSC for token validation.", e);
             }
 
+        }
+    }
+
+    private static SessionValidationResult validateSessionByInfo(UnirestInstance unirest, char[] token) {
+        try {
+            unirest.get(SSCUrls.USER_SESSION_INFO)
+                    .asObject(JsonNode.class)
+                    .getBody();
+            var tokenData = new SSCTokenData();
+            tokenData.setToken(token);
+            return new SessionValidationResult(true, tokenData);
+        } catch ( UnexpectedHttpResponseException e ) {
+            return new SessionValidationResult(false, null);
+        } catch ( Exception e ) {
+            LOG.debug("Error validating SSC session by user session info endpoint", e);
+            return new SessionValidationResult(false, null);
         }
     }
     

--- a/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/i18n/SSCMessages.properties
+++ b/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/i18n/SSCMessages.properties
@@ -121,7 +121,6 @@ fcli.ssc.session.list.usage.description.1 = For sessions created using user name
 fcli.ssc.session.list.usage.description.2 = For sessions created using a pre-generated token, fcli cannot \
   determine session expiration locally. Use --validate to check session status and retrieve expiry \
   information from SSC.
-fcli.ssc.session.list.validate = Verify the actual session status against SSC.
 
 # fcli ssc rest
 fcli.ssc.rest.usage.header = Interact with SSC REST API endpoints.

--- a/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/i18n/SSCMessages.properties
+++ b/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/i18n/SSCMessages.properties
@@ -116,9 +116,12 @@ fcli.ssc.session.list.usage.description.1 = For sessions created using user name
   the login command was issued. Any changes to the generated token will not be reflected in the output of \
   this command. Even if a session is no longer valid because the generated token was revoked (through SSC \
   UI or 'fcli ssc access-control revoke-token' command), the output of this command may still show the session as not having \
-  expired. Similarly, any changes to token validity will not be reflected in the output of this command. %n
+  expired. Similarly, any changes to token validity will not be reflected in the output of this command. \
+  Use --validate to verify the actual session status. %n
 fcli.ssc.session.list.usage.description.2 = For sessions created using a pre-generated token, fcli cannot \
-  display session expiration date or status, as SSC doesn't allow for obtaining this information.
+  determine session expiration locally. Use --validate to check session status and retrieve expiry \
+  information from SSC.
+fcli.ssc.session.list.validate = Verify the actual session status against SSC.
 
 # fcli ssc rest
 fcli.ssc.rest.usage.header = Interact with SSC REST API endpoints.


### PR DESCRIPTION
Added new option 'validate' in fcli ssc session list and fcli fod session list to validate current status.
feat: #962 
