### PR TITLE
feat: Implement admin session validation in Aviator gRPC client

### DIFF
--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/grpc/AviatorGrpcClient.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/grpc/AviatorGrpcClient.java
@@ -36,6 +36,7 @@ import com.fortify.aviator.application.GetApplicationByTokenRequest;
 import com.fortify.aviator.application.GetDefaultQuotaRequest;
 import com.fortify.aviator.application.GetDefaultQuotaResponse;
 import com.fortify.aviator.application.UpdateApplicationRequest;
+import com.fortify.aviator.application.ValidateAdminSessionRequest;
 import com.fortify.aviator.dastentitlement.DastEntitlement;
 import com.fortify.aviator.dastentitlement.DastEntitlementServiceGrpc;
 import com.fortify.aviator.dastentitlement.ListDastEntitlementsByTenantRequest;
@@ -212,6 +213,19 @@ public class AviatorGrpcClient implements AutoCloseable {
             ApplicationServiceGrpc.ApplicationServiceBlockingStub::getDefaultQuota,
             request, Constants.OP_GET_DEFAULT_QUOTA);
         return response.getDefaultQuota();
+    }
+
+    public void validateAdminSession(String tenantName, String signature, String message) {
+        ValidateAdminSessionRequest request = ValidateAdminSessionRequest.newBuilder()
+            .setTenantName(tenantName)
+            .setSignature(signature)
+            .setMessage(message)
+            .build();
+        GrpcUtil.executeGrpcCall(
+            blockingStub,
+            ApplicationServiceGrpc.ApplicationServiceBlockingStub::validateAdminSession,
+            request,
+            Constants.OP_VALIDATE_ADMIN_SESSION);
     }
 
     public List<Application> listApplication(String tenantName, String signature, String message) {

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/util/Constants.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/util/Constants.java
@@ -72,6 +72,7 @@ public class Constants {
     public static final String OP_DELETE_TOKEN = "deleting token";
     public static final String OP_VALIDATE_TOKEN = "validating token";
     public static final String OP_VALIDATE_USER_TOKEN = "validating user token";
+    public static final String OP_VALIDATE_ADMIN_SESSION = "admin session validation";
     public static final String OP_LIST_ENTITLEMENTS = "listing entitlements";
     public static final String OP_LIST_DAST_ENTITLEMENTS = "listing DAST entitlements";
     public static final String OP_GET_APP_BY_TOKEN = "retrieving application by token";

--- a/fcli-core/fcli-aviator-common/src/main/proto/Application.proto
+++ b/fcli-core/fcli-aviator-common/src/main/proto/Application.proto
@@ -53,6 +53,12 @@ message ApplicationByTenantName {
   string message = 3;
 }
 
+message ValidateAdminSessionRequest {
+  string tenantName = 1;
+  string signature = 2;
+  string message = 3;
+}
+
 message ApplicationList {
   repeated Application applications = 1;
 }
@@ -83,6 +89,7 @@ service ApplicationService {
   rpc UpdateApplication(UpdateApplicationRequest) returns (Application) {}
   rpc AddEntitlement(ApplicationById) returns (Application) {}
   rpc DeleteApplication(ApplicationById) returns (ApplicationResponseMessage) {}
+  rpc ValidateAdminSession(ValidateAdminSessionRequest) returns (google.protobuf.Empty) {}
   rpc ListApplications(ApplicationByTenantName) returns (ApplicationList) {}
   rpc ListApplicationsByEntitlement(ApplicationById) returns (ApplicationList) {}
   rpc GetApplicationByToken(GetApplicationByTokenRequest) returns (Application) {}

--- a/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/_common/config/admin/cli/cmd/AviatorAdminConfigCreateCommand.java
+++ b/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/_common/config/admin/cli/cmd/AviatorAdminConfigCreateCommand.java
@@ -12,6 +12,9 @@
  */
 package com.fortify.cli.aviator._common.config.admin.cli.cmd;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fortify.cli.aviator._common.config.admin.cli.mixin.AviatorAdminConfigCreateOptions;
 import com.fortify.cli.aviator._common.config.admin.cli.mixin.AviatorAdminConfigNameArgGroup;
 import com.fortify.cli.aviator._common.config.admin.helper.AviatorAdminConfigDescriptor;
@@ -27,6 +30,8 @@ import picocli.CommandLine.Mixin;
 
 @Command(name = OutputHelperMixins.Create.CMD_NAME, sortOptions = false)
 public class AviatorAdminConfigCreateCommand extends AbstractSessionLoginCommand<AviatorAdminConfigDescriptor> {
+    private static final Logger LOG = LoggerFactory.getLogger(AviatorAdminConfigCreateCommand.class);
+
     @Mixin @Getter private OutputHelperMixins.Create outputHelper;
     @Getter private AviatorAdminConfigHelper configHelper = AviatorAdminConfigHelper.instance();
     @Mixin private AviatorAdminConfigCreateOptions configCreateOptions = new AviatorAdminConfigCreateOptions();
@@ -45,7 +50,14 @@ public class AviatorAdminConfigCreateCommand extends AbstractSessionLoginCommand
     @Override
     protected AviatorAdminConfigDescriptor login(String configName) {
         String privateKeyContents = configCreateOptions.getPrivateKeyResolver().getPrivateKeyContents();
-        return new AviatorAdminConfigDescriptor(configCreateOptions.getAviatorUrl(), configCreateOptions.getTenant(), privateKeyContents);
+        AviatorAdminConfigDescriptor configDescriptor = new AviatorAdminConfigDescriptor(
+                configCreateOptions.getAviatorUrl(),
+                configCreateOptions.getTenant(),
+                privateKeyContents);
+        LOG.info("Validating Aviator admin configuration with the Aviator server...");
+        configHelper.validateConfig(configDescriptor);
+        LOG.info("Aviator admin configuration validated successfully.");
+        return configDescriptor;
     }
 
     @Override

--- a/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/_common/config/admin/helper/AviatorAdminConfigHelper.java
+++ b/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/_common/config/admin/helper/AviatorAdminConfigHelper.java
@@ -12,6 +12,9 @@
  */
 package com.fortify.cli.aviator._common.config.admin.helper;
 
+import com.fortify.cli.aviator._common.util.AviatorSignatureUtils;
+import com.fortify.cli.aviator.grpc.AviatorGrpcClient;
+import com.fortify.cli.aviator.grpc.AviatorGrpcClientHelper;
 import com.fortify.cli.common.session.helper.AbstractSessionHelper;
 
 public class AviatorAdminConfigHelper extends AbstractSessionHelper<AviatorAdminConfigDescriptor> {
@@ -32,6 +35,15 @@ public class AviatorAdminConfigHelper extends AbstractSessionHelper<AviatorAdmin
     @Override
     protected Class<AviatorAdminConfigDescriptor> getSessionDescriptorType() {
         return AviatorAdminConfigDescriptor.class;
+    }
+
+    public void validateConfig(AviatorAdminConfigDescriptor configDescriptor) {
+        try (AviatorGrpcClient client = AviatorGrpcClientHelper.createClient(configDescriptor.getAviatorUrl())) {
+            String[] messageAndSignature = AviatorSignatureUtils.createMessageAndSignature(configDescriptor, configDescriptor.getTenant());
+            String message = messageAndSignature[0];
+            String signature = messageAndSignature[1];
+            client.validateAdminSession(configDescriptor.getTenant(), signature, message);
+        }
     }
 
     public static final AviatorAdminConfigHelper instance() {

--- a/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/_common/util/AviatorSignatureUtils.java
+++ b/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/_common/util/AviatorSignatureUtils.java
@@ -21,15 +21,12 @@ import com.fortify.cli.aviator._common.config.admin.helper.AviatorAdminConfigDes
 import com.fortify.cli.common.crypto.helper.SignatureHelper;
 import com.fortify.cli.common.exception.FcliSimpleException;
 
-import lombok.SneakyThrows;
-
 public class AviatorSignatureUtils {
     public static String createMessage(String... params) {
         String timestamp = ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
         return String.join(";", params) + ";" + timestamp;
     }
 
-    @SneakyThrows
     public static String createSignature(String message, AviatorAdminConfigDescriptor configDescriptor) {
         String privateKeyContent = configDescriptor.getPrivateKeyContents();
         if (privateKeyContent == null) {
@@ -38,7 +35,9 @@ public class AviatorSignatureUtils {
         try {
             return SignatureHelper.signer(privateKeyContent, (char[]) null).sign(message, StandardCharsets.UTF_8);
         } catch (Exception e) {
-            throw new RuntimeException("Failed to generate signature using resolved private key", e);
+            throw new FcliSimpleException(
+                    "Unable to sign the Aviator admin request with the provided private key. Verify that --private-key points to a valid PEM private key",
+                    e);
         }
     }
 


### PR DESCRIPTION
This PR adds a dedicated validateAdminSession gRPC endpoint and updates `fcli aviator admin-config create` to use it for server-side validation before saving an admin config. 