### PR TITLE
chore: fix --exclude-filter in bulkcorrelate action

### DIFF
--- a/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/actions/zip/bulkcorrelate.yaml
+++ b/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/actions/zip/bulkcorrelate.yaml
@@ -172,6 +172,8 @@ steps:
   - if: ${candidate_versions != null && candidate_versions.size() > 0 && cli['exclude-filter'] != ''}
     do:
       - log.progress: Resolving exclusion filter scope...
+      - var.set:
+          excluded_version_lookup: null
       - rest.call:
           excluded_versions:
             uri: /api/v1/issueaging
@@ -183,7 +185,7 @@ steps:
               record.var-name: excluded_version
               do:
                 - var.set:
-                    excluded_ids..: ${excluded_version.id}
+                    excluded_version_lookup.${excluded_version.id}: true
 
       - var.set:
           filtered_versions: null
@@ -195,7 +197,7 @@ steps:
           do:
             - var.set:
                 should_exclude: false
-            - if: ${excluded_ids != null && excluded_ids.contains(candidate.id)}
+            - if: ${excluded_version_lookup != null && excluded_version_lookup[candidate.id.toString()] != null}
               var.set:
                 should_exclude: true
             - if: ${should_exclude}


### PR DESCRIPTION
Fix the `bulkcorrelate` action so `--exclude-filter` actually removes matching SSC application versions from the correlation candidate set.

## What changed
Replace the exclusion membership check with an ID-keyed lookup built from the `issueaging` exclusion results.

The previous implementation collected excluded IDs in an array and used `contains()` when filtering candidates. In `bulkcorrelate`, that comparison was not reliable for the candidate and exclusion record shapes returned by the action flow, so excluded versions could still be processed.