### PR TITLE
fix(aviator): record suppression state changes in audit history

### DIFF
--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/AuditProcessor.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/AuditProcessor.java
@@ -305,6 +305,7 @@ public class AuditProcessor {
         int revision = Integer.parseInt(issueElement.getAttribute("revision"));
         issueElement.setAttribute("revision", String.valueOf(++revision));
         String commentTimestamp = null;
+        Boolean suppressedHistoryValue = null;
 
         if (response != null && response.getAuditResult() != null) {
             String tagValue = response.getAuditResult().tagValue;
@@ -332,7 +333,8 @@ public class AuditProcessor {
             if (resultConfig != null && resultConfig.getValue() != null && !resultConfig.getValue().isEmpty()) {
                 updateOrAddTag(issueElement, tagMappingConfig.getTag_id(), resultConfig.getValue());
             }
-            applySuppressionDecision(issueElement, issueElement.getAttribute("instanceId"), resultConfig, tagMappingConfig, issueCategoryLookup);
+            suppressedHistoryValue = applySuppressionDecision(issueElement, issueElement.getAttribute("instanceId"), resultConfig,
+                    tagMappingConfig, issueCategoryLookup);
         }
 
         updateOrAddTag(issueElement, Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR);
@@ -341,13 +343,12 @@ public class AuditProcessor {
             commentTimestamp = updateOrAddComment(issueElement, response.getAuditResult().comment);
         }
 
-        updateClientAuditTrail(issueElement, response, tagMappingConfig, issueCategoryLookup);
+        updateClientAuditTrail(issueElement, response, tagMappingConfig, suppressedHistoryValue);
 
         return commentTimestamp;
     }
 
-    private void updateClientAuditTrail(Element issueElement, AuditResponse response, TagMappingConfig tagMappingConfig,
-            Map<String, String> issueCategoryLookup) throws AviatorTechnicalException {
+    private void updateClientAuditTrail(Element issueElement, AuditResponse response, TagMappingConfig tagMappingConfig, Boolean suppressedHistoryValue) {
         Element clientAuditTrail = getClientAuditTrailElement(issueElement);
 
         if (response != null && response.getAuditResult() != null) {
@@ -376,16 +377,20 @@ public class AuditProcessor {
             if (resultConfig != null && resultConfig.getValue() != null && !resultConfig.getValue().isEmpty()) {
                 addTagHistory(clientAuditTrail, tagMappingConfig.getTag_id(), resultConfig.getValue());
             }
-            applySuppressionDecision(issueElement, issueElement.getAttribute("instanceId"), resultConfig, tagMappingConfig, issueCategoryLookup);
+            if (suppressedHistoryValue != null) {
+                addTagHistory(clientAuditTrail, Constants.SUPPRESSED_TAG_ID, suppressedHistoryValue.toString());
+            }
         }
         addTagHistory(clientAuditTrail, Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR);
     }
 
-    private void applySuppressionDecision(Element issueElement, String instanceId, TagMappingConfig.Result resultConfig,
+    private Boolean applySuppressionDecision(Element issueElement, String instanceId, TagMappingConfig.Result resultConfig,
             TagMappingConfig tagMappingConfig, Map<String, String> issueCategoryLookup) throws AviatorTechnicalException {
-        if (shouldSuppress(instanceId, resultConfig, tagMappingConfig, issueCategoryLookup)) {
-            issueElement.setAttribute("suppressed", "true");
+        if (resultConfig == null) {
+            return null;
         }
+
+        return updateSuppressedState(issueElement, shouldSuppress(instanceId, resultConfig, tagMappingConfig, issueCategoryLookup));
     }
 
     private boolean shouldSuppress(String instanceId, TagMappingConfig.Result resultConfig,
@@ -521,6 +526,7 @@ public class AuditProcessor {
         newIssue.setAttribute("instanceId", instanceId);
         newIssue.setAttribute("revision", "0");
         String commentTimestamp = null;
+        Boolean suppressedHistoryValue = null;
 
         if (response != null && response.getAuditResult() != null) {
             String tagValue = response.getAuditResult().tagValue;
@@ -548,7 +554,7 @@ public class AuditProcessor {
             if (resultConfig != null && resultConfig.getValue() != null && !resultConfig.getValue().isEmpty()) {
                 updateOrAddTag(newIssue, tagMappingConfig.getTag_id(), resultConfig.getValue());
             }
-            applySuppressionDecision(newIssue, instanceId, resultConfig, tagMappingConfig, issueCategoryLookup);
+            suppressedHistoryValue = applySuppressionDecision(newIssue, instanceId, resultConfig, tagMappingConfig, issueCategoryLookup);
         }
 
         updateOrAddTag(newIssue, Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR);
@@ -557,10 +563,21 @@ public class AuditProcessor {
             commentTimestamp = updateOrAddComment(newIssue, response.getAuditResult().comment);
         }
 
-        updateClientAuditTrail(newIssue, response, tagMappingConfig, issueCategoryLookup);
+        updateClientAuditTrail(newIssue, response, tagMappingConfig, suppressedHistoryValue);
 
         issueList.appendChild(newIssue);
         return commentTimestamp;
+    }
+
+    private Boolean updateSuppressedState(Element issueElement, Boolean suppressed) {
+        if (suppressed == null) {
+            return null;
+        }
+
+        boolean currentSuppressed = Boolean.parseBoolean(issueElement.getAttribute("suppressed"));
+        issueElement.setAttribute("suppressed", Boolean.toString(suppressed));
+
+        return currentSuppressed == suppressed ? null : suppressed;
     }
 
     public void addCommentToIssueXml(String instanceId, String commentText, String username) {

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/util/Constants.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/util/Constants.java
@@ -41,6 +41,7 @@ public class Constants {
     public static final String AVIATOR_STATUS_TAG_ID = "FB7B0462-2C2E-46D9-811A-DCC1F3C83051";
     public static final String AVIATOR_EXPECTED_OUTCOME_TAG_ID = "013cc66f-8651-4e39-bacb-beb918c5ef65";
     public static final String ANALYSIS_TAG_ID = "87f2364f-dcd4-49e6-861d-f8d3f351686b";
+    public static final String SUPPRESSED_TAG_ID = "22222222-2222-2222-2222-222222222222";
     public static final String AUDITOR_STATUS_TAG_ID = "ACB05E55-E74D-468C-8501-52E1FDC27D71";
     public static final String FOD_TAG_ID = "604f0fbe-b5fe-47cd-a9cb-587ad8ebe93a";
 

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/fpr/processor/AuditProcessorSuppressionHistoryTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/fpr/processor/AuditProcessorSuppressionHistoryTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.aviator.fpr.processor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import com.fortify.cli.aviator.audit.model.AuditResponse;
+import com.fortify.cli.aviator.audit.model.AuditResult;
+import com.fortify.cli.aviator.config.TagMappingConfig;
+import com.fortify.cli.aviator.util.Constants;
+import com.fortify.cli.aviator.util.FprHandle;
+
+class AuditProcessorSuppressionHistoryTest {
+    private static final String AUDIT_NAMESPACE_URI = "xmlns://www.fortify.com/schema/audit";
+    private static final String INSTANCE_ID = "ISSUE-1";
+
+    @TempDir
+    Path tempDir;
+
+    private FprHandle fprHandle;
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (fprHandle != null) {
+            fprHandle.close();
+        }
+    }
+
+    @Test
+    void shouldAddSuppressionHistoryWhenAviatorSuppressesAnExistingIssue() throws Exception {
+        fprHandle = new FprHandle(createTestFpr(minimalAuditXml()));
+        AuditProcessor auditProcessor = new AuditProcessor(fprHandle);
+        auditProcessor.processAuditXML();
+
+        Element issueElement = auditProcessor.findIssueElement(INSTANCE_ID);
+        auditProcessor.updateIssueElement(issueElement, createAuditResponse("GOLD", Constants.NOT_AN_ISSUE), createTagMappingConfig(), Map.of());
+
+        assertEquals("true", issueElement.getAttribute("suppressed"));
+        assertEquals(1, countTagHistory(issueElement, Constants.SUPPRESSED_TAG_ID));
+        assertEquals(1, countTagHistory(issueElement, Constants.SUPPRESSED_TAG_ID, Boolean.TRUE.toString()));
+    }
+
+    @Test
+    void shouldNotAddSuppressionHistoryWhenMappingDoesNotSuppress() throws Exception {
+        fprHandle = new FprHandle(createTestFpr(minimalAuditXml()));
+        AuditProcessor auditProcessor = new AuditProcessor(fprHandle);
+        auditProcessor.processAuditXML();
+
+        Element issueElement = auditProcessor.findIssueElement(INSTANCE_ID);
+        auditProcessor.updateIssueElement(issueElement, createAuditResponse("SILVER", Constants.NOT_AN_ISSUE), createTagMappingConfig(), Map.of());
+
+        assertNotEquals("true", issueElement.getAttribute("suppressed"));
+        assertEquals(0, countTagHistory(issueElement, Constants.SUPPRESSED_TAG_ID));
+        assertEquals(0, countTagHistory(issueElement, Constants.SUPPRESSED_TAG_ID, Boolean.TRUE.toString()));
+    }
+
+    @Test
+    void shouldAddUnsuppressionHistoryWhenAviatorClearsAPreviouslySuppressedIssue() throws Exception {
+        fprHandle = new FprHandle(createTestFpr(minimalAuditXml(true)));
+        AuditProcessor auditProcessor = new AuditProcessor(fprHandle);
+        auditProcessor.processAuditXML();
+
+        Element issueElement = auditProcessor.findIssueElement(INSTANCE_ID);
+        auditProcessor.updateIssueElement(issueElement, createAuditResponse("SILVER", Constants.NOT_AN_ISSUE), createTagMappingConfig(), Map.of());
+
+        assertEquals("false", issueElement.getAttribute("suppressed"));
+        assertEquals(1, countTagHistory(issueElement, Constants.SUPPRESSED_TAG_ID));
+        assertEquals(1, countTagHistory(issueElement, Constants.SUPPRESSED_TAG_ID, Boolean.FALSE.toString()));
+    }
+
+    @Test
+    void shouldNotAddSuppressionHistoryWhenIssueIsAlreadySuppressedAndRemainsSuppressed() throws Exception {
+        fprHandle = new FprHandle(createTestFpr(minimalAuditXml(true)));
+        AuditProcessor auditProcessor = new AuditProcessor(fprHandle);
+        auditProcessor.processAuditXML();
+
+        Element issueElement = auditProcessor.findIssueElement(INSTANCE_ID);
+        auditProcessor.updateIssueElement(issueElement, createAuditResponse("GOLD", Constants.NOT_AN_ISSUE), createTagMappingConfig(), Map.of());
+
+        assertEquals("true", issueElement.getAttribute("suppressed"));
+        assertEquals(0, countTagHistory(issueElement, Constants.SUPPRESSED_TAG_ID));
+    }
+
+    @Test
+    void shouldAddSuppressionHistoryWhenAviatorSuppressesANewIssue() throws Exception {
+        fprHandle = new FprHandle(createTestFpr(emptyAuditXml()));
+        AuditProcessor auditProcessor = new AuditProcessor(fprHandle);
+        auditProcessor.processAuditXML();
+
+        auditProcessor.addNewIssueElement(INSTANCE_ID, createAuditResponse("GOLD", Constants.NOT_AN_ISSUE), createTagMappingConfig(), Map.of());
+
+        Element issueElement = auditProcessor.findIssueElement(INSTANCE_ID);
+        assertEquals("true", issueElement.getAttribute("suppressed"));
+        assertEquals(1, countTagHistory(issueElement, Constants.SUPPRESSED_TAG_ID));
+        assertEquals(1, countTagHistory(issueElement, Constants.SUPPRESSED_TAG_ID, Boolean.TRUE.toString()));
+    }
+
+    @Test
+    void shouldNotAddSuppressionHistoryWhenANewIssueRemainsUnsuppressed() throws Exception {
+        fprHandle = new FprHandle(createTestFpr(emptyAuditXml()));
+        AuditProcessor auditProcessor = new AuditProcessor(fprHandle);
+        auditProcessor.processAuditXML();
+
+        auditProcessor.addNewIssueElement(INSTANCE_ID, createAuditResponse("SILVER", Constants.NOT_AN_ISSUE), createTagMappingConfig(), Map.of());
+
+        Element issueElement = auditProcessor.findIssueElement(INSTANCE_ID);
+        assertEquals("false", issueElement.getAttribute("suppressed"));
+        assertEquals(0, countTagHistory(issueElement, Constants.SUPPRESSED_TAG_ID));
+    }
+
+    private Path createTestFpr(String auditXml) throws Exception {
+        Path fprPath = Files.createTempFile(tempDir, "audit-processor", ".fpr");
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(Files.newOutputStream(fprPath))) {
+            zipOutputStream.putNextEntry(new ZipEntry("audit.xml"));
+            zipOutputStream.write(auditXml.getBytes(StandardCharsets.UTF_8));
+            zipOutputStream.closeEntry();
+
+            zipOutputStream.putNextEntry(new ZipEntry("src-archive/index.xml"));
+            zipOutputStream.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?><index/>".getBytes(StandardCharsets.UTF_8));
+            zipOutputStream.closeEntry();
+        }
+        return fprPath;
+    }
+
+    private AuditResponse createAuditResponse(String tier, String tagValue) {
+        return AuditResponse.builder()
+                .issueId(INSTANCE_ID)
+                .tier(tier)
+                .auditResult(AuditResult.builder()
+                        .tagValue(tagValue)
+                        .comment("Processed by Aviator")
+                        .build())
+                .build();
+    }
+
+    private TagMappingConfig createTagMappingConfig() {
+        TagMappingConfig.Result goldFp = new TagMappingConfig.Result();
+        goldFp.setValue(Constants.NOT_AN_ISSUE);
+        goldFp.setSuppress(true);
+
+        TagMappingConfig.Result silverFp = new TagMappingConfig.Result();
+        silverFp.setValue(Constants.PROPOSED_NOT_AN_ISSUE);
+        silverFp.setSuppress(false);
+
+        TagMappingConfig.Tier tier1 = new TagMappingConfig.Tier();
+        tier1.setFp(goldFp);
+
+        TagMappingConfig.Tier tier2 = new TagMappingConfig.Tier();
+        tier2.setFp(silverFp);
+
+        TagMappingConfig.Mapping mapping = new TagMappingConfig.Mapping();
+        mapping.setTier_1(tier1);
+        mapping.setTier_2(tier2);
+
+        TagMappingConfig config = new TagMappingConfig();
+        config.setTag_id(Constants.ANALYSIS_TAG_ID);
+        config.setMapping(mapping);
+        return config;
+    }
+
+    private int countTagHistory(Element issueElement, String tagId) {
+        return countTagHistory(issueElement, tagId, null);
+    }
+
+    private int countTagHistory(Element issueElement, String tagId, String value) {
+        NodeList tagHistories = issueElement.getElementsByTagNameNS(AUDIT_NAMESPACE_URI, "TagHistory");
+        int count = 0;
+        for (int index = 0; index < tagHistories.getLength(); index++) {
+            Element tagHistory = (Element) tagHistories.item(index);
+            NodeList tags = tagHistory.getElementsByTagNameNS(AUDIT_NAMESPACE_URI, "Tag");
+            if (tags.getLength() == 0) {
+                continue;
+            }
+
+            Element tag = (Element) tags.item(0);
+            if (!tagId.equals(tag.getAttribute("id"))) {
+                continue;
+            }
+
+            NodeList values = tag.getElementsByTagNameNS(AUDIT_NAMESPACE_URI, "Value");
+            if (value == null) {
+                count++;
+            } else if (values.getLength() > 0 && value.equals(values.item(0).getTextContent())) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private String minimalAuditXml() {
+        return minimalAuditXml(false);
+    }
+
+    private String emptyAuditXml() {
+        return """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <ns2:Audit xmlns:ns2="xmlns://www.fortify.com/schema/audit" version="4.4">
+                  <ns2:IssueList/>
+                </ns2:Audit>
+                """;
+    }
+
+    private String minimalAuditXml(boolean suppressed) {
+        String suppressedAttribute = suppressed ? " suppressed=\"true\"" : "";
+        return """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <ns2:Audit xmlns:ns2="xmlns://www.fortify.com/schema/audit" version="4.4">
+                  <ns2:IssueList>
+                    <ns2:Issue instanceId="ISSUE-1" revision="0"%s/>
+                  </ns2:IssueList>
+                </ns2:Audit>
+                """.formatted(suppressedAttribute);
+    }
+}


### PR DESCRIPTION
## Summary
fcli aviator ssc audit updates the suppressed flag in audit.xml, but
it did not write the matching SUPPRESSED history entry. As a result,
SSC could reflect the new state without showing the suppression
transition in issue history.

## Changes
- add the SUPPRESSED GUID constant used by audit.xml history
- write suppression history only when the suppression state changes
- cover existing-issue and new-issue flows for suppress,
  unsuppress, and no-op cases
  
 NOTE;  PR DEPENDS ON #992 