### PR TITLE
fix: `fod dast-scan get-config` NPE when DAST Automated scan has not been configured

### DIFF
--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/cli/cmd/AbstractFoDScanConfigGetCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/cli/cmd/AbstractFoDScanConfigGetCommand.java
@@ -14,6 +14,7 @@ package com.fortify.cli.fod._common.scan.cli.cmd;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fortify.cli.common.cli.util.CommandGroup;
+import com.fortify.cli.common.exception.FcliSimpleException;
 import com.fortify.cli.common.json.JsonNodeHolder;
 import com.fortify.cli.common.util.DisableTest;
 import com.fortify.cli.common.util.DisableTest.TestType;
@@ -32,7 +33,11 @@ public abstract class AbstractFoDScanConfigGetCommand extends AbstractFoDJsonNod
     @Override
     public final JsonNode getJsonNode(UnirestInstance unirest) {
         var releaseId = releaseResolver.getReleaseId(unirest);
-        var result = getDescriptor(unirest, releaseId).asObjectNode();
+        var descriptor = getDescriptor(unirest, releaseId);
+        if ( descriptor==null ) {
+            throw new FcliSimpleException("Release does not have any saved scan settings");
+        }
+        var result = descriptor.asObjectNode();
         return result.get("assessmentTypeId").asText().equals("0")
                 ? result.put("state", "Not configured")
                 : result.put("state", "Configured");

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/cli/cmd/AbstractFoDScanConfigGetCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/cli/cmd/AbstractFoDScanConfigGetCommand.java
@@ -13,8 +13,8 @@
 package com.fortify.cli.fod._common.scan.cli.cmd;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fortify.cli.common.cli.util.CommandGroup;
-import com.fortify.cli.common.exception.FcliSimpleException;
 import com.fortify.cli.common.json.JsonNodeHolder;
 import com.fortify.cli.common.util.DisableTest;
 import com.fortify.cli.common.util.DisableTest.TestType;
@@ -34,11 +34,10 @@ public abstract class AbstractFoDScanConfigGetCommand extends AbstractFoDJsonNod
     public final JsonNode getJsonNode(UnirestInstance unirest) {
         var releaseId = releaseResolver.getReleaseId(unirest);
         var descriptor = getDescriptor(unirest, releaseId);
-        if ( descriptor==null ) {
-            throw new FcliSimpleException("Release does not have any saved scan settings");
-        }
-        var result = descriptor.asObjectNode();
-        return result.get("assessmentTypeId").asText().equals("0")
+        var result = descriptor == null
+                ? JsonNodeFactory.instance.objectNode().put("assessmentTypeId", 0)
+                : descriptor.asObjectNode();
+        return result.path("assessmentTypeId").asInt(0) == 0
                 ? result.put("state", "Not configured")
                 : result.put("state", "Configured");
     }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/FoDScanHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/FoDScanHelper.java
@@ -29,7 +29,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fortify.cli.common.exception.FcliSimpleException;
 import com.fortify.cli.common.json.JsonHelper;
 import com.fortify.cli.common.json.transform.fields.RenameFieldsTransformer;
-import com.fortify.cli.common.rest.unirest.UnexpectedHttpResponseException;
 import com.fortify.cli.fod._common.rest.FoDUrls;
 import com.fortify.cli.fod._common.scan.helper.dast.FoDScanDastAutomatedHelper;
 import com.fortify.cli.fod._common.util.FoDEnums;
@@ -135,13 +134,7 @@ public class FoDScanHelper {
     public static FoDScanAssessmentTypeDescriptor getEntitlementToUse(UnirestInstance unirest, String relId, FoDScanType scanType,
                                                                     String assessmentType, FoDEnums.EntitlementFrequencyType entitlementFrequencyType,
                                                                     int entitlementId) {
-        FoDScanConfigDastAutomatedDescriptor currentSetup = null;
-        try {
-            currentSetup = FoDScanDastAutomatedHelper.getSetupDescriptor(unirest, relId);
-        } catch (UnexpectedHttpResponseException ex) {
-            // we have no current setup;
-            LOG.info("Unable to find current setup: " + ex);
-        }
+        FoDScanConfigDastAutomatedDescriptor currentSetup = FoDScanDastAutomatedHelper.getSetupDescriptor(unirest, relId);
         Integer entitlementIdToUse = 0;
         Integer assessmentTypeId = 0;
         LOG.info("Finding/Validating entitlement to use.");

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/dast/FoDScanDastAutomatedHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/dast/FoDScanDastAutomatedHelper.java
@@ -51,7 +51,7 @@ public class FoDScanDastAutomatedHelper extends FoDScanHelper {
             if (e.getStatus() == 400) {
                 // use the internal FoD "errorCode" to determine if any settings have been defined
                 if (e.getMessage().contains("errorCode: 6000")) {
-                    throw new FcliSimpleException("Release does not have any saved scan settings");
+                    return null;
                 }
                 throw new FcliSimpleException("Bad request. Error: " + e.getMessage());
             }
@@ -86,7 +86,7 @@ public class FoDScanDastAutomatedHelper extends FoDScanHelper {
             for (JsonNode node : itemsNode) {
                 if (!"Dynamic".equals(node.path("scanType").asText())) continue;
                 String status = node.path("analysisStatusType").asText();
-                
+
                 if (isActiveStatus(status)) {
                     foundActive = true;
                     FoDScanDescriptor result = handleActiveScan(

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/dast/FoDScanDastAutomatedHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/dast/FoDScanDastAutomatedHelper.java
@@ -51,7 +51,7 @@ public class FoDScanDastAutomatedHelper extends FoDScanHelper {
             if (e.getStatus() == 400) {
                 // use the internal FoD "errorCode" to determine if any settings have been defined
                 if (e.getMessage().contains("errorCode: 6000")) {
-                    return null;
+                    throw new FcliSimpleException("Release does not have any saved scan settings");
                 }
                 throw new FcliSimpleException("Bad request. Error: " + e.getMessage());
             }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/helper/FoDScanConfigDastAutomatedHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/dast_scan/helper/FoDScanConfigDastAutomatedHelper.java
@@ -13,11 +13,17 @@
 package com.fortify.cli.fod.dast_scan.helper;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.springframework.beans.BeanUtils;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fortify.cli.common.exception.FcliSimpleException;
 import com.fortify.cli.common.json.JsonHelper;
+import com.fortify.cli.common.rest.unirest.UnexpectedHttpResponseException;
 import com.fortify.cli.fod._common.rest.FoDUrls;
 import com.fortify.cli.fod._common.scan.helper.dast.FoDScanDastAutomatedSetupBaseRequest;
 import com.fortify.cli.fod._common.scan.helper.dast.FoDScanDastAutomatedSetupGraphQlRequest;
@@ -27,10 +33,15 @@ import com.fortify.cli.fod._common.scan.helper.dast.FoDScanDastAutomatedSetupPos
 import com.fortify.cli.fod._common.util.FoDEnums;
 import com.fortify.cli.fod.release.helper.FoDReleaseDescriptor;
 
+import kong.unirest.UnirestException;
 import kong.unirest.UnirestInstance;
 import lombok.SneakyThrows;
 
 public class FoDScanConfigDastAutomatedHelper {
+    private static final Pattern LOCKED_SETUP_FIELD_PATTERN = Pattern.compile(
+            "cannot override current scan settings:\\s*([^\"\\n-]+)",
+            Pattern.CASE_INSENSITIVE);
+
     public static FoDScanConfigDastAutomatedDescriptor getSetupDescriptor(UnirestInstance unirest, String releaseId) {
         var body = unirest.get(FoDUrls.DAST_AUTOMATED_SCANS + "/scan-setup")
                 .routeParam("relId", releaseId)
@@ -43,11 +54,39 @@ public class FoDScanConfigDastAutomatedHelper {
                                                                     FoDReleaseDescriptor releaseDescriptor,
                                                                     T setupDastAutomatedScanRequest, String ep) {
         var releaseId = releaseDescriptor.getReleaseId();
-        unirest.put(FoDUrls.DAST_AUTOMATED_SCANS + ep)
-                .routeParam("relId", releaseId)
-                .body(setupDastAutomatedScanRequest)
-                .asString().getBody();
+        try {
+            unirest.put(FoDUrls.DAST_AUTOMATED_SCANS + ep)
+                    .routeParam("relId", releaseId)
+                    .body(setupDastAutomatedScanRequest)
+                    .asString().getBody();
+        } catch (UnexpectedHttpResponseException e) {
+            throw toSetupException(e, releaseId);
+        } catch (UnirestException e) {
+            throw new FcliSimpleException(
+                    String.format("Error configuring DAST Automated scan setup for release id '%s'", releaseId),
+                    e);
+        }
         return getSetupDescriptor(unirest, releaseId);
+    }
+
+    private static RuntimeException toSetupException(UnexpectedHttpResponseException e, String releaseId) {
+        if (e.getStatus() == 400 && e.getMessage().toLowerCase().contains("cannot override current scan settings")) {
+            var lockedSettings = extractLockedSettings(e.getMessage());
+            var lockedSettingsSuffix = lockedSettings.isBlank() ? "" : " Locked settings include: " + lockedSettings;
+            return new FcliSimpleException(
+                    "Cannot update DAST Automated scan setup for release id '%s' because scan settings are locked after scans have started.%s",
+                    releaseId, lockedSettingsSuffix);
+        }
+        return new FcliSimpleException("Error configuring DAST Automated scan setup for release id '%s': %s", releaseId, e.getMessage());
+    }
+
+    private static String extractLockedSettings(String message) {
+        Set<String> lockedSettings = new LinkedHashSet<>();
+        Matcher matcher = LOCKED_SETUP_FIELD_PATTERN.matcher(message);
+        while (matcher.find()) {
+            lockedSettings.add(matcher.group(1).trim());
+        }
+        return String.join(", ", lockedSettings);
     }
 
     @SneakyThrows


### PR DESCRIPTION
Updated `fod dast-scan get-config` to catch "unconfigured" DAST Automated configuration for release and prevent NPE. For consistency with other `get-config` commands now returns an empty descriptor:
```
---
assessmentTypeId: 0
state: Not configured
```
This is consistent with other scan behaviour.

Updated `fod dast-scan setup-xxx` to catch similar HTTP 400 exceptions and display information about why and what fields are locked. Note: currently API does not correctly identify all fields that are locked but the messaging is now more consistent, e.g.:
```
>fcli fod dast-scan setup-api --assessment-type="DAST Automated" --frequency="Subscription" --type="Postman"  --release 188331 --file my_postman_collection.json
FcliSimpleException: Cannot update DAST Automated scan setup for release id '188331' because scan settings are locked after scans have started. Locked settings: EnvironmentFacing Internal
        at com.fortify.cli.fod.dast_scan.helper.FoDScanConfigDastAutomatedHelper.toSetupException(FoDScanConfigDastAutomatedHelper.java:76)
```
These behaviours should also make the commands more suitable for use in AI Agents, MCP and/or skills.