### PR TITLE
chore: Add `--fetch` option to `list` commands

### DIFF
--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/action/runner/processor/ActionStepProcessorRunFcli.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/action/runner/processor/ActionStepProcessorRunFcli.java
@@ -56,6 +56,7 @@ public class ActionStepProcessorRunFcli extends AbstractActionStepProcessorMapEn
     private static final String FMT_DEPENDENCY_SKIP_REASON = "%s.dependencySkipReason";
     private static final String FMT_EXIT_CODE = "%s.exitCode";
     private static final String FMT_RECORDS = "%s.records";
+    private static final String FMT_METADATA = "%s.metadata";
     private static final String FMT_STDOUT = "%s.stdout";
     private static final String FMT_STDERR = "%s.stderr";
     
@@ -95,6 +96,7 @@ public class ActionStepProcessorRunFcli extends AbstractActionStepProcessorMapEn
     private FcliCommandExecutor createCmdExecutor(ActionStepRunFcliEntry entry, String cmd, FcliRecordConsumer recordConsumer) {
         var stdoutOutputType = getOutputTypeOrDefault(entry.getStdoutOutputType(), recordConsumer==null ? OutputType.show : OutputType.suppress );
         var stderrOutputType = getOutputTypeOrDefault(entry.getStderrOutputType(), OutputType.show );
+        ObjectNode[] metadataHolder = {null};
         try {
             return FcliCommandExecutorFactory.builder()
                     .cmd(cmd)
@@ -102,11 +104,13 @@ public class ActionStepProcessorRunFcli extends AbstractActionStepProcessorMapEn
                     .defaultOptionsIfNotPresent(ctx.getConfig().getDefaultFcliRunOptions())
                     .stdoutOutputType(stdoutOutputType)
                     .stderrOutputType(stderrOutputType)
-                    .onResult(r->onFcliResult(entry, recordConsumer, r))
+                    .onResult(r->onFcliResult(entry, recordConsumer, metadataHolder, r))
                     .onSuccess(r->onFcliSuccess(entry))
                     .onException(e->onFcliException(entry, e))
                     .onFail(r->onFcliFail(entry, recordConsumer, r))
-                    .recordConsumer(recordConsumer).build().create();
+                    .recordConsumer(recordConsumer)
+                    .metadataConsumer(m->metadataHolder[0]=m)
+                    .build().create();
         } catch ( Exception e ) {
             onFcliException(entry, e);
             return null;
@@ -205,14 +209,15 @@ public class ActionStepProcessorRunFcli extends AbstractActionStepProcessorMapEn
         }
     }
     
