### PR TITLE
feat: add --auto-required-attrs support to app update and release update commands

### DIFF
--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/app/cli/cmd/FoDAppUpdateCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/app/cli/cmd/FoDAppUpdateCommand.java
@@ -15,12 +15,15 @@ package com.fortify.cli.fod.app.cli.cmd;
 import static com.fortify.cli.common.util.DisableTest.TestType.MULTI_OPT_PLURAL_NAME;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fortify.cli.common.cli.mixin.CommonOptionMixins;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.output.transform.IActionCommandResultSupplier;
 import com.fortify.cli.common.output.transform.IRecordTransformer;
@@ -46,7 +49,7 @@ import picocli.CommandLine.Option;
 public class FoDAppUpdateCommand extends AbstractFoDJsonNodeOutputCommand implements IRecordTransformer, IActionCommandResultSupplier {
     @Getter @Mixin private OutputHelperMixins.Update outputHelper;
     @Mixin private FoDAppResolverMixin.PositionalParameter appResolver;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    @Mixin private CommonOptionMixins.AutoRequiredAttrsOption autoRequiredAttrsOption;
 
     @Option(names = {"--name", "-n"})
     private String applicationNameUpdate;
@@ -68,10 +71,24 @@ public class FoDAppUpdateCommand extends AbstractFoDJsonNodeOutputCommand implem
         // new values to replace
         FoDCriticalityTypeOptions.FoDCriticalityType appCriticalityNew = criticalityTypeUpdate.getCriticalityType();
         Map<String, String> attributeUpdates = appAttrsUpdate.getAttributes();
-        JsonNode jsonAttrs = objectMapper.createArrayNode();
-        if (attributeUpdates != null && !attributeUpdates.isEmpty()) {
-            jsonAttrs = FoDAttributeHelper.mergeAttributesNode(unirest, FoDEnums.AttributeTypes.Application, appAttrsCurrent, 
-                attributeUpdates);
+        boolean autoReqdAttrs = autoRequiredAttrsOption.isAutoRequiredAttrs();
+        JsonNode jsonAttrs;
+        if (autoReqdAttrs || (attributeUpdates != null && !attributeUpdates.isEmpty())) {
+            Map<String, String> combinedUpdates = new LinkedHashMap<>();
+            if (autoReqdAttrs) {
+                Set<String> currentAttrNamesWithValues = appAttrsCurrent.stream()
+                        .filter(a -> StringUtils.isNotBlank(a.getValue()))
+                        .map(FoDAttributeDescriptor::getName)
+                        .collect(Collectors.toSet());
+                FoDAttributeHelper.getRequiredAttributesDefaultValues(unirest, FoDEnums.AttributeTypes.Application)
+                        .forEach((k, v) -> { if (!currentAttrNamesWithValues.contains(k)) combinedUpdates.put(k, v); });
+            }
+            if (attributeUpdates != null) {
+                combinedUpdates.putAll(attributeUpdates);
+            }
+            jsonAttrs = combinedUpdates.isEmpty()
+                    ? FoDAttributeHelper.getAttributesNode(FoDEnums.AttributeTypes.Application, appAttrsCurrent)
+                    : FoDAttributeHelper.mergeAttributesNode(unirest, FoDEnums.AttributeTypes.Application, appAttrsCurrent, combinedUpdates);
         } else {
             jsonAttrs = FoDAttributeHelper.getAttributesNode(FoDEnums.AttributeTypes.Application, appAttrsCurrent);
         }

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/app/cli/cmd/FoDAppUpdateCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/app/cli/cmd/FoDAppUpdateCommand.java
@@ -15,10 +15,6 @@ package com.fortify.cli.fod.app.cli.cmd;
 import static com.fortify.cli.common.util.DisableTest.TestType.MULTI_OPT_PLURAL_NAME;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -36,7 +32,6 @@ import com.fortify.cli.fod.app.helper.FoDAppDescriptor;
 import com.fortify.cli.fod.app.helper.FoDAppHelper;
 import com.fortify.cli.fod.app.helper.FoDAppUpdateRequest;
 import com.fortify.cli.fod.attribute.cli.mixin.FoDAttributeUpdateOptions;
-import com.fortify.cli.fod.attribute.helper.FoDAttributeDescriptor;
 import com.fortify.cli.fod.attribute.helper.FoDAttributeHelper;
 
 import kong.unirest.UnirestInstance;
@@ -63,35 +58,10 @@ public class FoDAppUpdateCommand extends AbstractFoDJsonNodeOutputCommand implem
 
     @Override
     public JsonNode getJsonNode(UnirestInstance unirest) {
-
-        // current values of app being updated
         FoDAppDescriptor appDescriptor = FoDAppHelper.getAppDescriptor(unirest, appResolver.getAppNameOrId(), true);
-        ArrayList<FoDAttributeDescriptor> appAttrsCurrent = appDescriptor.getAttributes();
-
-        // new values to replace
         FoDCriticalityTypeOptions.FoDCriticalityType appCriticalityNew = criticalityTypeUpdate.getCriticalityType();
-        Map<String, String> attributeUpdates = appAttrsUpdate.getAttributes();
-        boolean autoReqdAttrs = autoRequiredAttrsOption.isAutoRequiredAttrs();
-        JsonNode jsonAttrs;
-        if (autoReqdAttrs || (attributeUpdates != null && !attributeUpdates.isEmpty())) {
-            Map<String, String> combinedUpdates = new LinkedHashMap<>();
-            if (autoReqdAttrs) {
-                Set<String> currentAttrNamesWithValues = appAttrsCurrent.stream()
-                        .filter(a -> StringUtils.isNotBlank(a.getValue()))
-                        .map(FoDAttributeDescriptor::getName)
-                        .collect(Collectors.toSet());
-                FoDAttributeHelper.getRequiredAttributesDefaultValues(unirest, FoDEnums.AttributeTypes.Application)
-                        .forEach((k, v) -> { if (!currentAttrNamesWithValues.contains(k)) combinedUpdates.put(k, v); });
-            }
-            if (attributeUpdates != null) {
-                combinedUpdates.putAll(attributeUpdates);
-            }
-            jsonAttrs = combinedUpdates.isEmpty()
-                    ? FoDAttributeHelper.getAttributesNode(FoDEnums.AttributeTypes.Application, appAttrsCurrent)
-                    : FoDAttributeHelper.mergeAttributesNode(unirest, FoDEnums.AttributeTypes.Application, appAttrsCurrent, combinedUpdates);
-        } else {
-            jsonAttrs = FoDAttributeHelper.getAttributesNode(FoDEnums.AttributeTypes.Application, appAttrsCurrent);
-        }
+        JsonNode jsonAttrs = FoDAttributeHelper.getAttributesNodeForUpdate(unirest, FoDEnums.AttributeTypes.Application,
+                appDescriptor.getAttributes(), appAttrsUpdate.getAttributes(), autoRequiredAttrsOption.isAutoRequiredAttrs());
         String appEmailListNew = FoDAppHelper.getEmailList(notificationsUpdate);
 
         FoDAppUpdateRequest appUpdateRequest = FoDAppUpdateRequest.builder()

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/attribute/helper/FoDAttributeHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/attribute/helper/FoDAttributeHelper.java
@@ -131,18 +131,16 @@ public class FoDAttributeHelper {
         return attrArray;
     }
 
-    public static JsonNode getAttributesNode(UnirestInstance unirest, FoDEnums.AttributeTypes attrType, 
-        Map<String, String> attributesMap, boolean autoReqdAttributes) {
-        Map<String, String> combinedAttributesMap = new LinkedHashMap<>();
-        if (autoReqdAttributes) {
-            // find any required attributes
-            combinedAttributesMap.putAll(getRequiredAttributesDefaultValues(unirest, attrType));
-        }
-        if ( attributesMap!=null && !attributesMap.isEmpty() ) {
-            combinedAttributesMap.putAll(attributesMap);
-        }
+    /**
+     * For create commands: amends user-provided attribute values with server-side defaults
+     * for any required attributes not already specified by the user.
+     * Resolves attribute names to IDs and filters by attrType.
+     */
+    public static JsonNode getAttributesNode(UnirestInstance unirest, FoDEnums.AttributeTypes attrType,
+            Map<String, String> attributesMap, boolean autoReqdAttributes) {
+        var effectiveMap = buildEffectiveAttributeUpdates(unirest, attrType, null, attributesMap, autoReqdAttributes);
         ArrayNode attrArray = JsonHelper.getObjectMapper().createArrayNode();
-        for (Map.Entry<String, String> attr : combinedAttributesMap.entrySet()) {
+        for (Map.Entry<String, String> attr : effectiveMap.entrySet()) {
             ObjectNode attrObj = getObjectMapper().createObjectNode();
             FoDAttributeDescriptor attributeDescriptor = FoDAttributeHelper.getAttributeDescriptor(unirest, attr.getKey(), true);
             // filter out any attributes that aren't valid for the entity we are working on, e.g. Application or Release
@@ -152,10 +150,54 @@ public class FoDAttributeHelper {
                 attrArray.add(attrObj);
             } else {
                 LOG.debug("Skipping attribute '"+attributeDescriptor.getName()+"' as it is not a "+attrType.toString()+" attribute");
-
-            }   
+            }
         }
         return attrArray;
+    }
+
+    /**
+     * For update commands: merges user-supplied attribute values with the entity's existing
+     * attribute values, then amends with server-side defaults for any required attributes
+     * not already covered by either the current values or user-supplied updates.
+     */
+    public static JsonNode getAttributesNodeForUpdate(UnirestInstance unirest, FoDEnums.AttributeTypes attrType,
+            ArrayList<FoDAttributeDescriptor> currentAttributes, Map<String, String> userSuppliedUpdates,
+            boolean autoReqdAttributes) {
+        var effectiveUpdates = buildEffectiveAttributeUpdates(
+                unirest, attrType, currentAttributes, userSuppliedUpdates, autoReqdAttributes);
+        return effectiveUpdates.isEmpty()
+                ? getAttributesNode(attrType, currentAttributes)
+                : mergeAttributesNode(unirest, attrType, currentAttributes, effectiveUpdates);
+    }
+
+    /**
+     * Computes the effective attribute updates to apply. For required attributes not already
+     * covered by current entity values or user-supplied updates, server-side defaults are added.
+     * User-supplied updates always take highest priority.
+     * Pass {@code currentAttributes=null} for create scenarios.
+     */
+    private static Map<String, String> buildEffectiveAttributeUpdates(UnirestInstance unirest,
+            FoDEnums.AttributeTypes attrType, ArrayList<FoDAttributeDescriptor> currentAttributes,
+            Map<String, String> userSuppliedUpdates, boolean autoReqdAttributes) {
+        var effective = new LinkedHashMap<String, String>();
+        if (autoReqdAttributes) {
+            Set<String> covered = new HashSet<>();
+            if (currentAttributes != null) {
+                currentAttributes.stream()
+                        .filter(a -> StringUtils.isNotBlank(a.getValue()))
+                        .map(FoDAttributeDescriptor::getName)
+                        .forEach(covered::add);
+            }
+            if (userSuppliedUpdates != null) {
+                covered.addAll(userSuppliedUpdates.keySet());
+            }
+            getRequiredAttributesDefaultValues(unirest, attrType)
+                    .forEach((k, v) -> { if (!covered.contains(k)) effective.put(k, v); });
+        }
+        if (userSuppliedUpdates != null) {
+            effective.putAll(userSuppliedUpdates);
+        }
+        return effective;
     }
 
     public static FoDAttributeDescriptor createAttribute(UnirestInstance unirest, FoDAttributeCreateRequest request) {

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/release/cli/cmd/FoDReleaseUpdateCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/release/cli/cmd/FoDReleaseUpdateCommand.java
@@ -13,12 +13,15 @@
 package com.fortify.cli.fod.release.cli.cmd;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fortify.cli.common.cli.mixin.CommonOptionMixins;
 import com.fortify.cli.common.exception.FcliSimpleException;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.common.output.transform.IActionCommandResultSupplier;
@@ -45,9 +48,10 @@ import picocli.CommandLine.Option;
 @Command(name = OutputHelperMixins.Update.CMD_NAME)
 public class FoDReleaseUpdateCommand extends AbstractFoDJsonNodeOutputCommand implements IRecordTransformer, IActionCommandResultSupplier {
     @Getter @Mixin private OutputHelperMixins.Update outputHelper;
-    private final ObjectMapper objectMapper = new ObjectMapper();
     @Mixin private FoDDelimiterMixin delimiterMixin; // Is automatically injected in resolver mixins
     @Mixin private FoDReleaseByQualifiedNameOrIdResolverMixin.PositionalParameter releaseResolver;
+    @Mixin private CommonOptionMixins.AutoRequiredAttrsOption autoRequiredAttrsOption;
+
     @Option(names = {"--name", "-n"})
     private String releaseName;
 
@@ -59,7 +63,7 @@ public class FoDReleaseUpdateCommand extends AbstractFoDJsonNodeOutputCommand im
 
     @Mixin
     private FoDSdlcStatusTypeOptions.OptionalOption sdlcStatus;
-    @Mixin 
+    @Mixin
     private FoDAttributeUpdateOptions.OptionalAttrOption appAttrsUpdate;
 
     @Override
@@ -68,10 +72,25 @@ public class FoDReleaseUpdateCommand extends AbstractFoDJsonNodeOutputCommand im
         ArrayList<FoDAttributeDescriptor> releaseAttrsCurrent = releaseDescriptor.getAttributes();
         FoDSdlcStatusTypeOptions.FoDSdlcStatusType sdlcStatusTypeNew = sdlcStatus.getSdlcStatusType();
         Map<String, String> attributeUpdates = appAttrsUpdate.getAttributes();
-        JsonNode jsonAttrs = objectMapper.createArrayNode();
-        if (attributeUpdates != null && !attributeUpdates.isEmpty()) {
-            jsonAttrs = FoDAttributeHelper.mergeAttributesNode(unirest, FoDEnums.AttributeTypes.Release, 
-                releaseAttrsCurrent, attributeUpdates);
+        boolean autoReqdAttrs = autoRequiredAttrsOption.isAutoRequiredAttrs();
+        JsonNode jsonAttrs;
+        if (autoReqdAttrs || (attributeUpdates != null && !attributeUpdates.isEmpty())) {
+            Map<String, String> combinedUpdates = new LinkedHashMap<>();
+            if (autoReqdAttrs) {
+                Set<String> currentAttrNamesWithValues = releaseAttrsCurrent.stream()
+                        .filter(a -> StringUtils.isNotBlank(a.getValue()))
+                        .map(FoDAttributeDescriptor::getName)
+                        .collect(Collectors.toSet());
+                FoDAttributeHelper.getRequiredAttributesDefaultValues(unirest, FoDEnums.AttributeTypes.Release)
+                        .forEach((k, v) -> { if (!currentAttrNamesWithValues.contains(k)) combinedUpdates.put(k, v); });
+            }
+            if (attributeUpdates != null) {
+                combinedUpdates.putAll(attributeUpdates);
+            }
+            jsonAttrs = combinedUpdates.isEmpty()
+                    ? FoDAttributeHelper.getAttributesNode(FoDEnums.AttributeTypes.Release, releaseAttrsCurrent)
+                    : FoDAttributeHelper.mergeAttributesNode(unirest, FoDEnums.AttributeTypes.Release,
+                            releaseAttrsCurrent, combinedUpdates);
         } else {
             jsonAttrs = FoDAttributeHelper.getAttributesNode(FoDEnums.AttributeTypes.Release, releaseAttrsCurrent);
         }
@@ -85,7 +104,7 @@ public class FoDReleaseUpdateCommand extends AbstractFoDJsonNodeOutputCommand im
 
         return FoDReleaseHelper.updateRelease(unirest, releaseDescriptor.getReleaseId(), appRelUpdateRequest).asJsonNode();
     }
-    
+
     private String getUnqualifiedReleaseName(String potentialQualifiedName, FoDReleaseDescriptor descriptor) {
         if ( StringUtils.isBlank(potentialQualifiedName) ) { return null; }
         var delim = delimiterMixin.getDelimiter();

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/release/cli/cmd/FoDReleaseUpdateCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/release/cli/cmd/FoDReleaseUpdateCommand.java
@@ -12,12 +12,6 @@
  */
 package com.fortify.cli.fod.release.cli.cmd;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import org.apache.commons.lang3.StringUtils;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -31,7 +25,6 @@ import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDJsonNodeOutputComma
 import com.fortify.cli.fod._common.util.FoDEnums;
 import com.fortify.cli.fod.app.cli.mixin.FoDSdlcStatusTypeOptions;
 import com.fortify.cli.fod.attribute.cli.mixin.FoDAttributeUpdateOptions;
-import com.fortify.cli.fod.attribute.helper.FoDAttributeDescriptor;
 import com.fortify.cli.fod.attribute.helper.FoDAttributeHelper;
 import com.fortify.cli.fod.release.cli.mixin.FoDReleaseByQualifiedNameOrIdResolverMixin;
 import com.fortify.cli.fod.release.helper.FoDReleaseDescriptor;
@@ -69,31 +62,10 @@ public class FoDReleaseUpdateCommand extends AbstractFoDJsonNodeOutputCommand im
     @Override
     public JsonNode getJsonNode(UnirestInstance unirest) {
         FoDReleaseDescriptor releaseDescriptor = releaseResolver.getReleaseDescriptor(unirest);
-        ArrayList<FoDAttributeDescriptor> releaseAttrsCurrent = releaseDescriptor.getAttributes();
         FoDSdlcStatusTypeOptions.FoDSdlcStatusType sdlcStatusTypeNew = sdlcStatus.getSdlcStatusType();
-        Map<String, String> attributeUpdates = appAttrsUpdate.getAttributes();
-        boolean autoReqdAttrs = autoRequiredAttrsOption.isAutoRequiredAttrs();
-        JsonNode jsonAttrs;
-        if (autoReqdAttrs || (attributeUpdates != null && !attributeUpdates.isEmpty())) {
-            Map<String, String> combinedUpdates = new LinkedHashMap<>();
-            if (autoReqdAttrs) {
-                Set<String> currentAttrNamesWithValues = releaseAttrsCurrent.stream()
-                        .filter(a -> StringUtils.isNotBlank(a.getValue()))
-                        .map(FoDAttributeDescriptor::getName)
-                        .collect(Collectors.toSet());
-                FoDAttributeHelper.getRequiredAttributesDefaultValues(unirest, FoDEnums.AttributeTypes.Release)
-                        .forEach((k, v) -> { if (!currentAttrNamesWithValues.contains(k)) combinedUpdates.put(k, v); });
-            }
-            if (attributeUpdates != null) {
-                combinedUpdates.putAll(attributeUpdates);
-            }
-            jsonAttrs = combinedUpdates.isEmpty()
-                    ? FoDAttributeHelper.getAttributesNode(FoDEnums.AttributeTypes.Release, releaseAttrsCurrent)
-                    : FoDAttributeHelper.mergeAttributesNode(unirest, FoDEnums.AttributeTypes.Release,
-                            releaseAttrsCurrent, combinedUpdates);
-        } else {
-            jsonAttrs = FoDAttributeHelper.getAttributesNode(FoDEnums.AttributeTypes.Release, releaseAttrsCurrent);
-        }
+        JsonNode jsonAttrs = FoDAttributeHelper.getAttributesNodeForUpdate(unirest, FoDEnums.AttributeTypes.Release,
+                releaseDescriptor.getAttributes(), appAttrsUpdate.getAttributes(), autoRequiredAttrsOption.isAutoRequiredAttrs());
+
         FoDReleaseUpdateRequest appRelUpdateRequest = FoDReleaseUpdateRequest.builder()
                 .releaseName(StringUtils.isNotBlank(releaseName) ? getUnqualifiedReleaseName(releaseName, releaseDescriptor) : releaseDescriptor.getReleaseName())
                 .releaseDescription(StringUtils.isNotBlank(description) ? description : releaseDescriptor.getReleaseDescription())

--- a/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
+++ b/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
@@ -327,8 +327,6 @@ fcli.fod.app.update.attrs = Set of application attribute id's or names and their
   may be provided but will be ignored.
 fcli.fod.app.update.auto-required-attrs = For each mandatory application attribute that does not already \
   have a value, read the default value from the server and set it automatically.
-fcli.fod.app.update.auto-required-attrs = For each mandatory application attribute that does not already \
-  have a value, read the default value from the server and set it automatically.
 fcli.fod.app.list-scans.usage.header = List scans for a given application.
 
 # fcli fod microservice
@@ -412,8 +410,6 @@ fcli.fod.release.update.status = SDLC lifecycle status of the release. Valid val
 fcli.fod.release.update.attrs = Set of release attribute id's or names and their values to set on the release. \
   Please note for user attributes only the userId is currently supported. Application attributes may be provided \
   but will be ignored.
-fcli.fod.release.update.auto-required-attrs = For each mandatory release attribute that does not already \
-  have a value, read the default value from the server and set it automatically.
 fcli.fod.release.update.auto-required-attrs = For each mandatory release attribute that does not already \
   have a value, read the default value from the server and set it automatically.
 fcli.fod.release.list-assessment-types.usage.header = List assessment types for a given release.

--- a/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
+++ b/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
@@ -325,6 +325,10 @@ fcli.fod.app.update.criticality = The business criticality of the application.
 fcli.fod.app.update.attrs = Set of application attribute id's or names and their values to set. \
   Please note for user attributes only the userId is currently supported. Release attributes \
   may be provided but will be ignored.
+fcli.fod.app.update.auto-required-attrs = For each mandatory application attribute that does not already \
+  have a value, read the default value from the server and set it automatically.
+fcli.fod.app.update.auto-required-attrs = For each mandatory application attribute that does not already \
+  have a value, read the default value from the server and set it automatically.
 fcli.fod.app.list-scans.usage.header = List scans for a given application.
 
 # fcli fod microservice
@@ -408,6 +412,10 @@ fcli.fod.release.update.status = SDLC lifecycle status of the release. Valid val
 fcli.fod.release.update.attrs = Set of release attribute id's or names and their values to set on the release. \
   Please note for user attributes only the userId is currently supported. Application attributes may be provided \
   but will be ignored.
+fcli.fod.release.update.auto-required-attrs = For each mandatory release attribute that does not already \
+  have a value, read the default value from the server and set it automatically.
+fcli.fod.release.update.auto-required-attrs = For each mandatory release attribute that does not already \
+  have a value, read the default value from the server and set it automatically.
 fcli.fod.release.list-assessment-types.usage.header = List assessment types for a given release.
 fcli.fod.release.list-assessment-types.scan-types = Comma-separated list of scan types for which to list assessment types. Default value: ${DEFAULT-VALUE}. Valid values: ${COMPLETION-CANDIDATES}.
 fcli.fod.release.list-scans.usage.header = List scans for a given release.


### PR DESCRIPTION
## Description
Added `--auto-required-attrs` support to FoD app update and release update commands.

Previously, `--auto-required-attrs` was only available on `fod app create` and `fod release create. This meant that when updating an existing app or release, users had to manually specify all mandatory attributes — including newly added ones — or risk update failures.

This change adds --auto-required-attrs to fcli fod app update and fcli fod release update. When the flag is passed, the command reads mandatory attribute default values from the FoD server and automatically applies them to any mandatory attributes that do not already have a value on the entity. Existing attribute values are always preserved, and any explicitly provided `--attrs` values take the highest priority.



## Refer to the following example screenshots

### Failing Scenario
<img width="1883" height="233" alt="image" src="https://github.com/user-attachments/assets/a0a735d4-84e3-4d10-958c-bcda638167b1" />


### Passed it with `--auto-required-attrs`
<img width="1462" height="90" alt="image" src="https://github.com/user-attachments/assets/22e5690d-e102-49a7-ae10-ba4949def398" />

