### PR TITLE
feat: Add entitlement management to Aviator application

### DIFF
--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/grpc/AviatorGrpcClient.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/grpc/AviatorGrpcClient.java
@@ -181,6 +181,11 @@ public class AviatorGrpcClient implements AutoCloseable {
         return GrpcUtil.executeGrpcCall(blockingStub, ApplicationServiceGrpc.ApplicationServiceBlockingStub::updateApplication, request, Constants.OP_UPDATE_APP);
     }
 
+    public Application addEntitlement(String projectId, String signature, String message, String tenantName) {
+        ApplicationById request = ApplicationById.newBuilder().setId(Long.parseLong(projectId)).setSignature(signature).setMessage(message).setTenantName(tenantName).build();
+        return GrpcUtil.executeGrpcCall(blockingStub, ApplicationServiceGrpc.ApplicationServiceBlockingStub::addEntitlement, request, Constants.OP_ADD_APP_ENTITLEMENT);
+    }
+
     public ApplicationResponseMessage deleteApplication(String projectId, String signature, String message, String tenantName) {
         ApplicationById request = ApplicationById.newBuilder().setId(Long.parseLong(projectId)).setSignature(signature).setMessage(message).setTenantName(tenantName).build();
         return GrpcUtil.executeGrpcCall(blockingStub, ApplicationServiceGrpc.ApplicationServiceBlockingStub::deleteApplication, request, Constants.OP_DELETE_APP);

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/util/Constants.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/util/Constants.java
@@ -60,6 +60,7 @@ public class Constants {
 
     // Operation constants for error messages
     public static final String OP_CREATE_APP = "application creation";
+    public static final String OP_ADD_APP_ENTITLEMENT = "application entitlement increment";
     public static final String OP_UPDATE_APP = "application update";
     public static final String OP_DELETE_APP = "application deletion";
     public static final String OP_GET_APP = "retrieving application";

--- a/fcli-core/fcli-aviator-common/src/main/proto/Application.proto
+++ b/fcli-core/fcli-aviator-common/src/main/proto/Application.proto
@@ -19,6 +19,10 @@ message Application {
   string legalTermsOfService=7;
   string quota_last_updated=8;
   int64 quota=9;
+  int64 entitlement_multiplier = 10;
+  int64 entitlements_consumed = 11;
+  int64 effective_initial_quota = 12;
+  int64 effective_monthly_quota = 13;
 }
 
 message CreateApplicationRequest {
@@ -77,6 +81,7 @@ service ApplicationService {
   rpc CreateApplication(CreateApplicationRequest) returns (Application) {}
   rpc GetApplication(ApplicationById) returns (Application) {}
   rpc UpdateApplication(UpdateApplicationRequest) returns (Application) {}
+  rpc AddEntitlement(ApplicationById) returns (Application) {}
   rpc DeleteApplication(ApplicationById) returns (ApplicationResponseMessage) {}
   rpc ListApplications(ApplicationByTenantName) returns (ApplicationList) {}
   rpc ListApplicationsByEntitlement(ApplicationById) returns (ApplicationList) {}

--- a/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/app/cli/cmd/AviatorAppAddEntitlementCommand.java
+++ b/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/app/cli/cmd/AviatorAppAddEntitlementCommand.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.aviator.app.cli.cmd;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fortify.aviator.application.Application;
+import com.fortify.cli.aviator._common.config.admin.helper.AviatorAdminConfigDescriptor;
+import com.fortify.cli.aviator._common.exception.AviatorSimpleException;
+import com.fortify.cli.aviator._common.exception.AviatorTechnicalException;
+import com.fortify.cli.aviator._common.output.cli.cmd.AbstractAviatorAdminSessionOutputCommand;
+import com.fortify.cli.aviator._common.util.AviatorGrpcUtils;
+import com.fortify.cli.aviator._common.util.AviatorSignatureUtils;
+import com.fortify.cli.aviator.grpc.AviatorGrpcClient;
+import com.fortify.cli.aviator.grpc.AviatorGrpcClientHelper;
+import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
+import com.fortify.cli.common.output.transform.IActionCommandResultSupplier;
+
+import lombok.Getter;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Parameters;
+
+@Command(name = "add-entitlement")
+public class AviatorAppAddEntitlementCommand extends AbstractAviatorAdminSessionOutputCommand implements IActionCommandResultSupplier {
+    @Getter @Mixin private OutputHelperMixins.TableNoQuery outputHelper;
+    @Parameters(index = "0") private Long applicationId;
+
+    @Override
+    protected JsonNode getJsonNode(AviatorAdminConfigDescriptor configDescriptor) throws AviatorSimpleException, AviatorTechnicalException {
+        try (AviatorGrpcClient client = AviatorGrpcClientHelper.createClient(configDescriptor.getAviatorUrl())) {
+            String[] messageAndSignature = AviatorSignatureUtils.createMessageAndSignature(
+                configDescriptor,
+                configDescriptor.getTenant(),
+                applicationId.toString(),
+                "add-entitlement");
+            String message = messageAndSignature[0];
+            String signature = messageAndSignature[1];
+            Application updatedApplication = client.addEntitlement(applicationId.toString(), signature, message, configDescriptor.getTenant());
+            return AviatorGrpcUtils.grpcToJsonNode(updatedApplication);
+        }
+    }
+
+    @Override
+    public boolean isSingular() {
+        return true;
+    }
+
+    @Override
+    public String getActionCommandResult() {
+        return "UPDATED";
+    }
+}

--- a/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/app/cli/cmd/AviatorAppCommands.java
+++ b/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/app/cli/cmd/AviatorAppCommands.java
@@ -20,6 +20,7 @@ import picocli.CommandLine;
         name = "app",
         subcommands = {
                 AviatorAppCreateCommand.class,
+                AviatorAppAddEntitlementCommand.class,
                 AviatorAppDeleteCommand.class,
                 AviatorAppGetCommand.class,
                 AviatorAppListCommand.class,

--- a/fcli-core/fcli-aviator/src/main/resources/com/fortify/cli/aviator/i18n/AviatorMessages.properties
+++ b/fcli-core/fcli-aviator/src/main/resources/com/fortify/cli/aviator/i18n/AviatorMessages.properties
@@ -53,6 +53,10 @@ fcli.aviator.app.create.usage.header = Create a new SAST Aviator application.
 fcli.aviator.app.create.usage.description = Creates a new Aviator application within the tenant specified in the admin configuration.
 fcli.aviator.app.create.name = Name of the application to create.
 
+fcli.aviator.app.add-entitlement.usage.header = Add one entitlement to an existing SAST Aviator application.
+fcli.aviator.app.add-entitlement.usage.description = Increments an existing Aviator application's entitlement multiplier by one and returns the updated application details.
+fcli.aviator.app.add-entitlement.applicationId = ID of the application to update.
+
 fcli.aviator.app.delete.usage.header = Delete an SAST Aviator application.
 fcli.aviator.app.delete.usage.description = Deletes an Aviator application by its ID from the tenant specified in the admin configuration.
 fcli.aviator.app.delete.applicationId = ID of the application to delete.
@@ -190,9 +194,10 @@ fcli.aviator.session.output.table.args = name,type,url,created,expires,expired
 fcli.aviator.admin-config.output.table.args = name,type,url,created
 fcli.aviator.ssc.audit.output.table.args = id,application.name,name,artifactId,action
 fcli.aviator.app.create.output.table.args = id,name,entitlement_id,disclaimer,quota_last_updated,quota
+fcli.aviator.app.add-entitlement.output.table.args = id,name,entitlement_id,entitlement_multiplier,entitlements_consumed,quota_last_updated,quota
 fcli.aviator.app.delete.output.table.args = message
-fcli.aviator.app.get.output.table.args = id,name,updated_at,quota_last_updated,quota
-fcli.aviator.app.list.output.table.args = id,name,entitlement_id,created_at,quota_last_updated,quota
+fcli.aviator.app.get.output.table.args = id,name,entitlement_id,entitlement_multiplier,entitlements_consumed,updated_at,quota_last_updated,quota
+fcli.aviator.app.list.output.table.args = id,name,entitlement_id,entitlement_multiplier,entitlements_consumed,created_at,quota_last_updated,quota
 fcli.aviator.app.update.output.table.args = id,name,updated_at,quota_last_updated,quota
 fcli.aviator.token.create.output.table.args = token_name,start_date,expiry_date,token
 fcli.aviator.token.delete.output.table.args = message


### PR DESCRIPTION
## Summary

This PR adds FCLI support for the Aviator Double Whiskey feature.

The change introduces a new `fcli aviator app add-entitlement <application-id>` command for incrementing an application's entitlement multiplier by one, and updates existing Aviator app output so multiplier-aware application state is visible in the CLI. The client continues to rely on the server for quota and multiplier business logic and only surfaces the returned application data.

## Changes

- Added a new `fcli aviator app add-entitlement <application-id>` admin command
- Registered the new command under the existing `aviator app` command group
- Updated the Aviator gRPC client wrapper to call the new `AddEntitlement` RPC
- Updated the shared Aviator application proto contract to include multiplier-aware fields:
  - `entitlement_multiplier`
  - `entitlements_consumed`
  - `effective_initial_quota`
  - `effective_monthly_quota`
- Updated `aviator app get` output to show multiplier-aware fields
- Updated `aviator app list` output to show multiplier-aware fields
- Added help text and table output configuration for the new command
- Added a dedicated operation label for clearer error reporting during entitlement increment
- Used a numeric application id parameter type so invalid ids fail fast at the CLI boundary

## User Impact

After this change, admins can increase application capacity directly from FCLI with:

`fcli aviator app add-entitlement <application-id>`

On success, the command returns the updated application record, including the new multiplier-aware fields. Existing `aviator app get` and `aviator app list` commands now also expose the multiplier-related state without requiring users to infer it externally.

## Backward Compatibility

- Existing `aviator app` commands remain unchanged in shape
- `aviator app get` and `aviator app list` only gain additional output fields
- No multiplier or quota math is implemented in FCLI; the server remains the source of truth
- This keeps the change backward compatible while making Double Whiskey behavior visible in the client

