### PR TITLE
fix: `fcli aviator ssc audit`: Count hidden issues for `--no-filterset` preflight

### DIFF
--- a/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/cli/cmd/AviatorSSCAuditCommand.java
+++ b/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/cli/cmd/AviatorSSCAuditCommand.java
@@ -90,7 +90,7 @@ public class AviatorSSCAuditCommand extends AbstractSSCJsonNodeOutputCommand imp
 
             refreshMetricsIfNeeded(unirest, av, logger);
 
-            long auditableIssueCount = AviatorSSCAuditHelper.getAuditableIssueCount(unirest, av, logger, noFilterSet, filterSetOptions, folderNames);
+            long auditableIssueCount = AviatorSSCAuditHelper.getAuditableIssueCount(unirest, av, logger, isNoFilterSet(), getFilterSetTitleOrId(), folderNames);
             if (auditableIssueCount == 0) {
                 logger.progress("Audit skipped - no auditable issues found matching the specified filters.");
                 ObjectNode result = AviatorSSCAuditHelper.buildResultNode(av, null, "SKIPPED");
@@ -120,6 +120,14 @@ public class AviatorSSCAuditCommand extends AbstractSSCJsonNodeOutputCommand imp
                 Files.deleteIfExists(downloadedFprPath);
             }
         }
+    }
+
+    String getFilterSetTitleOrId() {
+        return filterSetOptions.getFilterSetTitleOrId();
+    }
+
+    boolean isNoFilterSet() {
+        return noFilterSet;
     }
 
     private void refreshMetricsIfNeeded(UnirestInstance unirest, SSCAppVersionDescriptor av, AviatorLoggerImpl logger) {
@@ -245,8 +253,8 @@ public class AviatorSSCAuditCommand extends AbstractSSCJsonNodeOutputCommand imp
                     .sscAppVersion(av.getVersionName())
                     .logger(logger)
                     .tagMappingPath(tagMapping)
-                    .filterSetNameOrId(filterSetOptions.getFilterSetTitleOrId())
-                    .noFilterSet(noFilterSet)
+                    .filterSetNameOrId(getFilterSetTitleOrId())
+                    .noFilterSet(isNoFilterSet())
                     .folderNames(folderNames)
                     .folderPriorityOrder(folderPriorityOrder)
                     .build());

--- a/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/helper/AviatorSSCAuditHelper.java
+++ b/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/helper/AviatorSSCAuditHelper.java
@@ -38,7 +38,6 @@ import com.fortify.cli.common.output.transform.IActionCommandResultSupplier;
 import com.fortify.cli.common.rest.unirest.UnexpectedHttpResponseException;
 import com.fortify.cli.ssc._common.rest.ssc.SSCUrls;
 import com.fortify.cli.ssc.appversion.helper.SSCAppVersionDescriptor;
-import com.fortify.cli.ssc.issue.cli.mixin.SSCIssueFilterSetOptionMixin;
 import com.fortify.cli.ssc.issue.helper.SSCIssueFilterHelper;
 import com.fortify.cli.ssc.issue.helper.SSCIssueFilterSetDescriptor;
 import com.fortify.cli.ssc.issue.helper.SSCIssueFilterSetHelper;
