### PR TITLE
ci: update release-please-action from v4 to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v6
       - name: PROD - Prepare GitHub release
         id: create_prod_release
-        uses: fortify/3rdparty-actions/actions/googleapis/release-please-action/v4@main
+        uses: fortify/3rdparty-actions/actions/googleapis/release-please-action/v5@main
         if: contains(github.ref, 'refs/heads/rel/')
         with:
           skip-github-pull-request: true
@@ -372,7 +372,7 @@ jobs:
           
       - name: PROD - Prepare release PR
         if: contains(github.ref, 'refs/heads/rel/')
-        uses: fortify/3rdparty-actions/actions/googleapis/release-please-action/v4@main
+        uses: fortify/3rdparty-actions/actions/googleapis/release-please-action/v5@main
         with:
           skip-github-release: true
           target-branch: ${{ github.ref_name }}


### PR DESCRIPTION
Updates the `googleapis/release-please-action` reference in the CI workflow from `v4` to `v5`.