### PR TITLE
chore(aviator): improve correlation stability and relax parser requirements

### DIFF
--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/dast/StreamingWebInspectParser.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/dast/StreamingWebInspectParser.java
@@ -292,7 +292,6 @@ public class StreamingWebInspectParser {
             }
         }
 
-        applyFallbackCategory(issue);
         return issue;
     }
 

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/AuditProcessor.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/AuditProcessor.java
@@ -93,20 +93,20 @@ public class AuditProcessor {
             if (!Files.exists(auditPath)) {
                 logger.debug("audit.xml not found. Creating a default audit.xml.");
                 auditDoc = createDefaultAuditXml();
-            }
+            } else {
+                DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+                factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+                factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+                factory.setXIncludeAware(false);
+                factory.setExpandEntityReferences(false);
+                factory.setNamespaceAware(true);
+                DocumentBuilder builder = factory.newDocumentBuilder();
 
-            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-            factory.setXIncludeAware(false);
-            factory.setExpandEntityReferences(false);
-            factory.setNamespaceAware(true);
-            DocumentBuilder builder = factory.newDocumentBuilder();
-
-            try (InputStream auditStream = Files.newInputStream(auditPath)) {
-                auditDoc = builder.parse(auditStream);
+                try (InputStream auditStream = Files.newInputStream(auditPath)) {
+                    auditDoc = builder.parse(auditStream);
+                }
             }
             NodeList issueNodes = auditDoc.getElementsByTagNameNS(AUDIT_NAMESPACE_URI, "Issue");
             for (int i = 0; i < issueNodes.getLength(); i++) {

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/grpc/AviatorStreamProcessor.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/grpc/AviatorStreamProcessor.java
@@ -689,7 +689,7 @@ class AviatorStreamProcessor implements AutoCloseable {
                 }
 
                 if (!requestSemaphore.tryAcquire(1, 10, TimeUnit.SECONDS)) {
-                    LOG.warn("WARN: Timed out waiting for semaphore permit. Will retry.");
+                    LOG.debug("Timed out waiting for semaphore permit. Will retry.");
                     continue;
                 }
 

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/grpc/CorrelationStreamProcessor.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/grpc/CorrelationStreamProcessor.java
@@ -13,7 +13,8 @@
 package com.fortify.cli.aviator.grpc;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -558,7 +559,7 @@ public class CorrelationStreamProcessor implements AutoCloseable {
 
         for (Object bucketObj : mixedBuckets) {
             if (bucketObj instanceof CorrelationBucketData data) {
-                Set<String> dastUrls = new HashSet<>();
+                Set<String> dastUrls = new LinkedHashSet<>();
                 for (var dastIssue : data.dastFindings()) {
                     if (dastIssue.getSessionUrl() != null && !dastIssue.getSessionUrl().isEmpty()) {
                         dastUrls.add(dastIssue.getSessionUrl());
@@ -613,7 +614,7 @@ public class CorrelationStreamProcessor implements AutoCloseable {
 
     @SuppressWarnings("unchecked")
     private Map<String, List<DastIssue>> buildUrlToDastMap(List<? extends Object> mixedBuckets) {
-        var map = new java.util.HashMap<String, List<DastIssue>>();
+        Map<String, List<DastIssue>> map = new LinkedHashMap<>();
         for (Object bucketObj : mixedBuckets) {
             if (bucketObj instanceof CorrelationBucketData data) {
                 for (DastIssue issue : data.dastFindings()) {

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/util/FprHandle.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/util/FprHandle.java
@@ -12,16 +12,19 @@
  */
 package com.fortify.cli.aviator.util;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -46,6 +49,9 @@ import lombok.Getter;
  */
 public final class FprHandle implements AutoCloseable {
     private static final Logger LOG = LoggerFactory.getLogger(FprHandle.class);
+    private static final Pattern PROPERTIES_DOCTYPE_PATTERN = Pattern.compile(
+        "<!DOCTYPE\\s+properties\\s+SYSTEM\\s+(['\"])http://java\\.sun\\.com/dtd/properties\\.dtd\\1\\s*>"
+    );
 
     private final FileSystem zipfs;
     /**
@@ -163,28 +169,87 @@ public final class FprHandle implements AutoCloseable {
             return map;
         }
 
-        try (InputStream indexStream = Files.newInputStream(indexPath)) {
-            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-            factory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
-            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-            factory.setFeature("http://xml.org/sax/features/validation", false);
-            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            factory.setXIncludeAware(false);
-            factory.setExpandEntityReferences(false);
-            DocumentBuilder builder = factory.newDocumentBuilder();
-            Document indexDoc = builder.parse(indexStream);
+        try {
+            byte[] indexBytes = Files.readAllBytes(indexPath);
+            String xmlForValidation = new String(indexBytes, java.nio.charset.StandardCharsets.ISO_8859_1);
 
-            NodeList entryNodes = indexDoc.getElementsByTagName("entry");
-            for (int i = 0; i < entryNodes.getLength(); i++) {
-                Element entry = (Element) entryNodes.item(i);
-                String key = entry.getAttribute("key");
-                String value = entry.getTextContent();
-                map.put(key, value);
+            validateDoctype(xmlForValidation, indexPath);
+
+            if (containsDoctype(xmlForValidation)) {
+                loadPropertiesFormat(indexBytes, map);
+            } else {
+                loadEntryXmlFormat(indexBytes, map);
             }
         } catch (IOException | ParserConfigurationException | SAXException e) {
             throw new AviatorTechnicalException("Failed to parse src-archive/index.xml in FPR", e);
         }
         return map;
+    }
+
+    private void loadEntryXmlFormat(byte[] indexBytes, Map<String, String> map)
+            throws ParserConfigurationException, IOException, SAXException {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            factory.setFeature("http://xml.org/sax/features/validation", false);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            Document indexDoc = builder.parse(new ByteArrayInputStream(indexBytes));
+
+        NodeList entryNodes = indexDoc.getElementsByTagName("entry");
+        for (int i = 0; i < entryNodes.getLength(); i++) {
+            Element entry = (Element) entryNodes.item(i);
+            String key = entry.getAttribute("key");
+            String value = entry.getTextContent();
+            map.put(key, value);
+        }
+    }
+
+    private void loadPropertiesFormat(byte[] indexBytes, Map<String, String> map) throws IOException {
+        Properties properties = new Properties();
+        properties.loadFromXML(new ByteArrayInputStream(indexBytes));
+
+        for (String key : properties.stringPropertyNames()) {
+            map.put(key, properties.getProperty(key));
+        }
+    }
+
+    private void validateDoctype(String xmlContent, Path indexPath) throws IOException {
+        if (xmlContent.contains("<!ENTITY")) {
+            throw new IOException("index.xml contains ENTITY declarations, which are not supported: " + indexPath);
+        }
+
+        int doctypeStart = xmlContent.indexOf("<!DOCTYPE");
+        if (doctypeStart < 0) {
+            return;
+        }
+
+        int doctypeEnd = xmlContent.indexOf('>', doctypeStart);
+        if (doctypeEnd < 0) {
+            throw new IOException("index.xml contains an unterminated DOCTYPE declaration: " + indexPath);
+        }
+
+        String declaration = xmlContent.substring(doctypeStart, doctypeEnd + 1).trim();
+        if (declaration.contains("[")) {
+            throw new IOException("index.xml contains an internal DTD subset, which is not supported: " + indexPath);
+        }
+
+        if (!isSupportedPropertiesDoctype(declaration)) {
+            throw new IOException("index.xml contains an unsupported DOCTYPE declaration: " + indexPath);
+        }
+    }
+
+    private boolean isSupportedPropertiesDoctype(String declaration) {
+        return PROPERTIES_DOCTYPE_PATTERN.matcher(declaration).matches();
+    }
+
+    private boolean containsDoctype(String xmlContent) {
+        return xmlContent.contains("<!DOCTYPE");
     }
 }

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/grpc/CorrelationStreamProcessorTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/grpc/CorrelationStreamProcessorTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.aviator.grpc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.fortify.cli.aviator.dast.DastIssue;
+import com.fortify.cli.aviator.fpr.Vulnerability;
+
+class CorrelationStreamProcessorTest {
+
+    @Test
+    void buildCorrelationWorkItemsPreservesDastSessionUrlEncounterOrder() throws Exception {
+        CorrelationStreamProcessor processor = new CorrelationStreamProcessor(null, null, null, null, 0, 0);
+        CorrelationStreamProcessor.CorrelationBucketData bucket = createBucket(
+            "SQL Injection",
+            List.of("https://example.com/z", "https://example.com/login", "https://example.com/z", "https://example.com/a")
+        );
+
+        List<?> items = invokeBuildCorrelationWorkItems(processor, List.of(bucket));
+
+        assertEquals(1, items.size());
+        assertIterableEquals(
+            List.of("https://example.com/z", "https://example.com/login", "https://example.com/a"),
+            getDastUrls(items.get(0))
+        );
+    }
+
+    @Test
+    void buildUrlToDastMapPreservesUrlEncounterOrder() throws Exception {
+        CorrelationStreamProcessor processor = new CorrelationStreamProcessor(null, null, null, null, 0, 0);
+        CorrelationStreamProcessor.CorrelationBucketData bucket = createBucket(
+            "SQL Injection",
+            List.of("https://example.com/z", "https://example.com/login", "https://example.com/z", "https://example.com/a")
+        );
+
+        Map<String, List<DastIssue>> urlMap = invokeBuildUrlToDastMap(processor, List.of(bucket));
+
+        assertIterableEquals(
+            List.of("https://example.com/z", "https://example.com/login", "https://example.com/a"),
+            urlMap.keySet()
+        );
+    }
+
+    private CorrelationStreamProcessor.CorrelationBucketData createBucket(String category, List<String> sessionUrls) {
+        List<DastIssue> dastIssues = sessionUrls.stream()
+            .map(this::createDastIssue)
+            .toList();
+        Vulnerability vulnerability = Vulnerability.builder().instanceID("SAST-1").build();
+        return new CorrelationStreamProcessor.CorrelationBucketData(category, List.of(vulnerability), dastIssues);
+    }
+
+    private DastIssue createDastIssue(String sessionUrl) {
+        DastIssue issue = new DastIssue();
+        issue.setId(sessionUrl);
+        issue.setSessionUrl(sessionUrl);
+        return issue;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<?> invokeBuildCorrelationWorkItems(CorrelationStreamProcessor processor, List<?> mixedBuckets)
+            throws Exception {
+        Method method = CorrelationStreamProcessor.class.getDeclaredMethod("buildCorrelationWorkItems", List.class);
+        method.setAccessible(true);
+        return (List<?>) method.invoke(processor, mixedBuckets);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, List<DastIssue>> invokeBuildUrlToDastMap(CorrelationStreamProcessor processor, List<?> mixedBuckets)
+            throws Exception {
+        Method method = CorrelationStreamProcessor.class.getDeclaredMethod("buildUrlToDastMap", List.class);
+        method.setAccessible(true);
+        return (Map<String, List<DastIssue>>) method.invoke(processor, mixedBuckets);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> getDastUrls(Object workItem) throws Exception {
+        Method method = workItem.getClass().getDeclaredMethod("dastUrls");
+        method.setAccessible(true);
+        return (List<String>) method.invoke(workItem);
+    }
+}

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/util/FprHandleTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/util/FprHandleTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.aviator.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.fortify.cli.aviator._common.exception.AviatorTechnicalException;
+
+@DisplayName("FprHandle")
+class FprHandleTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    @DisplayName("parses simple index XML without DOCTYPE")
+    void parsesSimpleIndexXmlWithoutDoctype() throws Exception {
+        Path fprPath = createFpr("""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <index>
+                <entry key="Test.java">src-archive/Test.java</entry>
+            </index>
+            """);
+
+        try (FprHandle handle = new FprHandle(fprPath)) {
+            assertEquals("src-archive/Test.java", handle.getSourceFileMap().get("Test.java"));
+        }
+    }
+
+    @Test
+    @DisplayName("parses Java properties XML with the standard DOCTYPE")
+    void parsesPropertiesXmlWithStandardDoctype() throws Exception {
+        Path fprPath = createFpr("""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+            <properties>
+                <comment>Fortify Source Archive Index V1.0</comment>
+                <entry key="Test.java">src-archive/Test.java</entry>
+            </properties>
+            """);
+
+        try (FprHandle handle = new FprHandle(fprPath)) {
+            assertEquals("src-archive/Test.java", handle.getSourceFileMap().get("Test.java"));
+        }
+    }
+
+    @Test
+    @DisplayName("parses Java properties XML with the standard DOCTYPE split across lines")
+    void parsesPropertiesXmlWithMultilineStandardDoctype() throws Exception {
+        Path fprPath = createFpr("""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE properties
+              SYSTEM "http://java.sun.com/dtd/properties.dtd">
+            <properties>
+                <comment>Fortify Source Archive Index V1.0</comment>
+                <entry key="Test.java">src-archive/Test.java</entry>
+            </properties>
+            """);
+
+        try (FprHandle handle = new FprHandle(fprPath)) {
+            assertEquals("src-archive/Test.java", handle.getSourceFileMap().get("Test.java"));
+        }
+    }
+
+    @Test
+    @DisplayName("rejects unsupported external DOCTYPE declarations")
+    void rejectsUnsupportedExternalDoctypeDeclarations() throws Exception {
+        Path fprPath = createFpr("""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE properties SYSTEM "http://example.com/properties.dtd">
+            <properties>
+                <entry key="Test.java">src-archive/Test.java</entry>
+            </properties>
+            """);
+
+        AviatorTechnicalException exception = assertThrows(AviatorTechnicalException.class, () -> new FprHandle(fprPath));
+
+        assertTrue(exception.getCause() instanceof IOException);
+        assertTrue(exception.getCause().getMessage().contains("unsupported DOCTYPE declaration"));
+    }
+
+    @Test
+    @DisplayName("rejects internal entity declarations in properties XML")
+    void rejectsInternalEntityDeclarations() throws Exception {
+        Path fprPath = createFpr("""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE properties [
+                <!ENTITY bomb "boom">
+            ]>
+            <properties>
+                <entry key="Test.java">&bomb;</entry>
+            </properties>
+            """);
+
+        AviatorTechnicalException exception = assertThrows(AviatorTechnicalException.class, () -> new FprHandle(fprPath));
+
+        assertTrue(exception.getCause() instanceof IOException);
+        assertTrue(exception.getCause().getMessage().contains("ENTITY declarations"));
+    }
+
+    private Path createFpr(String indexXml) throws IOException {
+        Path fprPath = tempDir.resolve("test.fpr");
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(Files.newOutputStream(fprPath))) {
+            writeEntry(zipOutputStream, "src-archive/index.xml", indexXml);
+            writeEntry(zipOutputStream, "src-archive/Test.java", "public class Test {}\n");
+        }
+        return fprPath;
+    }
+
+    private void writeEntry(ZipOutputStream zipOutputStream, String entryName, String content) throws IOException {
+        zipOutputStream.putNextEntry(new ZipEntry(entryName));
+        zipOutputStream.write(content.getBytes(StandardCharsets.UTF_8));
+        zipOutputStream.closeEntry();
+    }
+}

--- a/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/helper/AviatorSSCCorrelateFprParser.java
+++ b/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/helper/AviatorSSCCorrelateFprParser.java
@@ -58,9 +58,6 @@ public final class AviatorSSCCorrelateFprParser {
     public static ParseResult parseSastFpr(Path sastfpr) {
         try (FprHandle fprHandle = new FprHandle(sastfpr)) {
             fprHandle.validate();
-            if (!Files.exists(fprHandle.getPath("/audit.xml"))) {
-                throw new FcliSimpleException("SAST FPR does not contain audit.xml");
-            }
             AuditProcessor auditProcessor = new AuditProcessor(fprHandle);
             Map<String, AuditIssue> auditIssueMap = auditProcessor.processAuditXML();
             StreamingFVDLProcessor fvdlProcessor = new StreamingFVDLProcessor(fprHandle);
@@ -90,9 +87,6 @@ public final class AviatorSSCCorrelateFprParser {
         try (FprHandle fprHandle = new FprHandle(dastfpr)) {
             if (!Files.exists(fprHandle.getPath("/webinspect.xml"))) {
                 throw new FcliSimpleException("DAST FPR does not contain webinspect.xml");
-            }
-            if (!Files.exists(fprHandle.getPath("/audit.xml"))) {
-                throw new FcliSimpleException("DAST FPR does not contain audit.xml");
             }
             AuditProcessor auditProcessor = new AuditProcessor(fprHandle);
             Map<String, AuditIssue> auditIssueMap = auditProcessor.processAuditXML();

--- a/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/helper/CategoryGrouper.java
+++ b/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/helper/CategoryGrouper.java
@@ -13,7 +13,7 @@
 package com.fortify.cli.aviator.ssc.helper;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -30,7 +30,7 @@ public class CategoryGrouper {
 
     private static final Logger LOG = LoggerFactory.getLogger(CategoryGrouper.class);
 
-    private final Map<String, CategoryBucket> buckets = new HashMap<>();
+    private final Map<String, CategoryBucket> buckets = new LinkedHashMap<>();
 
     /**
      * Groups all SAST and DAST findings by their category.

--- a/fcli-core/fcli-aviator/src/test/java/com/fortify/cli/aviator/ssc/helper/AviatorSSCCorrelateFprParserTest.java
+++ b/fcli-core/fcli-aviator/src/test/java/com/fortify/cli/aviator/ssc/helper/AviatorSSCCorrelateFprParserTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.aviator.ssc.helper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AviatorSSCCorrelateFprParserTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void parseSastFprAllowsMissingAuditXml() throws Exception {
+        Path fprPath = createMinimalSastFpr(false);
+
+        AviatorSSCCorrelateFprParser.ParseResult result = AviatorSSCCorrelateFprParser.parseSastFpr(fprPath);
+
+        assertEquals(1, result.vulnerabilities.size());
+        assertNotNull(result.auditIssueMap);
+        assertTrue(result.auditIssueMap.isEmpty());
+    }
+
+    @Test
+    void parseDastFprAllowsMissingAuditXml() throws Exception {
+        Path fprPath = createMinimalDastFpr(true, false);
+
+        AviatorSSCCorrelateFprParser.ParseResult result = AviatorSSCCorrelateFprParser.parseDastFpr(fprPath);
+
+        assertEquals(1, result.dastIssues.size());
+        assertNotNull(result.auditIssueMap);
+        assertTrue(result.auditIssueMap.isEmpty());
+        assertEquals("Injection", result.dastIssues.get(0).getCategory());
+    }
+
+    @Test
+    void parseDastFprPreservesNullCategoryWhen7pkCategoryIsMissing() throws Exception {
+        Path fprPath = createMinimalDastFpr(false, false);
+
+        AviatorSSCCorrelateFprParser.ParseResult result = AviatorSSCCorrelateFprParser.parseDastFpr(fprPath);
+
+        assertEquals(1, result.dastIssues.size());
+        assertNull(result.dastIssues.get(0).getCategory());
+        assertEquals("SQL Injection", result.dastIssues.get(0).getName());
+    }
+
+    private Path createMinimalSastFpr(boolean includeAuditXml) throws Exception {
+        Path fprPath = tempDir.resolve(includeAuditXml ? "sast-with-audit.fpr" : "sast-no-audit.fpr");
+        if (Files.exists(fprPath)) {
+            Files.delete(fprPath);
+        }
+
+        try (FileSystem zipFs = FileSystems.newFileSystem(fprPath, Map.of("create", "true"))) {
+            Files.writeString(zipFs.getPath("/audit.fvdl"), minimalAuditFvdl(), StandardCharsets.UTF_8);
+            Files.createDirectories(zipFs.getPath("/src-archive"));
+            Files.writeString(zipFs.getPath("/src-archive/index.xml"), indexXml(), StandardCharsets.UTF_8);
+            Files.writeString(zipFs.getPath("/src-archive/Test.java"), "class Test {}\n", StandardCharsets.UTF_8);
+            if (includeAuditXml) {
+                Files.writeString(zipFs.getPath("/audit.xml"), minimalAuditXml(), StandardCharsets.UTF_8);
+            }
+        }
+
+        return fprPath;
+    }
+
+    private Path createMinimalDastFpr(boolean includeCategory, boolean includeAuditXml) throws Exception {
+        Path fprPath = tempDir.resolve(includeAuditXml ? "dast-with-audit.fpr" : "dast-no-audit.fpr");
+        if (Files.exists(fprPath)) {
+            Files.delete(fprPath);
+        }
+
+        try (FileSystem zipFs = FileSystems.newFileSystem(fprPath, Map.of("create", "true"))) {
+            Files.writeString(zipFs.getPath("/webinspect.xml"), webInspectXml(includeCategory), StandardCharsets.UTF_8);
+            if (includeAuditXml) {
+                Files.writeString(zipFs.getPath("/audit.xml"), minimalAuditXml(), StandardCharsets.UTF_8);
+            }
+        }
+
+        return fprPath;
+    }
+
+    private String minimalAuditFvdl() {
+        return """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <FVDL>
+              <Vulnerabilities>
+                <Vulnerability>
+                  <ClassInfo>
+                    <ClassID>RULE-1</ClassID>
+                    <Kingdom>Dataflow</Kingdom>
+                    <Type>Cross-Site Scripting</Type>
+                    <Subtype>Reflected</Subtype>
+                    <AnalyzerName>Dataflow</AnalyzerName>
+                    <DefaultSeverity>3.0</DefaultSeverity>
+                  </ClassInfo>
+                  <InstanceInfo>
+                    <InstanceID>instance-1</InstanceID>
+                    <InstanceSeverity>3.0</InstanceSeverity>
+                    <Confidence>4.0</Confidence>
+                  </InstanceInfo>
+                </Vulnerability>
+              </Vulnerabilities>
+            </FVDL>
+            """;
+    }
+
+    private String minimalAuditXml() {
+        return """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Audit xmlns="xmlns://www.fortify.com/schema/audit">
+              <ProjectInfo>
+                <Name>TestProject</Name>
+              </ProjectInfo>
+              <IssueList/>
+            </Audit>
+            """;
+    }
+
+    private String indexXml() {
+        return """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <index>
+                <entry key="Test.java">src-archive/Test.java</entry>
+            </index>
+            """;
+    }
+
+    private String webInspectXml(boolean includeCategory) {
+        String categoryClassification = includeCategory
+                ? "<Classification kind=\"7PK Category\">Injection</Classification>"
+                : "";
+        return """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ScanResults>
+                <Session requestId="REQ-1">
+                    <URL>https://example.test/login</URL>
+                    <Issues>
+                        <Issue id="DAST-1">
+                            <CheckTypeID>1001</CheckTypeID>
+                            <EngineType>WebInspect</EngineType>
+                            <VulnerabilityID>WI-1001</VulnerabilityID>
+                            <Severity>4</Severity>
+                            <Name>SQL Injection</Name>
+                            <Classifications>
+                                %s
+                                <Classification kind="CWE" identifier="89">Improper Neutralization</Classification>
+                            </Classifications>
+                            <ReproSteps>
+                                <ReproStep>
+                                    <Url>https://example.test/login</Url>
+                                </ReproStep>
+                            </ReproSteps>
+                            <ReportSection>
+                                <Name>Summary</Name>
+                                <SectionText><![CDATA[Unsanitized user input reaches the SQL query.]]></SectionText>
+                            </ReportSection>
+                        </Issue>
+                    </Issues>
+                </Session>
+            </ScanResults>
+            """.formatted(categoryClassification);
+    }
+}

--- a/fcli-core/fcli-aviator/src/test/java/com/fortify/cli/aviator/ssc/helper/AviatorSSCCorrelateHelperTest.java
+++ b/fcli-core/fcli-aviator/src/test/java/com/fortify/cli/aviator/ssc/helper/AviatorSSCCorrelateHelperTest.java
@@ -14,7 +14,6 @@ package com.fortify.cli.aviator.ssc.helper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -63,7 +62,9 @@ class AviatorSSCCorrelateHelperTest {
         assertEquals(4, correlate.get("succeeded").asInt());
         assertEquals(1, correlate.get("skipped").asInt());
         assertEquals(2, correlate.get("correlated").asInt());
-        assertNotNull(correlate.get("message").asText());
+        assertEquals(
+            "5 SAST findings submitted, 2 correlated pairs confirmed",
+            correlate.get("message").asText());
     }
 
     @Test

--- a/fcli-core/fcli-aviator/src/test/java/com/fortify/cli/aviator/ssc/helper/CategoryGrouperTest.java
+++ b/fcli-core/fcli-aviator/src/test/java/com/fortify/cli/aviator/ssc/helper/CategoryGrouperTest.java
@@ -13,6 +13,7 @@
 package com.fortify.cli.aviator.ssc.helper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -151,6 +152,26 @@ class CategoryGrouperTest {
         var mixedBucket = grouper.getMixedBuckets().get(0);
         assertEquals(2, mixedBucket.getSastCount());
         assertEquals(1, mixedBucket.getDastCount());
+    }
+
+    @Test
+    void testGroupFindings_preservesMixedBucketEncounterOrder() {
+        var grouper = new CategoryGrouper();
+        List<Vulnerability> sast = List.of(
+            createVuln("INST-1", "Path Traversal", null),
+            createVuln("INST-2", "SQL Injection", null)
+        );
+        List<DastIssue> dast = List.of(
+            createDastIssue("DAST-1", "Path Traversal"),
+            createDastIssue("DAST-2", "SQL Injection")
+        );
+
+        grouper.groupFindings(sast, dast);
+
+        assertIterableEquals(
+            List.of("Path Traversal", "SQL Injection"),
+            grouper.getMixedBuckets().stream().map(CategoryBucket::getCategory).toList()
+        );
     }
 
     @Test


### PR DESCRIPTION
Improve Aviator correlation stability and reduce noisy runtime behavior in the SSC correlation flow.

## Changes

- preserve deterministic correlation ordering for DAST URL candidates and category buckets
- harden FPR `src-archive/index.xml` parsing
- relax correlation parser requirements so correlation can continue when `audit.xml` is missing
- preserve missing DAST categories in the correlation parse path instead of synthesizing fallback values
- downgrade the semaphore timeout message from `WARN` to `DEBUG` so normal backpressure does not look like a failure