@@ -193,23 +192,28 @@ public final class AviatorSSCAuditHelper {
     /**
      * Queries SSC to get the number of auditable issues for a given application version.
      */
-    public static long getAuditableIssueCount(UnirestInstance unirest, SSCAppVersionDescriptor av, AviatorLoggerImpl logger, boolean noFilterSet, SSCIssueFilterSetOptionMixin filterSetOptions, List<String> folderNames) {
+    public static long getAuditableIssueCount(UnirestInstance unirest, SSCAppVersionDescriptor av, AviatorLoggerImpl logger, boolean noFilterSet, String filterSetTitleOrId, List<String> folderNames) {
         logger.progress("Status: Checking for auditable issues...");
 
         LOG.debug("Starting auditable issue count for SSC version {} (application='{}', version='{}') with pageLimit={}, noFilterSet={}",
                 av.getVersionId(), av.getApplicationName(), av.getVersionName(), PAGE_LIMIT, noFilterSet);
 
+        String effectiveFilterSetTitleOrId = filterSetTitleOrId != null && !filterSetTitleOrId.isBlank()
+                ? filterSetTitleOrId
+                : null;
+        boolean effectiveNoFilterSet = noFilterSet && effectiveFilterSetTitleOrId == null;
+
         // Apply filter set if specified
         SSCIssueFilterSetDescriptor filterSetDescriptor = null;
         String filterSetGuid = null;
-        if (!noFilterSet) {
+        if (!effectiveNoFilterSet) {
             SSCIssueFilterSetHelper filterSetHelper = new SSCIssueFilterSetHelper(unirest, av.getVersionId());
-            filterSetDescriptor = filterSetHelper.getDescriptorByTitleOrId(filterSetOptions.getFilterSetTitleOrId(), false);
+            filterSetDescriptor = filterSetHelper.getDescriptorByTitleOrId(effectiveFilterSetTitleOrId, false);
             if (filterSetDescriptor != null) {
                 logger.progress("Status: Applying filter set '%s' for issue count check", filterSetDescriptor.getTitle());
-            filterSetGuid = filterSetDescriptor.getGuid();
+                filterSetGuid = filterSetDescriptor.getGuid();
                 LOG.debug("Applied SSC filter set '{}' with guid {} while counting auditable issues for version {}",
-                filterSetDescriptor.getTitle(), filterSetGuid, av.getVersionId());
+                        filterSetDescriptor.getTitle(), filterSetGuid, av.getVersionId());
             } else {
                 LOG.debug("No SSC filter set resolved from options while counting auditable issues for version {}",
                         av.getVersionId());
@@ -219,7 +223,7 @@ public final class AviatorSSCAuditHelper {
         // Apply folder filter if specified
         String folderFilter = null;
         if (folderNames != null && !folderNames.isEmpty()) {
-            folderFilter = getFolderFilter(noFilterSet, filterSetDescriptor, folderNames);
+            folderFilter = getFolderFilter(effectiveNoFilterSet, filterSetDescriptor, folderNames);
             logger.progress("Status: Applying folder filter for: %s", String.join(", ", folderNames));
             LOG.debug("Applied folder filter '{}' for folders {} while counting auditable issues for version {}",
                     folderFilter, folderNames, av.getVersionId());
@@ -237,6 +241,9 @@ public final class AviatorSSCAuditHelper {
                         .queryString("qm", "issues")
                         .queryString("q", "audited:false")
                         .queryString("start", start);
+                if (effectiveNoFilterSet) {
+                    request.queryString("showhidden", "true");
+                }
                 if (filterSetGuid != null) {
                     request.queryString("filterset", filterSetGuid);
                 }

--- a/fcli-core/fcli-aviator/src/test/java/com/fortify/cli/aviator/ssc/cli/cmd/AviatorSSCAuditCommandTest.java
+++ b/fcli-core/fcli-aviator/src/test/java/com/fortify/cli/aviator/ssc/cli/cmd/AviatorSSCAuditCommandTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.aviator.ssc.cli.cmd;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import picocli.CommandLine;
+
+class AviatorSSCAuditCommandTest {
+    @Test
+    void testAllowsCombinedFilterOptions() {
+        var cmd = parse("--filterset", "Security Auditor View", "--no-filterset");
+        assertEquals("Security Auditor View", cmd.getFilterSetTitleOrId());
+        assertTrue(cmd.isNoFilterSet());
+    }
+
+    @Test
+    void testAllowsFilterSetOption() {
+        var cmd = parse("--filterset", "Security Auditor View");
+        assertEquals("Security Auditor View", cmd.getFilterSetTitleOrId());
+        assertFalse(cmd.isNoFilterSet());
+    }
+
+    @Test
+    void testAllowsNoFilterSetOption() {
+        var cmd = parse("--no-filterset");
+        assertTrue(cmd.isNoFilterSet());
+        assertNull(cmd.getFilterSetTitleOrId());
+    }
+
+    private static AviatorSSCAuditCommand parse(String... args) {
+        var cmd = new AviatorSSCAuditCommand();
+        var fullArgs = new ArrayList<String>();
+        Collections.addAll(fullArgs, "--av", "test:1.0");
+        Collections.addAll(fullArgs, args);
+        new CommandLine(cmd).parseArgs(fullArgs.toArray(String[]::new));
+        return cmd;
+    }
+}


### PR DESCRIPTION
## Summary

Fix `fcli aviator ssc audit` preflight issue counting for `--no-filterset`.

When `--no-filterset` is used, the SSC preflight `/issues` query now includes hidden issues so the command no longer incorrectly short-circuits with zero auditable issues for application versions whose default SSC filterset hides all findings.

## Changes

- Update the SSC preflight issue count logic to request hidden issues for `--no-filterset`
- Align preflight filter option precedence with the downstream FPR audit path
- Pass plain filter option values into the helper instead of the CLI mixin type
- Add focused tests for command filter option parsing