-    private void onFcliResult(ActionStepRunFcliEntry fcli, FcliRecordConsumer recordConsumer, Result result) {
-        setResultVars(fcli, recordConsumer, result);
+    private void onFcliResult(ActionStepRunFcliEntry fcli, FcliRecordConsumer recordConsumer, ObjectNode[] metadataHolder, Result result) {
+        setResultVars(fcli, recordConsumer, metadataHolder, result);
         logStatus(fcli, result);
     }
 
-    private void setResultVars(ActionStepRunFcliEntry fcli, FcliRecordConsumer recordConsumer, Result result) {
+    private void setResultVars(ActionStepRunFcliEntry fcli, FcliRecordConsumer recordConsumer, ObjectNode[] metadataHolder, Result result) {
         var name = fcli.getKey();
         vars.set(String.format(FMT_RECORDS, name), recordConsumer!=null ? recordConsumer.getRecords() : JsonHelper.getObjectMapper().createArrayNode());
+        vars.set(String.format(FMT_METADATA, name), metadataHolder[0]!=null ? metadataHolder[0] : NullNode.instance);
         vars.set(String.format(FMT_STDOUT, name), result.getOut());
         vars.set(String.format(FMT_STDERR, name), result.getErr());
         vars.set(String.format(FMT_EXIT_CODE, name), new IntNode(result.getExitCode()));

--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/action/runner/processor/ActionStepProcessorRunFcli.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/action/runner/processor/ActionStepProcessorRunFcli.java
@@ -15,6 +15,7 @@ import java.io.PrintStream;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import org.apache.commons.lang3.StringUtils;
@@ -96,7 +97,7 @@ public class ActionStepProcessorRunFcli extends AbstractActionStepProcessorMapEn
     private FcliCommandExecutor createCmdExecutor(ActionStepRunFcliEntry entry, String cmd, FcliRecordConsumer recordConsumer) {
         var stdoutOutputType = getOutputTypeOrDefault(entry.getStdoutOutputType(), recordConsumer==null ? OutputType.show : OutputType.suppress );
         var stderrOutputType = getOutputTypeOrDefault(entry.getStderrOutputType(), OutputType.show );
-        ObjectNode[] metadataHolder = {null};
+        var metadataHolder = new AtomicReference<ObjectNode>();
         try {
             return FcliCommandExecutorFactory.builder()
                     .cmd(cmd)
@@ -109,7 +110,7 @@ public class ActionStepProcessorRunFcli extends AbstractActionStepProcessorMapEn
                     .onException(e->onFcliException(entry, e))
                     .onFail(r->onFcliFail(entry, recordConsumer, r))
                     .recordConsumer(recordConsumer)
-                    .metadataConsumer(m->metadataHolder[0]=m)
+                    .metadataConsumer(metadataHolder::set)
                     .build().create();
         } catch ( Exception e ) {
             onFcliException(entry, e);
@@ -209,15 +210,15 @@ public class ActionStepProcessorRunFcli extends AbstractActionStepProcessorMapEn
         }
     }
     
-    private void onFcliResult(ActionStepRunFcliEntry fcli, FcliRecordConsumer recordConsumer, ObjectNode[] metadataHolder, Result result) {
+    private void onFcliResult(ActionStepRunFcliEntry fcli, FcliRecordConsumer recordConsumer, AtomicReference<ObjectNode> metadataHolder, Result result) {
         setResultVars(fcli, recordConsumer, metadataHolder, result);
         logStatus(fcli, result);
     }
 
-    private void setResultVars(ActionStepRunFcliEntry fcli, FcliRecordConsumer recordConsumer, ObjectNode[] metadataHolder, Result result) {
+    private void setResultVars(ActionStepRunFcliEntry fcli, FcliRecordConsumer recordConsumer, AtomicReference<ObjectNode> metadataHolder, Result result) {
         var name = fcli.getKey();
         vars.set(String.format(FMT_RECORDS, name), recordConsumer!=null ? recordConsumer.getRecords() : JsonHelper.getObjectMapper().createArrayNode());
-        vars.set(String.format(FMT_METADATA, name), metadataHolder[0]!=null ? metadataHolder[0] : NullNode.instance);
+        vars.set(String.format(FMT_METADATA, name), metadataHolder.get()!=null ? metadataHolder.get() : NullNode.instance);
         vars.set(String.format(FMT_STDOUT, name), result.getOut());
         vars.set(String.format(FMT_STDERR, name), result.getErr());
         vars.set(String.format(FMT_EXIT_CODE, name), new IntNode(result.getExitCode()));

--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/cli/util/FcliCommandExecutorFactory.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/cli/util/FcliCommandExecutorFactory.java
@@ -48,6 +48,7 @@ import picocli.CommandLine.ParseResult;
 public final class FcliCommandExecutorFactory { 
     @NonNull private final String cmd;
     private final Consumer<ObjectNode> recordConsumer;
+    private final Consumer<ObjectNode> metadataConsumer;
     @Builder.Default private final OutputType stdoutOutputType = OutputType.show;
     @Builder.Default private final OutputType stderrOutputType = OutputType.show;
     private final Consumer<Result> onResult; // Always executed if fcli command didn't throw exception
@@ -105,7 +106,7 @@ public final class FcliCommandExecutorFactory {
 
         public final Result execute() {
             if ( parseErrorResult!=null ) { return parseErrorResult; }
-            if ( recordConsumer!=null && canCollectRecords() ) { setPerCommandRecordConsumer(); }
+            if ( (recordConsumer!=null || metadataConsumer!=null) && canCollectRecords() ) { setPerCommandConsumers(); }
             return call(()->_execute());
         }
 
@@ -189,10 +190,15 @@ public final class FcliCommandExecutorFactory {
             return FcliCommandSpecHelper.canCollectRecords(replicatedLeafCommandSpec);
         }
 
-        private void setPerCommandRecordConsumer() {
+        private void setPerCommandConsumers() {
             var userObj = replicatedLeafCommandSpec.userObject();
-            if ( userObj instanceof IRecordCollectionSupport ) {
-                ((IRecordCollectionSupport)userObj).setRecordConsumer(recordConsumer, stdoutOutputType!=OutputType.show);
+            if ( userObj instanceof IRecordCollectionSupport rcs ) {
+                if ( recordConsumer!=null ) {
+                    rcs.setRecordConsumer(recordConsumer, stdoutOutputType!=OutputType.show);
+                }
+                if ( metadataConsumer!=null ) {
+                    rcs.setMetadataConsumer(metadataConsumer);
+                }
             }
         }
         

--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/json/producer/AbstractObjectNodeProducer.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/json/producer/AbstractObjectNodeProducer.java
@@ -24,6 +24,7 @@ import com.fortify.cli.common.cli.util.FcliCommandSpecHelper;
 import com.fortify.cli.common.exception.FcliBugException;
 import com.fortify.cli.common.json.transform.fields.AddFieldsTransformer;
 import com.fortify.cli.common.output.product.IProductHelper;
+import com.fortify.cli.common.output.product.IResponseMetadataCollector;
 import com.fortify.cli.common.output.transform.IActionCommandResultSupplier;
 import com.fortify.cli.common.output.transform.IInputTransformer;
 import com.fortify.cli.common.output.transform.IRecordTransformer;
@@ -50,12 +51,18 @@ public abstract class AbstractObjectNodeProducer implements IObjectNodeProducer 
     @Getter @Singular private final List<UnaryOperator<JsonNode>> inputTransformers;
     @Getter @Singular private final List<UnaryOperator<JsonNode>> recordTransformers;
     @Getter private final QueryExpression queryExpression;
+    @Getter private final IResponseMetadataCollector responseMetadataCollector;
+    private ObjectNode responseMetadata;
+
+    @Override
+    public ObjectNode getResponseMetadata() { return responseMetadata; }
 
     /**
      * Template method used by subclasses to feed input JSON to this base class for processing.
      */
     protected final void process(JsonNode input, IObjectNodeConsumer consumer) {
         if ( input==null ) { return; }
+        collectMetadata(input);
         JsonNode transformed = applyInputTransformers(input);
         if ( transformed==null || transformed.isNull() ) { return; }
         if ( transformed.isObject() ) {
@@ -81,6 +88,12 @@ public abstract class AbstractObjectNodeProducer implements IObjectNodeProducer 
         JsonNode current = input;
         for ( var t : inputTransformers ) { current = t.apply(current); if ( current==null ) { break; } }
         return current;
+    }
+
+    private void collectMetadata(JsonNode rawInput) {
+        if ( responseMetadata==null && responseMetadataCollector!=null ) {
+            responseMetadata = responseMetadataCollector.collectResponseMetadata(rawInput);
+        }
     }
 
     protected Break processSingleRecord(ObjectNode node, IObjectNodeConsumer consumer) {
@@ -136,6 +149,7 @@ public abstract class AbstractObjectNodeProducer implements IObjectNodeProducer 
             applyRecordTransformationsFrom(applyFrom);
             applyQueryFrom(applyFrom);
             applyActionCommandResultSupplierFrom(applyFrom);
+            applyResponseMetadataCollectorFrom(applyFrom);
             return self();
         }
         private void applyActionCommandResultSupplierFrom(ObjectNodeProducerApplyFrom applyFrom) {
@@ -158,6 +172,10 @@ public abstract class AbstractObjectNodeProducer implements IObjectNodeProducer 
             }
             return self();
         }
+        public B applyResponseMetadataCollectorFrom(ObjectNodeProducerApplyFrom applyFrom) {
+            applyFrom.getSourceStream(getRequiredCommandHelper(), explicitProductHelper).forEach(this::addResponseMetadataCollectorFromObject);
+            return self();
+        }
         protected ICommandHelper getRequiredCommandHelper() {
             if ( commandHelper==null ) {
                 throw new FcliBugException("CommandHelper not configured; call commandHelper(<helper>) before apply*From()");
@@ -172,6 +190,11 @@ public abstract class AbstractObjectNodeProducer implements IObjectNodeProducer 
         }
         private void addRecordTransformersFromObject(Object o) {
             if ( o instanceof IRecordTransformer rt ) { recordTransformer(n->rt.transformRecord(n)); }
+        }
+        private void addResponseMetadataCollectorFromObject(Object o) {
+            if ( o instanceof IResponseMetadataCollector rmc && this.responseMetadataCollector==null ) {
+                responseMetadataCollector(rmc);
+            }
         }
     }
 }

--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/json/producer/IObjectNodeProducer.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/json/producer/IObjectNodeProducer.java
@@ -21,6 +21,13 @@ import com.fortify.cli.common.util.Break;
 public interface IObjectNodeProducer {
     void forEach(IObjectNodeConsumer consumer);
 
+    /**
+     * Return response-level metadata (e.g., total count, paging links) captured from
+     * the underlying data source. Available after {@link #forEach} has been invoked.
+     * Returns {@code null} if no metadata was captured.
+     */
+    default ObjectNode getResponseMetadata() { return null; }
+
     @FunctionalInterface
     interface IObjectNodeConsumer { Break accept(ObjectNode node); }
 }

--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/json/producer/RequestObjectNodeProducer.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/json/producer/RequestObjectNodeProducer.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fortify.cli.common.rest.paging.INextPageRequestProducer;
 import com.fortify.cli.common.rest.paging.INextPageUrlProducer;
 import com.fortify.cli.common.rest.paging.INextPageUrlProducerSupplier;
+import com.fortify.cli.common.rest.paging.IPagingSuppressor;
 import com.fortify.cli.common.rest.paging.PagingHelper;
 import com.fortify.cli.common.rest.unirest.IHttpRequestUpdater;
 import com.fortify.cli.common.rest.unirest.IUnirestInstanceSupplier;
@@ -41,6 +42,7 @@ public class RequestObjectNodeProducer extends AbstractObjectNodeProducer {
     @Singular private final List<IHttpRequestUpdater> requestUpdaters;
     private final INextPageRequestProducer nextPageRequestProducer;
     private final INextPageUrlProducer nextPageUrlProducer;
+    private final boolean pagingSuppressed;
     // Test-only support: if configured, simulate multi-page responses without performing HTTP requests
     @Singular private final List<JsonNode> testPageBodies;
 
@@ -52,6 +54,10 @@ public class RequestObjectNodeProducer extends AbstractObjectNodeProducer {
             return;
         }
         HttpRequest<?> request = applyRequestUpdaters(baseRequest);
+        if ( pagingSuppressed ) {
+            request.asObject(JsonNode.class).ifSuccess(r->handleResponse(r, consumer)).ifFailure(IfFailureHandler::handle);
+            return;
+        }
         INextPageRequestProducer effectiveNextPageRequestProducer = nextPageRequestProducer;
         if ( effectiveNextPageRequestProducer==null && nextPageUrlProducer!=null && unirestInstance!=null ) {
             effectiveNextPageRequestProducer = PagingHelper.asNextPageRequestProducer(unirestInstance, nextPageUrlProducer);
@@ -83,29 +89,14 @@ public class RequestObjectNodeProducer extends AbstractObjectNodeProducer {
             var ch = getRequiredCommandHelper();
             ch.getCommandAs(IUnirestInstanceSupplier.class)
                 .ifPresent(s -> super.unirestInstance(s.getUnirestInstance()));
-            applyRequestUpdatersFrom(applyFrom);
-            applyNextPageUrlProducerFrom(applyFrom);
+            applyFrom.getSourceStream(ch, getExplicitProductHelper()).forEach(this::applyFromObject);
             return self();
         }
 
-        private void applyNextPageUrlProducerFrom(ObjectNodeProducerApplyFrom applyFrom) {
-            applyFrom.getSourceStream(getRequiredCommandHelper(), getExplicitProductHelper()).forEach(this::addNextPageUrlProducerFromObject);
-        }
-
-        public void applyRequestUpdatersFrom(ObjectNodeProducerApplyFrom applyFrom) {
-            applyFrom.getSourceStream(getRequiredCommandHelper(), getExplicitProductHelper()).forEach(this::addRequestUpdaterFromObject);
-        }
-
-        private void addRequestUpdaterFromObject(Object o) {
-            if (o instanceof IHttpRequestUpdater u) {
-                requestUpdater(u);
-            }
-        }
-
-        private void addNextPageUrlProducerFromObject(Object o) {
-            if (o instanceof INextPageUrlProducerSupplier s) {
-                nextPageUrlProducer(s.getNextPageUrlProducer());
-            }
+        private void applyFromObject(Object o) {
+            if (o instanceof IHttpRequestUpdater u) { requestUpdater(u); }
+            if (o instanceof INextPageUrlProducerSupplier s) { nextPageUrlProducer(s.getNextPageUrlProducer()); }
+            if (o instanceof IPagingSuppressor s && s.isPagingSuppressed()) { pagingSuppressed(true); }
         }
 
         /** Configure unirest instance to enable streaming paging conversion. */

--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/output/cli/cmd/AbstractOutputCommand.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/output/cli/cmd/AbstractOutputCommand.java
@@ -46,6 +46,7 @@ public abstract class AbstractOutputCommand extends AbstractRunnableCommand
         implements ISingularSupplier, IOutputHelperSupplier, IRecordCollectionSupport 
 {
     @Getter private Consumer<ObjectNode> recordConsumer;
+    @Getter private Consumer<ObjectNode> metadataConsumer;
     @Getter private boolean stdoutSuppressedForRecordCollection;
 
     @Override
@@ -124,5 +125,10 @@ public abstract class AbstractOutputCommand extends AbstractRunnableCommand
     public final void setRecordConsumer(Consumer<ObjectNode> consumer, boolean suppressStdout) {
         this.recordConsumer = consumer;
         this.stdoutSuppressedForRecordCollection = suppressStdout;
+    }
+    
+    @Override
+    public final void setMetadataConsumer(Consumer<ObjectNode> consumer) {
+        this.metadataConsumer = consumer;
     }
 }

--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/output/cli/cmd/IRecordCollectionSupport.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/output/cli/cmd/IRecordCollectionSupport.java
@@ -25,4 +25,6 @@ public interface IRecordCollectionSupport {
     void setRecordConsumer(Consumer<ObjectNode> consumer, boolean suppressStdout);
     Consumer<ObjectNode> getRecordConsumer();
     boolean isStdoutSuppressedForRecordCollection();
+    default void setMetadataConsumer(Consumer<ObjectNode> consumer) {}
+    default Consumer<ObjectNode> getMetadataConsumer() { return null; }
 }

--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/output/product/IResponseMetadataCollector.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/output/product/IResponseMetadataCollector.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.common.output.product;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Interface for extracting response-level metadata (e.g., total record count,
+ * paging links) from a raw API response body before input transformation
+ * strips non-record data.
+ * <p>
+ * Product helpers (e.g., SSCProductHelper, FoDProductHelper) implement this
+ * to capture metadata specific to their API response format.
+ */
+@FunctionalInterface
+public interface IResponseMetadataCollector {
+    /**
+     * Extract metadata from the raw response body. Called before input
+     * transformation (which typically extracts only the records array).
+     * Returns {@code null} if no metadata is available.
+     */
+    ObjectNode collectResponseMetadata(JsonNode responseBody);
+}

--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/output/writer/output/standard/StandardOutputWriter.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/output/writer/output/standard/StandardOutputWriter.java
@@ -15,6 +15,7 @@ package com.fortify.cli.common.output.writer.output.standard;
 import java.io.FileWriter;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.util.function.Consumer;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fortify.cli.common.cli.util.FcliCommandSpecHelper;
@@ -51,6 +52,7 @@ public class StandardOutputWriter implements IOutputWriter {
     private final IOutputOptions outputOptions;
     private final IMessageResolver messageResolver;
     private final IRecordWriter recordCollector; // instance-level collector, may be null
+    private final Consumer<ObjectNode> metadataConsumer; // programmatic metadata callback, may be null
     private final boolean suppressOutput;
 
     public StandardOutputWriter(CommandSpec commandSpec, IOutputOptions outputOptions, StandardOutputConfig defaultOutputConfig) {
@@ -72,9 +74,11 @@ public class StandardOutputWriter implements IOutputWriter {
                 }
             };
             this.suppressOutput = rcs.isStdoutSuppressedForRecordCollection();
+            this.metadataConsumer = rcs.getMetadataConsumer();
         } else {
             this.recordCollector = null;
             this.suppressOutput = false;
+            this.metadataConsumer = null;
         }
     }
 
@@ -89,6 +93,11 @@ public class StandardOutputWriter implements IOutputWriter {
         }
         try (IRecordWriter rw = new OutputAndVariableRecordWriter()) {
             recordProducer.forEach(recordConsumer(rw));
+            var metadata = recordProducer.getResponseMetadata();
+            rw.setResponseMetadata(metadata);
+            if (metadataConsumer != null && metadata != null) {
+                metadataConsumer.accept(metadata);
+            }
         }
     }
 
@@ -145,6 +154,13 @@ public class StandardOutputWriter implements IOutputWriter {
             }
             if (variableRecordWriter.isEnabled()) {
                 variableRecordWriter.close();
+            }
+        }
+
+        @Override
+        public void setResponseMetadata(ObjectNode metadata) {
+            if (outputRecordWriter != null) {
+                outputRecordWriter.setResponseMetadata(metadata);
             }
         }
 

--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/output/writer/record/IRecordWriter.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/output/writer/record/IRecordWriter.java
@@ -19,4 +19,10 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 public interface IRecordWriter extends Closeable {
     void append(ObjectNode node);
     void close();
+    /**
+     * Set response-level metadata to be included in the output when envelope
+     * style is active. Must be called before {@link #close()} for the metadata
+     * to be written. Writers that do not support envelope style ignore this.
+     */
+    default void setResponseMetadata(ObjectNode metadata) {}
 }

--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/output/writer/record/RecordWriterStyle.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/output/writer/record/RecordWriterStyle.java
@@ -100,6 +100,11 @@ public final class RecordWriterStyle {
         return getOrDefault(RecordWriterStyleElementGroup.FAST_OUTPUT)==RecordWriterStyleElement.fast_output;
     }
     
+    /** Indicates whether output should be wrapped in an envelope containing response metadata. Defaults to no-envelope. */
+    public final boolean isEnvelope() {
+        return getOrDefault(RecordWriterStyleElementGroup.ENVELOPE)==RecordWriterStyleElement.envelope;
+    }
+    
     private final RecordWriterStyleElement getOrDefault(RecordWriterStyleElementGroup group) {
         return styleElementsByGroup.getOrDefault(group, group.defaultStyle());
     }
@@ -113,7 +118,8 @@ public final class RecordWriterStyle {
         border(RecordWriterStyleElementGroup.BORDER), no_border(RecordWriterStyleElementGroup.BORDER),
         md_border(RecordWriterStyleElementGroup.BORDER),
         wrap(RecordWriterStyleElementGroup.WRAP), no_wrap(RecordWriterStyleElementGroup.WRAP),
-        fast_output(RecordWriterStyleElementGroup.FAST_OUTPUT), no_fast_output(RecordWriterStyleElementGroup.FAST_OUTPUT)
+        fast_output(RecordWriterStyleElementGroup.FAST_OUTPUT), no_fast_output(RecordWriterStyleElementGroup.FAST_OUTPUT),
+        envelope(RecordWriterStyleElementGroup.ENVELOPE), no_envelope(RecordWriterStyleElementGroup.ENVELOPE)
         ;
         
         @Getter private final RecordWriterStyleElementGroup group;
@@ -135,7 +141,8 @@ public final class RecordWriterStyle {
         SINGULAR("array"),
         BORDER("no-border"),
         WRAP("wrap"),
-        FAST_OUTPUT("fast-output");
+        FAST_OUTPUT("fast-output"),
+        ENVELOPE("no-envelope");
         
         private final String defaultStyleElementName;
         

--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/output/writer/record/impl/AbstractRecordWriter.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/output/writer/record/impl/AbstractRecordWriter.java
@@ -27,12 +27,14 @@ import com.fortify.cli.common.output.writer.record.RecordWriterConfig;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import lombok.SneakyThrows;
 
 //TODO Do proper exception handling instead of @SneakyThrows
 @RequiredArgsConstructor
 public abstract class AbstractRecordWriter<T> implements IRecordWriter {
     @Getter(value = AccessLevel.PRIVATE, lazy=true) private final Writer writer = createWriter();
+    @Getter(value = AccessLevel.PROTECTED) @Setter private ObjectNode responseMetadata;
     private T out;
     private Function<ObjectNode, ObjectNode> recordFormatter;
     

--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/output/writer/record/impl/AbstractRecordWriterJackson.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/output/writer/record/impl/AbstractRecordWriterJackson.java
@@ -38,14 +38,17 @@ public abstract class AbstractRecordWriterJackson<T extends JsonGenerator> exten
     @Override
     protected void close(T out) throws IOException {
         writeEnd(out);
+        writeEnvelopeEnd(out);
         out.close();
     }
     
     @Override
     protected void closeWithNoData(Writer writer) throws IOException {
         var out = createGenerator(writer);
+        writeEnvelopeStart(out);
         writeStart(out);
         writeEnd(out);
+        writeEnvelopeEnd(out);
         writer.flush();
         out.close();
     }
@@ -54,8 +57,35 @@ public abstract class AbstractRecordWriterJackson<T extends JsonGenerator> exten
     protected T createOut(Writer writer, ObjectNode formattedRecord) throws IOException {
         if ( formattedRecord==null ) { return null; }
         var result = createGenerator(writer);
+        writeEnvelopeStart(result);
         writeStart(result);
         return result;
+    }
+
+    private void writeEnvelopeStart(T out) throws IOException {
+        if ( getConfig().getStyle().isEnvelope() ) {
+            doWriteEnvelopeStart(out);
+        }
+    }
+    
+    private void writeEnvelopeEnd(T out) throws IOException {
+        if ( getConfig().getStyle().isEnvelope() ) {
+            doWriteEnvelopeEnd(out);
+        }
+    }
+
+    protected void doWriteEnvelopeStart(T out) throws IOException {
+        out.writeStartObject();
+        out.writeFieldName("records");
+    }
+
+    protected void doWriteEnvelopeEnd(T out) throws IOException {
+        var metadata = getResponseMetadata();
+        if ( metadata!=null ) {
+            out.writeFieldName("metadata");
+            out.writeTree(metadata);
+        }
+        out.writeEndObject();
     }
 
     protected abstract T createGenerator(Writer writer) throws IOException;

--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/output/writer/record/impl/RecordWriterXml.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/output/writer/record/impl/RecordWriterXml.java
@@ -57,4 +57,21 @@ public class RecordWriterXml extends AbstractRecordWriterJackson<ToXmlGenerator>
     protected void writeEnd(ToXmlGenerator out) throws IOException {
         out.writeEndObject();
     }
+
+    @Override
+    protected void doWriteEnvelopeStart(ToXmlGenerator out) throws IOException {
+        out.setNextName(new QName(null, "envelope"));
+        out.writeStartObject();
+        out.writeFieldName("records");
+    }
+    
+    @Override
+    protected void doWriteEnvelopeEnd(ToXmlGenerator out) throws IOException {
+        var metadata = getResponseMetadata();
+        if ( metadata!=null ) {
+            out.writeFieldName("metadata");
+            out.writeTree(metadata);
+        }
+        out.writeEndObject();
+    }
 }

--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/rest/cli/cmd/AbstractRestCallCommand.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/rest/cli/cmd/AbstractRestCallCommand.java
@@ -29,6 +29,7 @@ import com.fortify.cli.common.output.transform.IInputTransformer;
 import com.fortify.cli.common.output.transform.IRecordTransformer;
 import com.fortify.cli.common.rest.paging.INextPageUrlProducer;
 import com.fortify.cli.common.rest.paging.INextPageUrlProducerSupplier;
+import com.fortify.cli.common.rest.paging.IPagingSuppressor;
 import com.fortify.cli.common.rest.unirest.IUnirestInstanceSupplier;
 import com.fortify.cli.common.util.DisableTest;
 import com.fortify.cli.common.util.DisableTest.TestType;
@@ -49,7 +50,7 @@ import picocli.CommandLine.Parameters;
  * 
  * @author Ruud Senden
  */
-public abstract class AbstractRestCallCommand extends AbstractOutputCommand implements IBaseRequestSupplier, IUnirestInstanceSupplier, IInputTransformer, IRecordTransformer, INextPageUrlProducerSupplier {
+public abstract class AbstractRestCallCommand extends AbstractOutputCommand implements IBaseRequestSupplier, IUnirestInstanceSupplier, IInputTransformer, IRecordTransformer, INextPageUrlProducerSupplier, IPagingSuppressor {
     @EnvSuffix("URI") @Parameters(index = "0", arity = "1..1", descriptionKey = "api.uri") String uri;
     
     @Option(names = {"--request", "-X"}, required = false, defaultValue = "GET")
@@ -110,12 +111,13 @@ public abstract class AbstractRestCallCommand extends AbstractOutputCommand impl
     }
 
     @Override
+    public boolean isPagingSuppressed() {
+        return noPaging;
+    }
+
+    @Override
     public final INextPageUrlProducer getNextPageUrlProducer() {
-        INextPageUrlProducer result = null;
-        if ( !noPaging ) {
-            result = _getNextPageUrlProducer();
-        }
-        return result;
+        return applyOnProductHelper(INextPageUrlProducerSupplier.class, s->s.getNextPageUrlProducer(), null);
     }
 
     private final JsonNode _transformRecord(JsonNode input) {
@@ -123,9 +125,6 @@ public abstract class AbstractRestCallCommand extends AbstractOutputCommand impl
     }
     private final JsonNode _transformInput(JsonNode input) {
         return applyOnProductHelper(IInputTransformer.class, t->t.transformInput(input), input);
-    }
-    private final INextPageUrlProducer _getNextPageUrlProducer() {
-        return applyOnProductHelper(INextPageUrlProducerSupplier.class, s->s.getNextPageUrlProducer(), null);
     }
 
     protected String formatUri(String uri) {

--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/rest/cli/mixin/AbstractFetchRangeMixin.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/rest/cli/mixin/AbstractFetchRangeMixin.java
@@ -23,7 +23,6 @@ import picocli.CommandLine.Option;
 
 public abstract class AbstractFetchRangeMixin implements IHttpRequestUpdater, IPagingSuppressor {
     @Option(names = "--fetch", paramLabel = "<fetch-range>",
-            description = "Limit the number of records fetched from the server. Format: [<start>-]<end>, where start and end are 1-based, inclusive record numbers. Examples: 10 (first 10 records), 1-10 (same), 21-30 (records 21 through 30). By default, all records are fetched using API paging.",
             converter = FetchRangeConverter.class)
     private FetchRange fetchRange;
 

--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/rest/cli/mixin/AbstractFetchRangeMixin.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/rest/cli/mixin/AbstractFetchRangeMixin.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.common.rest.cli.mixin;
+
+import com.fortify.cli.common.exception.FcliBugException;
+import com.fortify.cli.common.rest.paging.FetchRange;
+import com.fortify.cli.common.rest.paging.FetchRangeConverter;
+import com.fortify.cli.common.rest.paging.IPagingSuppressor;
+import com.fortify.cli.common.rest.unirest.IHttpRequestUpdater;
+
+import kong.unirest.HttpRequest;
+import picocli.CommandLine.Option;
+
+public abstract class AbstractFetchRangeMixin implements IHttpRequestUpdater, IPagingSuppressor {
+    @Option(names = "--fetch", paramLabel = "<fetch-range>",
+            description = "Limit the number of records fetched from the server. Format: [<start>-]<end>, where start and end are 1-based, inclusive record numbers. Examples: 10 (first 10 records), 1-10 (same), 21-30 (records 21 through 30). By default, all records are fetched using API paging.",
+            converter = FetchRangeConverter.class)
+    private FetchRange fetchRange;
+
+    public final boolean isFetchSpecified() {
+        return fetchRange != null;
+    }
+
+    @Override
+    public final boolean isPagingSuppressed() {
+        return fetchRange != null;
+    }
+
+    @Override
+    public final HttpRequest<?> updateRequest(HttpRequest<?> request) {
+        assertNoExistingPagingParams(request);
+        if ( fetchRange == null ) { return request; }
+        return applyFetchParams(request, fetchRange);
+    }
+
+    protected abstract HttpRequest<?> applyFetchParams(HttpRequest<?> request, FetchRange range);
+
+    private void assertNoExistingPagingParams(HttpRequest<?> request) {
+        var url = request.getUrl();
+        if ( url.matches(".*[?&](limit|start|offset)=.*") ) {
+            throw new FcliBugException("Request URL contains hardcoded paging params: " + url);
+        }
+    }
+}

--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/rest/cli/mixin/AbstractFetchRangeMixin.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/rest/cli/mixin/AbstractFetchRangeMixin.java
@@ -37,6 +37,8 @@ public abstract class AbstractFetchRangeMixin implements IHttpRequestUpdater, IP
 
     @Override
     public final HttpRequest<?> updateRequest(HttpRequest<?> request) {
+        // We always assert to catch any erraneous paging params early,
+        // even if fetchRange is not specified
         assertNoExistingPagingParams(request);
         if ( fetchRange == null ) { return request; }
         return applyFetchParams(request, fetchRange);

--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/rest/paging/FetchRange.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/rest/paging/FetchRange.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.common.rest.paging;
+
+/**
+ * Represents a fetch range consisting of an offset (start record, 0-based) and
+ * a maximum number of records to retrieve (limit). Used by fetch-range mixins to
+ * restrict paging to a specific slice of server-side results.
+ */
+public record FetchRange(int offset, int limit) {}

--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/rest/paging/FetchRangeConverter.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/rest/paging/FetchRangeConverter.java
@@ -33,9 +33,7 @@ public class FetchRangeConverter implements ITypeConverter<FetchRange> {
                 if ( end < start ) throw new FcliSimpleException("--fetch end must be >= start (%d)".formatted(start));
             }
             return new FetchRange(start - 1, end - start + 1);
-        } catch ( FcliSimpleException e ) {
-            throw e;
-        } catch ( Exception e ) {
+        } catch ( NumberFormatException e ) {
             throw new FcliSimpleException("Invalid --fetch value '%s'. Expected format: [<start>-]<end>".formatted(value));
         }
     }

--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/rest/paging/FetchRangeConverter.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/rest/paging/FetchRangeConverter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.common.rest.paging;
+
+import com.fortify.cli.common.exception.FcliSimpleException;
+
+import picocli.CommandLine.ITypeConverter;
+
+public class FetchRangeConverter implements ITypeConverter<FetchRange> {
+    @Override
+    public FetchRange convert(String value) {
+        try {
+            var parts = value.split("-", 2);
+            int start, end;
+            if ( parts.length == 1 ) {
+                start = 1;
+                end = Integer.parseInt(parts[0].trim());
+                if ( end < 1 ) throw new FcliSimpleException("--fetch value must be >= 1");
+            } else {
+                start = Integer.parseInt(parts[0].trim());
+                end = Integer.parseInt(parts[1].trim());
+                if ( start < 1 ) throw new FcliSimpleException("--fetch start must be >= 1");
+                if ( end < start ) throw new FcliSimpleException("--fetch end must be >= start (%d)".formatted(start));
+            }
+            return new FetchRange(start - 1, end - start + 1);
+        } catch ( FcliSimpleException e ) {
+            throw e;
+        } catch ( Exception e ) {
+            throw new FcliSimpleException("Invalid --fetch value '%s'. Expected format: [<start>-]<end>".formatted(value));
+        }
+    }
+}

--- a/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/rest/paging/IPagingSuppressor.java
+++ b/fcli-core/fcli-common/src/main/java/com/fortify/cli/common/rest/paging/IPagingSuppressor.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.common.rest.paging;
+
+public interface IPagingSuppressor {
+    boolean isPagingSuppressed();
+}

--- a/fcli-core/fcli-common/src/main/resources/com/fortify/cli/common/i18n/FortifyCLIMessages.properties
+++ b/fcli-core/fcli-common/src/main/resources/com/fortify/cli/common/i18n/FortifyCLIMessages.properties
@@ -84,6 +84,9 @@ style = Select output style: ${COMPLETION-CANDIDATES}.
 to-file = Write output to the specified file.
 store = Store JSON results in an fcli variable for later reference.
 query = Only display records for which the given Spring Expression Language (SpEL) expression returns true. 
+fetch = Limit the number of records fetched from the server. Format: [<start>-]<end>, where start \
+  and end are 1-based, inclusive record numbers. Examples: 10 (first 10 records), 1-10 (same), \
+  21-30 (records 21 through 30). By default, all records are fetched.
 
 # Options and prompts defined in CommonOptionMixins
 fcli.confirm = Confirm operation.

--- a/fcli-core/fcli-common/src/test/java/com/fortify/cli/common/rest/paging/FetchRangeTest.java
+++ b/fcli-core/fcli-common/src/test/java/com/fortify/cli/common/rest/paging/FetchRangeTest.java
@@ -52,26 +52,31 @@ public class FetchRangeTest {
 
     @Test
     void zeroEndRejected() {
-        assertThrows(FcliSimpleException.class, () -> converter.convert("0"));
+        var ex = assertThrows(FcliSimpleException.class, () -> converter.convert("0"));
+        assertEquals("--fetch value must be >= 1", ex.getMessage());
     }
 
     @Test
     void zeroStartRejected() {
-        assertThrows(FcliSimpleException.class, () -> converter.convert("0-10"));
+        var ex = assertThrows(FcliSimpleException.class, () -> converter.convert("0-10"));
+        assertEquals("--fetch start must be >= 1", ex.getMessage());
     }
 
     @Test
     void endBeforeStartRejected() {
-        assertThrows(FcliSimpleException.class, () -> converter.convert("30-21"));
+        var ex = assertThrows(FcliSimpleException.class, () -> converter.convert("30-21"));
+        assertEquals("--fetch end must be >= start (30)", ex.getMessage());
     }
 
     @Test
     void nonNumericRejected() {
-        assertThrows(FcliSimpleException.class, () -> converter.convert("abc"));
+        var ex = assertThrows(FcliSimpleException.class, () -> converter.convert("abc"));
+        assertEquals("Invalid --fetch value 'abc'. Expected format: [<start>-]<end>", ex.getMessage());
     }
 
     @Test
     void extraSeparatorRejected() {
-        assertThrows(FcliSimpleException.class, () -> converter.convert("1-2-3"));
+        var ex = assertThrows(FcliSimpleException.class, () -> converter.convert("1-2-3"));
+        assertEquals("Invalid --fetch value '1-2-3'. Expected format: [<start>-]<end>", ex.getMessage());
     }
 }

--- a/fcli-core/fcli-common/src/test/java/com/fortify/cli/common/rest/paging/FetchRangeTest.java
+++ b/fcli-core/fcli-common/src/test/java/com/fortify/cli/common/rest/paging/FetchRangeTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.common.rest.paging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.fortify.cli.common.exception.FcliSimpleException;
+
+public class FetchRangeTest {
+    private final FetchRangeConverter converter = new FetchRangeConverter();
+
+    @Test
+    void endOnly() {
+        var result = converter.convert("10");
+        assertEquals(0, result.offset());
+        assertEquals(10, result.limit());
+    }
+
+    @Test
+    void startAndEndFromOne() {
+        var result = converter.convert("1-10");
+        assertEquals(0, result.offset());
+        assertEquals(10, result.limit());
+    }
+
+    @Test
+    void startAndEndMidRange() {
+        var result = converter.convert("21-30");
+        assertEquals(20, result.offset());
+        assertEquals(10, result.limit());
+    }
+
+    @Test
+    void singleRecord() {
+        var result = converter.convert("1");
+        assertEquals(0, result.offset());
+        assertEquals(1, result.limit());
+    }
+
+    @Test
+    void zeroEndRejected() {
+        assertThrows(FcliSimpleException.class, () -> converter.convert("0"));
+    }
+
+    @Test
+    void zeroStartRejected() {
+        assertThrows(FcliSimpleException.class, () -> converter.convert("0-10"));
+    }
+
+    @Test
+    void endBeforeStartRejected() {
+        assertThrows(FcliSimpleException.class, () -> converter.convert("30-21"));
+    }
+
+    @Test
+    void nonNumericRejected() {
+        assertThrows(FcliSimpleException.class, () -> converter.convert("abc"));
+    }
+
+    @Test
+    void extraSeparatorRejected() {
+        assertThrows(FcliSimpleException.class, () -> converter.convert("1-2-3"));
+    }
+}

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/cli/mixin/FoDFetchRangeMixin.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/cli/mixin/FoDFetchRangeMixin.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.fod._common.cli.mixin;
+
+import com.fortify.cli.common.rest.cli.mixin.AbstractFetchRangeMixin;
+import com.fortify.cli.common.rest.paging.FetchRange;
+
+import kong.unirest.HttpRequest;
+
+public final class FoDFetchRangeMixin extends AbstractFetchRangeMixin {
+    @Override
+    protected HttpRequest<?> applyFetchParams(HttpRequest<?> request, FetchRange range) {
+        return request
+                .queryString("offset", range.offset())
+                .queryString("limit", range.limit());
+    }
+}

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/rest/helper/FoDProductHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/rest/helper/FoDProductHelper.java
@@ -16,8 +16,11 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fortify.cli.common.exception.FcliSimpleException;
+import com.fortify.cli.common.json.JsonHelper;
 import com.fortify.cli.common.output.product.IProductHelper;
+import com.fortify.cli.common.output.product.IResponseMetadataCollector;
 import com.fortify.cli.common.output.transform.IInputTransformer;
 import com.fortify.cli.common.rest.paging.INextPageUrlProducer;
 import com.fortify.cli.common.rest.paging.INextPageUrlProducerSupplier;
@@ -26,7 +29,7 @@ import lombok.SneakyThrows;
 
 // IMPORTANT: When updating/adding any methods in this class, FoDRestCallCommand
 // also likely needs to be updated
-public class FoDProductHelper implements IProductHelper, IInputTransformer, INextPageUrlProducerSupplier 
+public class FoDProductHelper implements IProductHelper, IInputTransformer, INextPageUrlProducerSupplier, IResponseMetadataCollector 
 {
     public static final FoDProductHelper INSTANCE = new FoDProductHelper(); 
     private FoDProductHelper() {}
@@ -38,6 +41,22 @@ public class FoDProductHelper implements IProductHelper, IInputTransformer, INex
     @Override
     public JsonNode transformInput(JsonNode input) {
         return FoDInputTransformer.getItems(input);
+    }
+    
+    @Override
+    public ObjectNode collectResponseMetadata(JsonNode responseBody) {
+        if ( responseBody==null || !responseBody.has("items") ) { return null; }
+        var metadata = JsonHelper.getObjectMapper().createObjectNode();
+        if ( responseBody.has("totalCount") ) {
+            metadata.set("totalCount", responseBody.get("totalCount"));
+        }
+        if ( responseBody.has("offset") ) {
+            metadata.set("offset", responseBody.get("offset"));
+        }
+        if ( responseBody.has("limit") ) {
+            metadata.set("limit", responseBody.get("limit"));
+        }
+        return metadata.isEmpty() ? null : metadata;
     }
     
     public String getApiUrl(String url) {

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/cli/cmd/AbstractFoDScanListCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/cli/cmd/AbstractFoDScanListCommand.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fortify.cli.common.cli.util.CommandGroup;
 import com.fortify.cli.common.output.transform.IRecordTransformer;
 import com.fortify.cli.fod._common.cli.mixin.FoDDelimiterMixin;
+import com.fortify.cli.fod._common.cli.mixin.FoDFetchRangeMixin;
 import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDBaseRequestOutputCommand;
 import com.fortify.cli.fod._common.rest.FoDUrls;
 import com.fortify.cli.fod._common.scan.helper.FoDScanHelper;
@@ -29,6 +30,7 @@ import picocli.CommandLine.Mixin;
 @CommandGroup("*-scan")
 public abstract class AbstractFoDScanListCommand extends AbstractFoDBaseRequestOutputCommand implements IRecordTransformer {
     @Mixin private FoDDelimiterMixin delimiterMixin; // Is automatically injected in resolver mixins
+    @Mixin private FoDFetchRangeMixin fetchRangeMixin;
     @Mixin private FoDReleaseByQualifiedNameOrIdResolverMixin.RequiredOption releaseResolver;
     
     @Override

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/access_control/cli/cmd/FoDGroupListCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/access_control/cli/cmd/FoDGroupListCommand.java
@@ -19,6 +19,7 @@ import com.fortify.cli.common.output.transform.IRecordTransformer;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamGeneratorSupplier;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamValueGenerator;
 import com.fortify.cli.common.variable.DefaultVariablePropertyName;
+import com.fortify.cli.fod._common.cli.mixin.FoDFetchRangeMixin;
 import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDBaseRequestOutputCommand;
 import com.fortify.cli.fod._common.rest.FoDUrls;
 import com.fortify.cli.fod._common.rest.query.FoDFiltersParamGenerator;
@@ -35,6 +36,7 @@ import picocli.CommandLine.Mixin;
 @DefaultVariablePropertyName("id")
 public class FoDGroupListCommand extends AbstractFoDBaseRequestOutputCommand implements IRecordTransformer, IServerSideQueryParamGeneratorSupplier {
     @Getter @Mixin private OutputHelperMixins.TableWithQuery outputHelper;
+    @Mixin private FoDFetchRangeMixin fetchRangeMixin;
     @Mixin private FoDFiltersParamMixin filterParamMixin;
     @Getter private IServerSideQueryParamValueGenerator serverSideQueryParamGenerator = new FoDFiltersParamGenerator()
             .add("groupId")

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/access_control/cli/cmd/FoDRoleListCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/access_control/cli/cmd/FoDRoleListCommand.java
@@ -19,7 +19,6 @@ import com.fortify.cli.common.json.transform.fields.RenameFieldsTransformer;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.output.transform.IRecordTransformer;
 import com.fortify.cli.common.variable.DefaultVariablePropertyName;
-import com.fortify.cli.fod._common.cli.mixin.FoDFetchRangeMixin;
 import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDBaseRequestOutputCommand;
 import com.fortify.cli.fod._common.rest.FoDUrls;
 import com.fortify.cli.fod.rest.lookup.helper.FoDLookupType;
@@ -36,7 +35,8 @@ public class FoDRoleListCommand extends AbstractFoDBaseRequestOutputCommand impl
     private static final RenameFieldsTransformer RECORD_TRANSFORMER = new RenameFieldsTransformer(
             new String[] {"value:id", "text:name"});
     @Getter @Mixin private OutputHelperMixins.TableWithQuery outputHelper;
-    @Mixin private FoDFetchRangeMixin fetchRangeMixin;
+    // FoD does not support paging for this endpoint, so we cannot use the fetch range mixin here
+    //@Mixin private FoDFetchRangeMixin fetchRangeMixin;
     
     @Override
     public HttpRequest<?> getBaseRequest(UnirestInstance unirest) {

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/access_control/cli/cmd/FoDRoleListCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/access_control/cli/cmd/FoDRoleListCommand.java
@@ -19,6 +19,7 @@ import com.fortify.cli.common.json.transform.fields.RenameFieldsTransformer;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.output.transform.IRecordTransformer;
 import com.fortify.cli.common.variable.DefaultVariablePropertyName;
+import com.fortify.cli.fod._common.cli.mixin.FoDFetchRangeMixin;
 import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDBaseRequestOutputCommand;
 import com.fortify.cli.fod._common.rest.FoDUrls;
 import com.fortify.cli.fod.rest.lookup.helper.FoDLookupType;
@@ -35,6 +36,7 @@ public class FoDRoleListCommand extends AbstractFoDBaseRequestOutputCommand impl
     private static final RenameFieldsTransformer RECORD_TRANSFORMER = new RenameFieldsTransformer(
             new String[] {"value:id", "text:name"});
     @Getter @Mixin private OutputHelperMixins.TableWithQuery outputHelper;
+    @Mixin private FoDFetchRangeMixin fetchRangeMixin;
     
     @Override
     public HttpRequest<?> getBaseRequest(UnirestInstance unirest) {

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/access_control/cli/cmd/FoDUserListCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/access_control/cli/cmd/FoDUserListCommand.java
@@ -19,6 +19,7 @@ import com.fortify.cli.common.output.transform.IRecordTransformer;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamGeneratorSupplier;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamValueGenerator;
 import com.fortify.cli.common.variable.DefaultVariablePropertyName;
+import com.fortify.cli.fod._common.cli.mixin.FoDFetchRangeMixin;
 import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDBaseRequestOutputCommand;
 import com.fortify.cli.fod._common.rest.FoDUrls;
 import com.fortify.cli.fod._common.rest.query.FoDFiltersParamGenerator;
@@ -35,6 +36,7 @@ import picocli.CommandLine.Mixin;
 @DefaultVariablePropertyName("userId")
 public class FoDUserListCommand extends AbstractFoDBaseRequestOutputCommand implements IRecordTransformer, IServerSideQueryParamGeneratorSupplier {
     @Getter @Mixin private OutputHelperMixins.TableWithQuery outputHelper;
+    @Mixin private FoDFetchRangeMixin fetchRangeMixin;
     @Mixin private FoDFiltersParamMixin filterParamMixin;
     @Getter private IServerSideQueryParamValueGenerator serverSideQueryParamGenerator = new FoDFiltersParamGenerator()
             .add("userId","userId")

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/app/cli/cmd/FoDAppListCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/app/cli/cmd/FoDAppListCommand.java
@@ -17,6 +17,7 @@ import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.output.transform.IRecordTransformer;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamGeneratorSupplier;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamValueGenerator;
+import com.fortify.cli.fod._common.cli.mixin.FoDFetchRangeMixin;
 import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDBaseRequestOutputCommand;
 import com.fortify.cli.fod._common.rest.FoDUrls;
 import com.fortify.cli.fod._common.rest.query.FoDFiltersParamGenerator;
@@ -32,6 +33,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = OutputHelperMixins.List.CMD_NAME)
 public class FoDAppListCommand extends AbstractFoDBaseRequestOutputCommand implements IRecordTransformer, IServerSideQueryParamGeneratorSupplier {
     @Getter @Mixin private OutputHelperMixins.List outputHelper;
+    @Mixin private FoDFetchRangeMixin fetchRangeMixin;
     @Mixin private FoDFiltersParamMixin filterParamMixin;
     @Getter private IServerSideQueryParamValueGenerator serverSideQueryParamGenerator = new FoDFiltersParamGenerator()
             .add("id","applicationId")

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/app/cli/cmd/FoDAppScanListCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/app/cli/cmd/FoDAppScanListCommand.java
@@ -14,6 +14,7 @@ package com.fortify.cli.fod.app.cli.cmd;
 
 import com.fortify.cli.common.cli.util.CommandGroup;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
+import com.fortify.cli.fod._common.cli.mixin.FoDFetchRangeMixin;
 import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDBaseRequestOutputCommand;
 import com.fortify.cli.fod._common.rest.FoDUrls;
 import com.fortify.cli.fod._common.scan.helper.FoDScanHelper;
@@ -28,6 +29,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = "list-scans", aliases = "lss") @CommandGroup("scan")
 public class FoDAppScanListCommand extends AbstractFoDBaseRequestOutputCommand {
     @Getter @Mixin private OutputHelperMixins.TableWithQuery outputHelper;
+    @Mixin private FoDFetchRangeMixin fetchRangeMixin;
     @Mixin private FoDAppResolverMixin.RequiredOption appResolver;
     
     @Override

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/attribute/cli/cmd/FoDAttributeListCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/attribute/cli/cmd/FoDAttributeListCommand.java
@@ -15,6 +15,7 @@ package com.fortify.cli.fod.attribute.cli.cmd;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamGeneratorSupplier;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamValueGenerator;
+import com.fortify.cli.fod._common.cli.mixin.FoDFetchRangeMixin;
 import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDBaseRequestOutputCommand;
 import com.fortify.cli.fod._common.rest.FoDUrls;
 import com.fortify.cli.fod._common.rest.query.FoDFiltersParamGenerator;
@@ -29,6 +30,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = OutputHelperMixins.List.CMD_NAME)
 public class FoDAttributeListCommand extends AbstractFoDBaseRequestOutputCommand implements IServerSideQueryParamGeneratorSupplier {
     @Getter @Mixin private OutputHelperMixins.List outputHelper;
+    @Mixin private FoDFetchRangeMixin fetchRangeMixin;
     @Mixin private FoDFiltersParamMixin filterParamMixin;
     @Getter private IServerSideQueryParamValueGenerator serverSideQueryParamGenerator = new FoDFiltersParamGenerator()
             .add("id", "attributeId")

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/attribute/cli/cmd/FoDAttributeListCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/attribute/cli/cmd/FoDAttributeListCommand.java
@@ -15,7 +15,6 @@ package com.fortify.cli.fod.attribute.cli.cmd;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamGeneratorSupplier;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamValueGenerator;
-import com.fortify.cli.fod._common.cli.mixin.FoDFetchRangeMixin;
 import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDBaseRequestOutputCommand;
 import com.fortify.cli.fod._common.rest.FoDUrls;
 import com.fortify.cli.fod._common.rest.query.FoDFiltersParamGenerator;
@@ -30,7 +29,8 @@ import picocli.CommandLine.Mixin;
 @Command(name = OutputHelperMixins.List.CMD_NAME)
 public class FoDAttributeListCommand extends AbstractFoDBaseRequestOutputCommand implements IServerSideQueryParamGeneratorSupplier {
     @Getter @Mixin private OutputHelperMixins.List outputHelper;
-    @Mixin private FoDFetchRangeMixin fetchRangeMixin;
+    // FoD does not support paging for this endpoint, so we cannot use the fetch range mixin here
+    //@Mixin private FoDFetchRangeMixin fetchRangeMixin;
     @Mixin private FoDFiltersParamMixin filterParamMixin;
     @Getter private IServerSideQueryParamValueGenerator serverSideQueryParamGenerator = new FoDFiltersParamGenerator()
             .add("id", "attributeId")

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/issue/cli/cmd/FoDIssueListCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/issue/cli/cmd/FoDIssueListCommand.java
@@ -22,6 +22,7 @@ import java.util.stream.Stream;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fortify.cli.common.exception.FcliSimpleException;
 import com.fortify.cli.common.json.JsonHelper;
 import com.fortify.cli.common.json.producer.AbstractObjectNodeProducer.AbstractObjectNodeProducerBuilder;
 import com.fortify.cli.common.json.producer.IObjectNodeProducer;
@@ -33,6 +34,7 @@ import com.fortify.cli.common.rest.query.IServerSideQueryParamValueGenerator;
 import com.fortify.cli.common.util.Break;
 import com.fortify.cli.fod._common.cli.mixin.FoDAppOrReleaseMixin;
 import com.fortify.cli.fod._common.cli.mixin.FoDDelimiterMixin;
+import com.fortify.cli.fod._common.cli.mixin.FoDFetchRangeMixin;
 import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDOutputCommand;
 import com.fortify.cli.fod._common.rest.FoDUrls;
 import com.fortify.cli.fod._common.rest.query.FoDFiltersParamGenerator;
@@ -54,6 +56,7 @@ import picocli.CommandLine.Option;
 @Command(name = OutputHelperMixins.List.CMD_NAME)
 public class FoDIssueListCommand extends AbstractFoDOutputCommand implements IServerSideQueryParamGeneratorSupplier {
     @Getter @Mixin private OutputHelperMixins.List outputHelper;
+    @Mixin private FoDFetchRangeMixin fetchRangeMixin;
     @Mixin private FoDDelimiterMixin delimiterMixin;
     @Mixin @Getter private FoDAppOrReleaseMixin appOrRelease;
     @Mixin private FoDFiltersParamMixin filterParamMixin;
@@ -75,6 +78,9 @@ public class FoDIssueListCommand extends AbstractFoDOutputCommand implements ISe
     @Override
     protected IObjectNodeProducer getObjectNodeProducer(UnirestInstance unirest) {
         boolean releaseSpecified = appOrRelease.isReleaseSpecified();
+        if (!releaseSpecified && fetchRangeMixin.isFetchSpecified()) {
+            throw new FcliSimpleException("--fetch cannot be combined with --app; use --release to specify a single release");
+        }
         var result = releaseSpecified
                 ? singleReleaseProducerBuilder(unirest, appOrRelease.getReleaseId(unirest))
                 : applicationProducerBuilder(unirest, appOrRelease.getAppId(unirest));

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/microservice/cli/cmd/FoDMicroserviceListCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/microservice/cli/cmd/FoDMicroserviceListCommand.java
@@ -16,7 +16,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.output.transform.IRecordTransformer;
-import com.fortify.cli.fod._common.cli.mixin.FoDFetchRangeMixin;
 import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDBaseRequestOutputCommand;
 import com.fortify.cli.fod._common.rest.FoDUrls;
 import com.fortify.cli.fod.app.cli.mixin.FoDAppResolverMixin;
@@ -31,7 +30,8 @@ import picocli.CommandLine.Mixin;
 @Command(name = OutputHelperMixins.List.CMD_NAME)
 public class FoDMicroserviceListCommand extends AbstractFoDBaseRequestOutputCommand implements IRecordTransformer {
     @Getter @Mixin private OutputHelperMixins.List outputHelper;
-    @Mixin private FoDFetchRangeMixin fetchRangeMixin;
+    // FoD does not support paging for this endpoint, so we cannot use the fetch range mixin here
+    //@Mixin private FoDFetchRangeMixin fetchRangeMixin;
     @Mixin private FoDAppResolverMixin.RequiredOption appResolver;
 
     @Override

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/microservice/cli/cmd/FoDMicroserviceListCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/microservice/cli/cmd/FoDMicroserviceListCommand.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.output.transform.IRecordTransformer;
+import com.fortify.cli.fod._common.cli.mixin.FoDFetchRangeMixin;
 import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDBaseRequestOutputCommand;
 import com.fortify.cli.fod._common.rest.FoDUrls;
 import com.fortify.cli.fod.app.cli.mixin.FoDAppResolverMixin;
@@ -30,6 +31,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = OutputHelperMixins.List.CMD_NAME)
 public class FoDMicroserviceListCommand extends AbstractFoDBaseRequestOutputCommand implements IRecordTransformer {
     @Getter @Mixin private OutputHelperMixins.List outputHelper;
+    @Mixin private FoDFetchRangeMixin fetchRangeMixin;
     @Mixin private FoDAppResolverMixin.RequiredOption appResolver;
 
     @Override

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/release/cli/cmd/FoDReleaseListCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/release/cli/cmd/FoDReleaseListCommand.java
@@ -17,6 +17,7 @@ import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.output.transform.IRecordTransformer;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamGeneratorSupplier;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamValueGenerator;
+import com.fortify.cli.fod._common.cli.mixin.FoDFetchRangeMixin;
 import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDBaseRequestOutputCommand;
 import com.fortify.cli.fod._common.rest.FoDUrls;
 import com.fortify.cli.fod._common.rest.query.FoDFiltersParamGenerator;
@@ -33,6 +34,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = OutputHelperMixins.List.CMD_NAME)
 public class FoDReleaseListCommand extends AbstractFoDBaseRequestOutputCommand implements IRecordTransformer, IServerSideQueryParamGeneratorSupplier {
     @Getter @Mixin private OutputHelperMixins.List outputHelper;
+    @Mixin private FoDFetchRangeMixin fetchRangeMixin;
     @Mixin private FoDAppResolverMixin.OptionalOption appResolver;
     @Mixin private FoDFiltersParamMixin filterParamMixin;
     @Getter private IServerSideQueryParamValueGenerator serverSideQueryParamGenerator = new FoDFiltersParamGenerator()

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/release/cli/cmd/FoDReleaseScanListCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/release/cli/cmd/FoDReleaseScanListCommand.java
@@ -15,6 +15,7 @@ package com.fortify.cli.fod.release.cli.cmd;
 import com.fortify.cli.common.cli.util.CommandGroup;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.fod._common.cli.mixin.FoDDelimiterMixin;
+import com.fortify.cli.fod._common.cli.mixin.FoDFetchRangeMixin;
 import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDBaseRequestOutputCommand;
 import com.fortify.cli.fod._common.rest.FoDUrls;
 import com.fortify.cli.fod._common.scan.helper.FoDScanHelper;
@@ -29,6 +30,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = "list-scans", aliases = "lss") @CommandGroup("scan")
 public class FoDReleaseScanListCommand extends AbstractFoDBaseRequestOutputCommand {
     @Getter @Mixin private OutputHelperMixins.TableWithQuery outputHelper;
+    @Mixin private FoDFetchRangeMixin fetchRangeMixin;
     @Mixin private FoDDelimiterMixin delimiterMixin; // Is automatically injected in resolver mixins
     @Mixin private FoDReleaseByQualifiedNameOrIdResolverMixin.RequiredOption releaseResolver;
     

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/report/cli/cmd/FoDReportListCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/report/cli/cmd/FoDReportListCommand.java
@@ -15,6 +15,7 @@ package com.fortify.cli.fod.report.cli.cmd;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamGeneratorSupplier;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamValueGenerator;
+import com.fortify.cli.fod._common.cli.mixin.FoDFetchRangeMixin;
 import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDBaseRequestOutputCommand;
 import com.fortify.cli.fod._common.rest.FoDUrls;
 import com.fortify.cli.fod._common.rest.query.FoDFiltersParamGenerator;
@@ -29,6 +30,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = OutputHelperMixins.List.CMD_NAME)
 public class FoDReportListCommand extends AbstractFoDBaseRequestOutputCommand implements IServerSideQueryParamGeneratorSupplier {
     @Getter @Mixin private OutputHelperMixins.List outputHelper;
+    @Mixin private FoDFetchRangeMixin fetchRangeMixin;
     @Mixin private FoDFiltersParamMixin filterParamMixin;
     @Getter private IServerSideQueryParamValueGenerator serverSideQueryParamGenerator = new FoDFiltersParamGenerator()
             .add("id","reportId")

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/report/cli/cmd/FoDReportTemplateListCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/report/cli/cmd/FoDReportTemplateListCommand.java
@@ -15,7 +15,6 @@ package com.fortify.cli.fod.report.cli.cmd;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fortify.cli.common.cli.util.CommandGroup;
 import com.fortify.cli.common.output.transform.IRecordTransformer;
-import com.fortify.cli.fod._common.cli.mixin.FoDFetchRangeMixin;
 import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDBaseRequestOutputCommand;
 import com.fortify.cli.fod._common.output.cli.mixin.FoDOutputHelperMixins;
 import com.fortify.cli.fod._common.rest.FoDUrls;
@@ -32,7 +31,8 @@ import picocli.CommandLine.Option;
 @Command(name = "list-templates", aliases = "lst") @CommandGroup("report-template")
 public final class FoDReportTemplateListCommand extends AbstractFoDBaseRequestOutputCommand implements IRecordTransformer {
     @Getter @Mixin private FoDOutputHelperMixins.Lookup outputHelper;
-    @Mixin private FoDFetchRangeMixin fetchRangeMixin;
+    // FoD does not support paging for this endpoint, so we cannot use the fetch range mixin here
+    //@Mixin private FoDFetchRangeMixin fetchRangeMixin;
 
     @Option(names = {"--group"}, defaultValue = "All")
     FoDReportTemplateGroupType groupType;

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/report/cli/cmd/FoDReportTemplateListCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/report/cli/cmd/FoDReportTemplateListCommand.java
@@ -15,6 +15,7 @@ package com.fortify.cli.fod.report.cli.cmd;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fortify.cli.common.cli.util.CommandGroup;
 import com.fortify.cli.common.output.transform.IRecordTransformer;
+import com.fortify.cli.fod._common.cli.mixin.FoDFetchRangeMixin;
 import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDBaseRequestOutputCommand;
 import com.fortify.cli.fod._common.output.cli.mixin.FoDOutputHelperMixins;
 import com.fortify.cli.fod._common.rest.FoDUrls;
@@ -31,6 +32,7 @@ import picocli.CommandLine.Option;
 @Command(name = "list-templates", aliases = "lst") @CommandGroup("report-template")
 public final class FoDReportTemplateListCommand extends AbstractFoDBaseRequestOutputCommand implements IRecordTransformer {
     @Getter @Mixin private FoDOutputHelperMixins.Lookup outputHelper;
+    @Mixin private FoDFetchRangeMixin fetchRangeMixin;
 
     @Option(names = {"--group"}, defaultValue = "All")
     FoDReportTemplateGroupType groupType;

--- a/fcli-core/fcli-sc-dast/src/main/java/com/fortify/cli/sc_dast/_common/cli/mixin/SCDastFetchRangeMixin.java
+++ b/fcli-core/fcli-sc-dast/src/main/java/com/fortify/cli/sc_dast/_common/cli/mixin/SCDastFetchRangeMixin.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.sc_dast._common.cli.mixin;
+
+import com.fortify.cli.common.rest.cli.mixin.AbstractFetchRangeMixin;
+import com.fortify.cli.common.rest.paging.FetchRange;
+
+import kong.unirest.HttpRequest;
+
+public final class SCDastFetchRangeMixin extends AbstractFetchRangeMixin {
+    @Override
+    protected HttpRequest<?> applyFetchParams(HttpRequest<?> request, FetchRange range) {
+        return request
+                .queryString("offset", range.offset())
+                .queryString("limit", range.limit());
+    }
+}

--- a/fcli-core/fcli-sc-dast/src/main/java/com/fortify/cli/sc_dast/scan/cli/cmd/SCDastScanListCommand.java
+++ b/fcli-core/fcli-sc-dast/src/main/java/com/fortify/cli/sc_dast/scan/cli/cmd/SCDastScanListCommand.java
@@ -13,6 +13,7 @@
 package com.fortify.cli.sc_dast.scan.cli.cmd;
 
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
+import com.fortify.cli.sc_dast._common.cli.mixin.SCDastFetchRangeMixin;
 import com.fortify.cli.sc_dast._common.output.cli.cmd.AbstractSCDastBaseRequestOutputCommand;
 import com.fortify.cli.ssc._common.rest.sc_dast.query.cli.mixin.SCDastQueryParamsMixin;
 
@@ -25,6 +26,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = OutputHelperMixins.List.CMD_NAME)
 public class SCDastScanListCommand extends AbstractSCDastBaseRequestOutputCommand {
     @Getter @Mixin private OutputHelperMixins.List outputHelper;
+    @Mixin private SCDastFetchRangeMixin fetchRangeMixin;
     // TODO Re-implement support for querying on scan type name based on 
     //      SCDastScanStatus.valueOf(scanStatus).getScanStatusType()
     // TODO Re-implement auto-generated queries based on -q / --query option

--- a/fcli-core/fcli-sc-dast/src/main/java/com/fortify/cli/sc_dast/scan_settings/cli/cmd/SCDastScanSettingsListCommand.java
+++ b/fcli-core/fcli-sc-dast/src/main/java/com/fortify/cli/sc_dast/scan_settings/cli/cmd/SCDastScanSettingsListCommand.java
@@ -13,6 +13,7 @@
 package com.fortify.cli.sc_dast.scan_settings.cli.cmd;
 
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
+import com.fortify.cli.sc_dast._common.cli.mixin.SCDastFetchRangeMixin;
 import com.fortify.cli.sc_dast._common.output.cli.cmd.AbstractSCDastBaseRequestOutputCommand;
 import com.fortify.cli.ssc._common.rest.sc_dast.query.cli.mixin.SCDastQueryParamsMixin;
 
@@ -25,6 +26,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = OutputHelperMixins.List.CMD_NAME)
 public class SCDastScanSettingsListCommand extends AbstractSCDastBaseRequestOutputCommand {
     @Getter @Mixin private OutputHelperMixins.List outputHelper;
+    @Mixin private SCDastFetchRangeMixin fetchRangeMixin;
     // TODO Re-implement support for querying on scan type name based on 
     //      SCDastScanStatus.valueOf(scanStatus).getScanStatusType()
     // TODO Re-implement auto-generated queries based on -q / --query option

--- a/fcli-core/fcli-sc-dast/src/main/java/com/fortify/cli/sc_dast/sensor/cli/cmd/SCDastSensorListCommand.java
+++ b/fcli-core/fcli-sc-dast/src/main/java/com/fortify/cli/sc_dast/sensor/cli/cmd/SCDastSensorListCommand.java
@@ -13,6 +13,7 @@
 package com.fortify.cli.sc_dast.sensor.cli.cmd;
 
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
+import com.fortify.cli.sc_dast._common.cli.mixin.SCDastFetchRangeMixin;
 import com.fortify.cli.sc_dast._common.output.cli.cmd.AbstractSCDastBaseRequestOutputCommand;
 
 import kong.unirest.HttpRequest;
@@ -24,6 +25,7 @@ import picocli.CommandLine.Mixin;
 @Command(name=OutputHelperMixins.List.CMD_NAME)
 public class SCDastSensorListCommand extends AbstractSCDastBaseRequestOutputCommand {
     @Getter @Mixin private OutputHelperMixins.List outputHelper;
+    @Mixin private SCDastFetchRangeMixin fetchRangeMixin;
     public HttpRequest<?> getBaseRequest(UnirestInstance unirest) {
         return unirest.get("/api/v2/scanners");
     };

--- a/fcli-core/fcli-sc-sast/src/main/java/com/fortify/cli/sc_sast/scan/cli/cmd/SCSastScanListCommand.java
+++ b/fcli-core/fcli-sc-sast/src/main/java/com/fortify/cli/sc_sast/scan/cli/cmd/SCSastScanListCommand.java
@@ -21,6 +21,7 @@ import com.fortify.cli.common.output.transform.IRecordTransformer;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamGeneratorSupplier;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamValueGenerator;
 import com.fortify.cli.common.spel.SpelEvaluator;
+import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCBaseRequestOutputCommand;
 import com.fortify.cli.ssc._common.rest.ssc.query.SSCQParamGenerator;
 import com.fortify.cli.ssc._common.rest.ssc.query.SSCQParamValueGenerators;
@@ -35,6 +36,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = OutputHelperMixins.List.CMD_NAME)
 public class SCSastScanListCommand extends AbstractSSCBaseRequestOutputCommand implements IRecordTransformer, IServerSideQueryParamGeneratorSupplier {
     @Getter @Mixin private OutputHelperMixins.List outputHelper;
+    @Mixin private SSCFetchRangeMixin fetchRangeMixin;
     @Mixin private SSCQParamMixin qParamMixin;
     @Getter private IServerSideQueryParamValueGenerator serverSideQueryParamGenerator = new SSCQParamGenerator()
                 .add("jobState", SSCQParamValueGenerators::plain)

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/cli/mixin/SSCFetchRangeMixin.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/cli/mixin/SSCFetchRangeMixin.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.ssc._common.cli.mixin;
+
+import com.fortify.cli.common.rest.cli.mixin.AbstractFetchRangeMixin;
+import com.fortify.cli.common.rest.paging.FetchRange;
+
+import kong.unirest.HttpRequest;
+
+public final class SSCFetchRangeMixin extends AbstractFetchRangeMixin {
+    @Override
+    protected HttpRequest<?> applyFetchParams(HttpRequest<?> request, FetchRange range) {
+        return request
+                .queryString("start", range.offset())
+                .queryString("limit", range.limit());
+    }
+}

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/rest/ssc/helper/SSCProductHelper.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/_common/rest/ssc/helper/SSCProductHelper.java
@@ -13,14 +13,17 @@
 package com.fortify.cli.ssc._common.rest.ssc.helper;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fortify.cli.common.json.JsonHelper;
 import com.fortify.cli.common.output.product.IProductHelper;
+import com.fortify.cli.common.output.product.IResponseMetadataCollector;
 import com.fortify.cli.common.output.transform.IInputTransformer;
 import com.fortify.cli.common.rest.paging.INextPageUrlProducer;
 import com.fortify.cli.common.rest.paging.INextPageUrlProducerSupplier;
 
 //IMPORTANT: When updating/adding any methods in this class, SSCRestCallCommand
 //also likely needs to be updated
-public class SSCProductHelper implements IProductHelper, IInputTransformer, INextPageUrlProducerSupplier
+public class SSCProductHelper implements IProductHelper, IInputTransformer, INextPageUrlProducerSupplier, IResponseMetadataCollector
 {
     public static final SSCProductHelper INSTANCE = new SSCProductHelper();
     private SSCProductHelper() {}
@@ -32,5 +35,18 @@ public class SSCProductHelper implements IProductHelper, IInputTransformer, INex
     @Override
     public JsonNode transformInput(JsonNode input) {
         return SSCInputTransformer.getDataOrSelf(input);
+    }
+    
+    @Override
+    public ObjectNode collectResponseMetadata(JsonNode responseBody) {
+        if ( responseBody==null || !responseBody.has("data") ) { return null; }
+        var metadata = JsonHelper.getObjectMapper().createObjectNode();
+        if ( responseBody.has("count") ) {
+            metadata.set("totalCount", responseBody.get("count"));
+        }
+        if ( responseBody.has("links") ) {
+            metadata.set("links", responseBody.get("links"));
+        }
+        return metadata.isEmpty() ? null : metadata;
     }
 }

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/cli/cmd/SSCAppVersionUserListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/cli/cmd/SSCAppVersionUserListCommand.java
@@ -14,6 +14,7 @@ package com.fortify.cli.ssc.access_control.cli.cmd;
 
 import com.fortify.cli.common.cli.util.CommandGroup;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
+import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCBaseRequestOutputCommand;
 import com.fortify.cli.ssc._common.rest.ssc.SSCUrls;
 import com.fortify.cli.ssc.appversion.cli.mixin.SSCAppVersionResolverMixin;
@@ -27,6 +28,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = "list-appversion-users", aliases = "lsavu") @CommandGroup("appversion-user")
 public class SSCAppVersionUserListCommand extends AbstractSSCBaseRequestOutputCommand {
     @Getter @Mixin private OutputHelperMixins.TableWithQuery outputHelper; 
+    @Mixin private SSCFetchRangeMixin fetchRangeMixin;
     @Mixin private SSCAppVersionResolverMixin.RequiredOption parentResolver;
     
     // TODO Can we do any server-side filtering?

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/cli/cmd/SSCAppVersionUserListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/cli/cmd/SSCAppVersionUserListCommand.java
@@ -14,7 +14,6 @@ package com.fortify.cli.ssc.access_control.cli.cmd;
 
 import com.fortify.cli.common.cli.util.CommandGroup;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
-import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCBaseRequestOutputCommand;
 import com.fortify.cli.ssc._common.rest.ssc.SSCUrls;
 import com.fortify.cli.ssc.appversion.cli.mixin.SSCAppVersionResolverMixin;
@@ -28,7 +27,8 @@ import picocli.CommandLine.Mixin;
 @Command(name = "list-appversion-users", aliases = "lsavu") @CommandGroup("appversion-user")
 public class SSCAppVersionUserListCommand extends AbstractSSCBaseRequestOutputCommand {
     @Getter @Mixin private OutputHelperMixins.TableWithQuery outputHelper; 
-    @Mixin private SSCFetchRangeMixin fetchRangeMixin;
+    // SSC does not support paging for this endpoint, so we cannot use the fetch range mixin here
+    //@Mixin private SSCFetchRangeMixin fetchRangeMixin;
     @Mixin private SSCAppVersionResolverMixin.RequiredOption parentResolver;
     
     // TODO Can we do any server-side filtering?

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/cli/cmd/SSCPermissionListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/cli/cmd/SSCPermissionListCommand.java
@@ -28,7 +28,6 @@ import com.fortify.cli.ssc.access_control.helper.SSCRolePermissionHelper;
 import kong.unirest.HttpRequest;
 import kong.unirest.UnirestInstance;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/cli/cmd/SSCPermissionListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/cli/cmd/SSCPermissionListCommand.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fortify.cli.common.cli.util.CommandGroup;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.output.transform.IRecordTransformer;
+import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCBaseRequestOutputCommand;
 import com.fortify.cli.ssc._common.rest.ssc.SSCUrls;
 import com.fortify.cli.ssc.access_control.cli.mixin.SSCRoleResolverMixin;
@@ -32,6 +33,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = "list-permissions", aliases = {"lsp"}) @CommandGroup("permission")
 public class SSCPermissionListCommand extends AbstractSSCBaseRequestOutputCommand implements IRecordTransformer {
     @Getter @Mixin private OutputHelperMixins.TableWithQuery outputHelper; 
+    @Mixin private SSCFetchRangeMixin fetchRangeMixin;
     @Mixin private SSCRoleResolverMixin.OptionalOption roleResolverMixin;
     
     @Override

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/cli/cmd/SSCPermissionListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/cli/cmd/SSCPermissionListCommand.java
@@ -16,6 +16,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fortify.cli.common.cli.util.CommandGroup;
+import com.fortify.cli.common.exception.FcliSimpleException;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.output.transform.IRecordTransformer;
 import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
@@ -27,6 +28,7 @@ import com.fortify.cli.ssc.access_control.helper.SSCRolePermissionHelper;
 import kong.unirest.HttpRequest;
 import kong.unirest.UnirestInstance;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 
@@ -41,6 +43,9 @@ public class SSCPermissionListCommand extends AbstractSSCBaseRequestOutputComman
         if ( StringUtils.isBlank(roleResolverMixin.getRoleNameOrId()) ) {
             return unirest.get(SSCUrls.PERMISSIONS);
         } else {
+            if ( fetchRangeMixin.isFetchSpecified() ) {
+                throw new FcliSimpleException("--fetch cannot be used in combination with --role/-r");
+            }
             return unirest.get(SSCUrls.ROLE_PERMISSIONS(roleResolverMixin.getRoleId(unirest)));
         }
     }

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/cli/cmd/SSCRoleListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/cli/cmd/SSCRoleListCommand.java
@@ -16,6 +16,7 @@ import com.fortify.cli.common.cli.util.CommandGroup;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamGeneratorSupplier;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamValueGenerator;
+import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCBaseRequestOutputCommand;
 import com.fortify.cli.ssc._common.rest.ssc.SSCUrls;
 import com.fortify.cli.ssc._common.rest.ssc.query.SSCQParamGenerator;
@@ -31,6 +32,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = "list-roles", aliases = "lsr") @CommandGroup("role")
 public class SSCRoleListCommand extends AbstractSSCBaseRequestOutputCommand implements IServerSideQueryParamGeneratorSupplier {
     @Getter @Mixin private OutputHelperMixins.TableWithQuery outputHelper; 
+    @Mixin private SSCFetchRangeMixin fetchRangeMixin;
     @Mixin private SSCQParamMixin qParamMixin;
     @Getter private IServerSideQueryParamValueGenerator serverSideQueryParamGenerator = new SSCQParamGenerator()
                 .add("id", SSCQParamValueGenerators::plain)

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/cli/cmd/SSCTokenDefinitionListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/cli/cmd/SSCTokenDefinitionListCommand.java
@@ -16,6 +16,7 @@ import com.fortify.cli.common.cli.util.CommandGroup;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamGeneratorSupplier;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamValueGenerator;
+import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCBaseRequestOutputCommand;
 import com.fortify.cli.ssc._common.rest.ssc.SSCUrls;
 import com.fortify.cli.ssc._common.rest.ssc.query.SSCQParamGenerator;
@@ -31,6 +32,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = "list-token-definitions", aliases = "lstd") @CommandGroup("token-definition")
 public class SSCTokenDefinitionListCommand extends AbstractSSCBaseRequestOutputCommand implements IServerSideQueryParamGeneratorSupplier {
     @Getter @Mixin private OutputHelperMixins.TableWithQuery outputHelper; 
+    @Mixin private SSCFetchRangeMixin fetchRangeMixin;
     @Mixin private SSCQParamMixin qParamMixin;
     @Getter private IServerSideQueryParamValueGenerator serverSideQueryParamGenerator = new SSCQParamGenerator()
                 .add("type", SSCQParamValueGenerators::wrapInQuotes)

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/cli/cmd/SSCUserListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/cli/cmd/SSCUserListCommand.java
@@ -16,6 +16,7 @@ import com.fortify.cli.common.cli.util.CommandGroup;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamGeneratorSupplier;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamValueGenerator;
+import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCBaseRequestOutputCommand;
 import com.fortify.cli.ssc._common.rest.ssc.SSCUrls;
 import com.fortify.cli.ssc._common.rest.ssc.query.SSCQParamGenerator;
@@ -31,6 +32,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = "list-users", aliases = "lsu") @CommandGroup("user")
 public class SSCUserListCommand extends AbstractSSCBaseRequestOutputCommand implements IServerSideQueryParamGeneratorSupplier {
     @Getter @Mixin private OutputHelperMixins.TableWithQuery outputHelper; 
+    @Mixin private SSCFetchRangeMixin fetchRangeMixin;
     @Mixin private SSCQParamMixin qParamMixin;
     @Getter private IServerSideQueryParamValueGenerator serverSideQueryParamGenerator = new SSCQParamGenerator()
                 .add("id", SSCQParamValueGenerators::plain)

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/alert/cli/cmd/SSCAlertDefinitionListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/alert/cli/cmd/SSCAlertDefinitionListCommand.java
@@ -16,6 +16,7 @@ import com.fortify.cli.common.cli.util.CommandGroup;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamGeneratorSupplier;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamValueGenerator;
+import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCBaseRequestOutputCommand;
 import com.fortify.cli.ssc._common.rest.ssc.SSCUrls;
 import com.fortify.cli.ssc._common.rest.ssc.query.SSCQParamGenerator;
@@ -31,6 +32,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = OutputHelperMixins.ListDefinitions.CMD_NAME) @CommandGroup("definition")
 public class SSCAlertDefinitionListCommand extends AbstractSSCBaseRequestOutputCommand implements IServerSideQueryParamGeneratorSupplier {
     @Getter @Mixin private OutputHelperMixins.ListDefinitions outputHelper; 
+    @Mixin private SSCFetchRangeMixin fetchRangeMixin;
     @Mixin private SSCQParamMixin qParamMixin;
     @Getter private IServerSideQueryParamValueGenerator serverSideQueryParamGenerator = new SSCQParamGenerator()
                 .add("id", SSCQParamValueGenerators::plain)

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/alert/cli/cmd/SSCAlertListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/alert/cli/cmd/SSCAlertListCommand.java
@@ -18,6 +18,7 @@ import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.output.transform.IRecordTransformer;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamGeneratorSupplier;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamValueGenerator;
+import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCBaseRequestOutputCommand;
 import com.fortify.cli.ssc._common.rest.ssc.SSCUrls;
 import com.fortify.cli.ssc._common.rest.ssc.query.SSCQParamGenerator;
@@ -33,6 +34,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = OutputHelperMixins.List.CMD_NAME)
 public class SSCAlertListCommand extends AbstractSSCBaseRequestOutputCommand implements IRecordTransformer, IServerSideQueryParamGeneratorSupplier {
     @Getter @Mixin private OutputHelperMixins.List outputHelper; 
+    @Mixin private SSCFetchRangeMixin fetchRangeMixin;
     @Mixin private SSCQParamMixin qParamMixin;
     @Getter private IServerSideQueryParamValueGenerator serverSideQueryParamGenerator = new SSCQParamGenerator()
                 .add("id", SSCQParamValueGenerators::plain)

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/app/cli/cmd/SSCAppListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/app/cli/cmd/SSCAppListCommand.java
@@ -15,6 +15,7 @@ package com.fortify.cli.ssc.app.cli.cmd;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamGeneratorSupplier;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamValueGenerator;
+import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCBaseRequestOutputCommand;
 import com.fortify.cli.ssc._common.rest.ssc.SSCUrls;
 import com.fortify.cli.ssc._common.rest.ssc.query.SSCQParamGenerator;
@@ -30,6 +31,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = OutputHelperMixins.List.CMD_NAME)
 public class SSCAppListCommand extends AbstractSSCBaseRequestOutputCommand implements IServerSideQueryParamGeneratorSupplier {
     @Getter @Mixin private OutputHelperMixins.List outputHelper; 
+    @Mixin private SSCFetchRangeMixin fetchRangeMixin;
     @Mixin private SSCQParamMixin qParamMixin;
     @Getter private IServerSideQueryParamValueGenerator serverSideQueryParamGenerator = new SSCQParamGenerator()
                 .add("id", SSCQParamValueGenerators::plain)

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/cli/cmd/SSCAppVersionListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/cli/cmd/SSCAppVersionListCommand.java
@@ -17,6 +17,7 @@ import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.output.transform.IRecordTransformer;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamGeneratorSupplier;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamValueGenerator;
+import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCBaseRequestOutputCommand;
 import com.fortify.cli.ssc._common.rest.ssc.query.SSCQParamGenerator;
 import com.fortify.cli.ssc._common.rest.ssc.query.SSCQParamValueGenerators;
@@ -35,6 +36,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = OutputHelperMixins.List.CMD_NAME)
 public class SSCAppVersionListCommand extends AbstractSSCBaseRequestOutputCommand implements IRecordTransformer, IServerSideQueryParamGeneratorSupplier {
     @Getter @Mixin private OutputHelperMixins.List outputHelper; 
+    @Mixin private SSCFetchRangeMixin fetchRangeMixin;
     @Mixin private SSCQParamMixin qParamMixin;
     @Getter private IServerSideQueryParamValueGenerator serverSideQueryParamGenerator = new SSCQParamGenerator()
                 .add("id", SSCQParamValueGenerators::plain)
@@ -47,7 +49,7 @@ public class SSCAppVersionListCommand extends AbstractSSCBaseRequestOutputComman
     
     @Override
     public HttpRequest<?> getBaseRequest(UnirestInstance unirest) {
-        return unirest.get("/api/v1/projectVersions?limit=100");
+        return unirest.get("/api/v1/projectVersions");
     }
 
     @Override

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/artifact/cli/cmd/SSCArtifactListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/artifact/cli/cmd/SSCArtifactListCommand.java
@@ -14,6 +14,7 @@ package com.fortify.cli.ssc.artifact.cli.cmd;
 
 import com.fortify.cli.common.output.cli.cmd.IBaseRequestSupplier;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
+import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
 import com.fortify.cli.ssc._common.rest.ssc.SSCUrls;
 import com.fortify.cli.ssc.appversion.cli.mixin.SSCAppVersionResolverMixin;
 
@@ -25,6 +26,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = OutputHelperMixins.List.CMD_NAME)
 public class SSCArtifactListCommand extends AbstractSSCArtifactOutputCommand implements IBaseRequestSupplier {
     @Getter @Mixin private OutputHelperMixins.List outputHelper; 
+    @Mixin private SSCFetchRangeMixin fetchRangeMixin;
     @Mixin private SSCAppVersionResolverMixin.RequiredOption parentResolver;
     
     @Override

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/attribute/cli/cmd/SSCAttributeDefinitionListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/attribute/cli/cmd/SSCAttributeDefinitionListCommand.java
@@ -16,6 +16,7 @@ import com.fortify.cli.common.cli.util.CommandGroup;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamGeneratorSupplier;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamValueGenerator;
+import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCBaseRequestOutputCommand;
 import com.fortify.cli.ssc._common.rest.ssc.query.SSCQParamGenerator;
 import com.fortify.cli.ssc._common.rest.ssc.query.SSCQParamValueGenerators;
@@ -30,6 +31,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = OutputHelperMixins.ListDefinitions.CMD_NAME) @CommandGroup("definition")
 public class SSCAttributeDefinitionListCommand extends AbstractSSCBaseRequestOutputCommand implements IServerSideQueryParamGeneratorSupplier {
     @Getter @Mixin private OutputHelperMixins.ListDefinitions outputHelper; 
+    @Mixin private SSCFetchRangeMixin fetchRangeMixin;
     @Mixin private SSCQParamMixin qParamMixin;
     @Getter private IServerSideQueryParamValueGenerator serverSideQueryParamGenerator = new SSCQParamGenerator()
                 .add("id", SSCQParamValueGenerators::plain)
@@ -41,7 +43,7 @@ public class SSCAttributeDefinitionListCommand extends AbstractSSCBaseRequestOut
 
     @Override
     public HttpRequest<?> getBaseRequest(UnirestInstance unirest) {
-        return unirest.get("/api/v1/attributeDefinitions?limit=100&orderby=category,name");
+        return unirest.get("/api/v1/attributeDefinitions?orderby=category,name");
     }
     
     @Override

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/issue/cli/cmd/SSCIssueFilterSetListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/issue/cli/cmd/SSCIssueFilterSetListCommand.java
@@ -14,6 +14,7 @@ package com.fortify.cli.ssc.issue.cli.cmd;
 
 import com.fortify.cli.common.cli.util.CommandGroup;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
+import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCBaseRequestOutputCommand;
 import com.fortify.cli.ssc._common.rest.ssc.SSCUrls;
 import com.fortify.cli.ssc.appversion.cli.mixin.SSCAppVersionResolverMixin;
@@ -27,6 +28,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = "list-filtersets", aliases = {"lsfs"}) @CommandGroup("filter-set")
 public class SSCIssueFilterSetListCommand extends AbstractSSCBaseRequestOutputCommand {
     @Getter @Mixin private OutputHelperMixins.TableWithQuery outputHelper; 
+    @Mixin private SSCFetchRangeMixin fetchRangeMixin;
     @Mixin private SSCAppVersionResolverMixin.RequiredOption parentResolver;
     
     @Override

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/issue/cli/cmd/SSCIssueListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/issue/cli/cmd/SSCIssueListCommand.java
@@ -23,6 +23,7 @@ import com.fortify.cli.common.json.producer.ObjectNodeProducerApplyFrom;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamGeneratorSupplier;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamValueGenerator;
+import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCOutputCommand;
 import com.fortify.cli.ssc._common.rest.ssc.query.SSCQParamGenerator;
 import com.fortify.cli.ssc._common.rest.ssc.query.SSCQParamValueGenerators;
@@ -45,6 +46,7 @@ import picocli.CommandLine.Option;
 @Command(name = OutputHelperMixins.List.CMD_NAME)
 public class SSCIssueListCommand extends AbstractSSCOutputCommand implements IServerSideQueryParamGeneratorSupplier {
     @Getter @Mixin private OutputHelperMixins.List outputHelper; 
+    @Mixin private SSCFetchRangeMixin fetchRangeMixin;
     @Mixin private SSCAppVersionResolverMixin.RequiredOption parentResolver;
     @Mixin private SSCIssueFilterSetResolverMixin.FilterSetOption filterSetResolver;
     @Mixin private SSCQParamMixin qParamMixin;
@@ -70,7 +72,7 @@ public class SSCIssueListCommand extends AbstractSSCOutputCommand implements ISe
     }
     
     public HttpRequest<?> getBaseRequest(UnirestInstance unirest, String appVersionId, SSCIssueFilterSetDescriptor filterSetDescriptor) {
-        GetRequest request = unirest.get("/api/v1/projectVersions/{id}/issues?limit=100&qm=issues")
+        GetRequest request = unirest.get("/api/v1/projectVersions/{id}/issues?qm=issues")
                 .routeParam("id", appVersionId);
         if ( filterSetDescriptor!=null ) {
             request.queryString("filterset", filterSetDescriptor.getGuid());

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/issue_template/cli/cmd/AbstractSSCIssueTemplateListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/issue_template/cli/cmd/AbstractSSCIssueTemplateListCommand.java
@@ -14,6 +14,7 @@ package com.fortify.cli.ssc.issue_template.cli.cmd;
 
 import com.fortify.cli.common.rest.query.IServerSideQueryParamGeneratorSupplier;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamValueGenerator;
+import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCBaseRequestOutputCommand;
 import com.fortify.cli.ssc._common.rest.ssc.SSCUrls;
 import com.fortify.cli.ssc._common.rest.ssc.query.SSCQParamGenerator;
@@ -25,6 +26,7 @@ import kong.unirest.UnirestInstance;
 import picocli.CommandLine.Mixin;
 
 public abstract class AbstractSSCIssueTemplateListCommand extends AbstractSSCBaseRequestOutputCommand implements IServerSideQueryParamGeneratorSupplier {
+    @Mixin private SSCFetchRangeMixin fetchRangeMixin;
     @Mixin protected SSCQParamMixin qParamMixin;
     protected IServerSideQueryParamValueGenerator serverSideQueryParamGenerator = new SSCQParamGenerator()
                 .add("id", SSCQParamValueGenerators::plain)

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/performance_indicator/cli/cmd/SSCPerformanceIndicatorDefinitionListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/performance_indicator/cli/cmd/SSCPerformanceIndicatorDefinitionListCommand.java
@@ -14,6 +14,7 @@ package com.fortify.cli.ssc.performance_indicator.cli.cmd;
 
 import com.fortify.cli.common.cli.util.CommandGroup;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
+import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCBaseRequestOutputCommand;
 import com.fortify.cli.ssc._common.rest.ssc.SSCUrls;
 
@@ -26,6 +27,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = OutputHelperMixins.ListDefinitions.CMD_NAME) @CommandGroup("definition")
 public class SSCPerformanceIndicatorDefinitionListCommand extends AbstractSSCBaseRequestOutputCommand {
     @Getter @Mixin private OutputHelperMixins.ListDefinitions outputHelper; 
+    @Mixin private SSCFetchRangeMixin fetchRangeMixin;
     
     @Override
     public HttpRequest<?> getBaseRequest(UnirestInstance unirest) {

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/performance_indicator/cli/cmd/SSCPerformanceIndicatorListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/performance_indicator/cli/cmd/SSCPerformanceIndicatorListCommand.java
@@ -15,6 +15,7 @@ package com.fortify.cli.ssc.performance_indicator.cli.cmd;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.output.transform.IRecordTransformer;
+import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCBaseRequestOutputCommand;
 import com.fortify.cli.ssc._common.rest.ssc.SSCUrls;
 import com.fortify.cli.ssc.appversion.cli.mixin.SSCAppVersionResolverMixin;
@@ -29,6 +30,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = OutputHelperMixins.List.CMD_NAME)
 public class SSCPerformanceIndicatorListCommand extends AbstractSSCBaseRequestOutputCommand implements IRecordTransformer {
     @Getter @Mixin private OutputHelperMixins.List outputHelper; 
+    @Mixin private SSCFetchRangeMixin fetchRangeMixin;
     @Mixin private SSCAppVersionResolverMixin.RequiredOption parentResolver;
     
     @Override

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/plugin/cli/cmd/SSCPluginListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/plugin/cli/cmd/SSCPluginListCommand.java
@@ -14,6 +14,7 @@ package com.fortify.cli.ssc.plugin.cli.cmd;
 
 import com.fortify.cli.common.mcp.MCPInclude;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
+import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCBaseRequestOutputCommand;
 
 import kong.unirest.HttpRequest;
@@ -26,11 +27,12 @@ import picocli.CommandLine.Mixin;
 @Command(name = OutputHelperMixins.List.CMD_NAME)
 public class SSCPluginListCommand extends AbstractSSCBaseRequestOutputCommand  {
     @Getter @Mixin private OutputHelperMixins.List outputHelper; 
+    @Mixin private SSCFetchRangeMixin fetchRangeMixin;
     // TODO Can we do any server-side filtering?
 
     @Override
     public HttpRequest<?> getBaseRequest(UnirestInstance unirest) {
-        return unirest.get("/api/v1/plugins?orderBy=pluginType,pluginName,pluginVersion&limit=100");
+        return unirest.get("/api/v1/plugins?orderBy=pluginType,pluginName,pluginVersion");
     }
     
     @Override

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/report/cli/cmd/SSCReportListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/report/cli/cmd/SSCReportListCommand.java
@@ -17,6 +17,7 @@ import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.output.transform.IRecordTransformer;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamGeneratorSupplier;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamValueGenerator;
+import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCBaseRequestOutputCommand;
 import com.fortify.cli.ssc._common.rest.ssc.SSCUrls;
 import com.fortify.cli.ssc._common.rest.ssc.query.SSCQParamGenerator;
@@ -33,6 +34,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = OutputHelperMixins.List.CMD_NAME)
 public class SSCReportListCommand extends AbstractSSCBaseRequestOutputCommand implements IRecordTransformer, IServerSideQueryParamGeneratorSupplier {
     @Getter @Mixin private OutputHelperMixins.List outputHelper; 
+    @Mixin private SSCFetchRangeMixin fetchRangeMixin;
     @Mixin private SSCQParamMixin qParamMixin;
     @Getter private IServerSideQueryParamValueGenerator serverSideQueryParamGenerator = new SSCQParamGenerator()
             .add("id", SSCQParamValueGenerators::plain)

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/report/cli/cmd/SSCReportTemplateListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/report/cli/cmd/SSCReportTemplateListCommand.java
@@ -14,6 +14,7 @@ package com.fortify.cli.ssc.report.cli.cmd;
 
 import com.fortify.cli.common.cli.util.CommandGroup;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
+import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCBaseRequestOutputCommand;
 import com.fortify.cli.ssc._common.rest.ssc.SSCUrls;
 
@@ -26,6 +27,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = OutputHelperMixins.ListTemplates.CMD_NAME) @CommandGroup("template")
 public class SSCReportTemplateListCommand extends AbstractSSCBaseRequestOutputCommand  {
     @Getter @Mixin private OutputHelperMixins.ListTemplates outputHelper; 
+    @Mixin private SSCFetchRangeMixin fetchRangeMixin;
     // TODO Can we do any server-side filtering?
     
     @Override

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/system_state/cli/cmd/SSCStateActivitiesListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/system_state/cli/cmd/SSCStateActivitiesListCommand.java
@@ -19,6 +19,7 @@ import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.output.transform.IRecordTransformer;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamGeneratorSupplier;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamValueGenerator;
+import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCBaseRequestOutputCommand;
 import com.fortify.cli.ssc._common.rest.ssc.SSCUrls;
 import com.fortify.cli.ssc._common.rest.ssc.query.SSCQParamGenerator;
@@ -34,6 +35,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = "list-activities", aliases = {"lsa"}) @CommandGroup("activity")
 public class SSCStateActivitiesListCommand extends AbstractSSCBaseRequestOutputCommand implements IRecordTransformer, IServerSideQueryParamGeneratorSupplier {
     @Getter @Mixin private OutputHelperMixins.TableWithQuery outputHelper; 
+    @Mixin private SSCFetchRangeMixin fetchRangeMixin;
     @Mixin private SSCQParamMixin qParamMixin;
     @Getter private IServerSideQueryParamValueGenerator serverSideQueryParamGenerator = new SSCQParamGenerator()
             .add("userName", SSCQParamValueGenerators::wrapInQuotes)

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/system_state/cli/cmd/SSCStateEventListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/system_state/cli/cmd/SSCStateEventListCommand.java
@@ -19,6 +19,7 @@ import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.output.transform.IRecordTransformer;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamGeneratorSupplier;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamValueGenerator;
+import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCBaseRequestOutputCommand;
 import com.fortify.cli.ssc._common.rest.ssc.query.SSCQParamGenerator;
 import com.fortify.cli.ssc._common.rest.ssc.query.SSCQParamValueGenerators;
@@ -33,6 +34,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = "list-events", aliases = {"lse"}) @CommandGroup("event")
 public class SSCStateEventListCommand extends AbstractSSCBaseRequestOutputCommand implements IRecordTransformer, IServerSideQueryParamGeneratorSupplier {
     @Getter @Mixin private OutputHelperMixins.TableWithQuery outputHelper; 
+    @Mixin private SSCFetchRangeMixin fetchRangeMixin;
     @Mixin private SSCQParamMixin qParamMixin;
     @Getter private IServerSideQueryParamValueGenerator serverSideQueryParamGenerator = new SSCQParamGenerator()
                 .add("userName", SSCQParamValueGenerators::wrapInQuotes)
@@ -48,7 +50,7 @@ public class SSCStateEventListCommand extends AbstractSSCBaseRequestOutputComman
     
     @Override
     public HttpRequest<?> getBaseRequest(UnirestInstance unirest) {
-        return unirest.get("/api/v1/events?limit=100");
+        return unirest.get("/api/v1/events");
     }
     
     @Override

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/system_state/cli/cmd/SSCStateJobListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/system_state/cli/cmd/SSCStateJobListCommand.java
@@ -16,6 +16,7 @@ import com.fortify.cli.common.cli.util.CommandGroup;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamGeneratorSupplier;
 import com.fortify.cli.common.rest.query.IServerSideQueryParamValueGenerator;
+import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCBaseRequestOutputCommand;
 import com.fortify.cli.ssc._common.rest.ssc.SSCUrls;
 import com.fortify.cli.ssc._common.rest.ssc.query.SSCQParamGenerator;
@@ -31,6 +32,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = "list-jobs", aliases = {"lsj"}) @CommandGroup("job")
 public class SSCStateJobListCommand extends AbstractSSCBaseRequestOutputCommand implements IServerSideQueryParamGeneratorSupplier {
     @Getter @Mixin private OutputHelperMixins.TableWithQuery outputHelper; 
+    @Mixin private SSCFetchRangeMixin fetchRangeMixin;
     @Mixin private SSCQParamMixin qParamMixin;
     @Getter private IServerSideQueryParamValueGenerator serverSideQueryParamGenerator = new SSCQParamGenerator()
                 .add("jobClass", SSCQParamValueGenerators::wrapInQuotes)

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/system_state/cli/cmd/SSCStateRulepackListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/system_state/cli/cmd/SSCStateRulepackListCommand.java
@@ -14,6 +14,7 @@ package com.fortify.cli.ssc.system_state.cli.cmd;
 
 import com.fortify.cli.common.cli.util.CommandGroup;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
+import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCBaseRequestOutputCommand;
 
 import kong.unirest.HttpRequest;
@@ -25,6 +26,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = "list-rulepacks", aliases = {"lsr"}) @CommandGroup("rulepack")
 public class SSCStateRulepackListCommand extends AbstractSSCBaseRequestOutputCommand {
     @Getter @Mixin private OutputHelperMixins.TableWithQuery outputHelper; 
+    @Mixin private SSCFetchRangeMixin fetchRangeMixin;
     
     @Override
     public HttpRequest<?> getBaseRequest(UnirestInstance unirest) {

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/variable/cli/cmd/SSCVariableDefinitionListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/variable/cli/cmd/SSCVariableDefinitionListCommand.java
@@ -14,6 +14,7 @@ package com.fortify.cli.ssc.variable.cli.cmd;
 
 import com.fortify.cli.common.cli.util.CommandGroup;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
+import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCBaseRequestOutputCommand;
 import com.fortify.cli.ssc._common.rest.ssc.SSCUrls;
 
@@ -26,6 +27,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = OutputHelperMixins.ListDefinitions.CMD_NAME) @CommandGroup("definition")
 public class SSCVariableDefinitionListCommand extends AbstractSSCBaseRequestOutputCommand {
     @Getter @Mixin private OutputHelperMixins.ListDefinitions outputHelper; 
+    @Mixin private SSCFetchRangeMixin fetchRangeMixin;
     
     @Override
     public HttpRequest<?> getBaseRequest(UnirestInstance unirest) {

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/variable/cli/cmd/SSCVariableListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/variable/cli/cmd/SSCVariableListCommand.java
@@ -13,6 +13,7 @@
 package com.fortify.cli.ssc.variable.cli.cmd;
 
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
+import com.fortify.cli.ssc._common.cli.mixin.SSCFetchRangeMixin;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCBaseRequestOutputCommand;
 import com.fortify.cli.ssc._common.rest.ssc.SSCUrls;
 import com.fortify.cli.ssc.appversion.cli.mixin.SSCAppVersionResolverMixin;
@@ -26,6 +27,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = OutputHelperMixins.List.CMD_NAME)
 public class SSCVariableListCommand extends AbstractSSCBaseRequestOutputCommand {
     @Getter @Mixin private OutputHelperMixins.List outputHelper; 
+    @Mixin private SSCFetchRangeMixin fetchRangeMixin;
     @Mixin private SSCAppVersionResolverMixin.RequiredOption parentResolver;
     
     @Override

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ fcliMainClassName=com.fortify.cli.app.FortifyCLI
 # given schema version, it is very important to maintain this correctly. At all cost,
 # we should avoid for example updating only patch version if there are any structural
 # changes. 
-fcliActionSchemaVersion=2.7.0
+fcliActionSchemaVersion=2.8.0
 
 org.gradle.parallel=true
 # Ensure JDK IO subsystem is opened for all Gradle daemon JVM processes (suppresses native subprocess control warning)


### PR DESCRIPTION
```
feat: `fcli fod * list`: Add `--fetch` option on most `list` commands to fetch subset of records from FoD

feat: `fcli ssc * list`: Add `--fetch` option on most `list` commands to fetch subset of records from SSC

feat: `fcli sc-sast * list`: Add `--fetch` option on some `list` commands that utilize SSC REST endpoints to fetch subset of records from SSC

feat: `fcli sc-dast * list`: Add `--fetch` option on most `list` commands to fetch subset of records from ScanCentral DAST

feat: fcli `--style` option: Add `[no-]envelope` style for various output formats like JSON and YAML to allow for outputting paging and potentially other metadata

feat: fcli action framework: Emit `<key>.metadata` variable on `run.fcli` instructions to allow actions to access paging and potentially other metadata produced by the fcli command
```