### PR TITLE
chore: Align Aviator exception handling with Aviator simple/technical exceptions

### DIFF
--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/model/Priority.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/model/Priority.java
@@ -12,6 +12,7 @@
  */
 package com.fortify.cli.aviator.audit.model;
 
+import com.fortify.cli.aviator._common.exception.AviatorSimpleException;
 
 public enum Priority {
     Critical,
@@ -21,13 +22,13 @@ public enum Priority {
 
     public static Priority fromString(String value) {
         if (value == null) {
-            throw new IllegalArgumentException("Priority value cannot be null.");
+            throw new AviatorSimpleException("Priority value cannot be null.");
         }
         for (Priority p : values()) {
             if (p.name().equalsIgnoreCase(value)) {
                 return p;
             }
         }
-        throw new IllegalArgumentException("No Priority constant with name '" + value + "' found.");
+        throw new AviatorSimpleException("No Priority constant with name '" + value + "' found.");
     }
 }

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/filter/comparer/NumberRangeComparer.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/filter/comparer/NumberRangeComparer.java
@@ -18,6 +18,8 @@ import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fortify.cli.aviator._common.exception.AviatorSimpleException;
+
 public class NumberRangeComparer implements SearchComparer {
     private static final Logger logger = LoggerFactory.getLogger(NumberRangeComparer.class);
 
@@ -35,7 +37,7 @@ public class NumberRangeComparer implements SearchComparer {
 
         String trimmed = rangeTerm.trim();
         if (trimmed.length() < 3) { // Must be at least 3 chars like (1,2)
-            throw new IllegalArgumentException("Invalid range format: " + rangeTerm);
+            throw new AviatorSimpleException("Invalid range format: " + rangeTerm);
         }
 
         // Determine inclusiveness from the start and end characters
@@ -52,7 +54,7 @@ public class NumberRangeComparer implements SearchComparer {
         }
 
         if (sep == -1) {
-            throw new IllegalArgumentException("Invalid range format (missing separator ',' or '-'): " + rangeTerm);
+            throw new AviatorSimpleException("Invalid range format (missing separator ',' or '-'): " + rangeTerm);
         }
 
         try {
@@ -60,7 +62,7 @@ public class NumberRangeComparer implements SearchComparer {
             this.upperBound = new BigDecimal(inner.substring(sep + 1).trim());
         } catch (NumberFormatException e) {
             logger.error("Error parsing number in range term '{}'", rangeTerm, e);
-            throw new IllegalArgumentException("Invalid number in range format: " + rangeTerm);
+            throw new AviatorSimpleException("Invalid number in range format: " + rangeTerm, e);
         }
     }
 

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/model/FPRInfo.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/model/FPRInfo.java
@@ -12,6 +12,7 @@
  */
 package com.fortify.cli.aviator.fpr.model;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -19,6 +20,10 @@ import java.util.Optional;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,6 +31,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
+import com.fortify.cli.aviator._common.exception.AviatorTechnicalException;
 import com.fortify.cli.aviator.fpr.filter.FilterSet;
 import com.fortify.cli.aviator.fpr.filter.FilterTemplate;
 import com.fortify.cli.aviator.util.FprHandle;
@@ -53,12 +59,7 @@ public class FPRInfo {
     public FPRInfo(FprHandle fprHandle) {
         FPRName = String.valueOf(fprHandle.getFprPath().getFileName());
         buildId = "";
-        try {
-            extractInfoFromAuditFvdlStreaming(fprHandle);
-        } catch (Exception e) {
-            // It's better to wrap this in a specific runtime exception
-            throw new RuntimeException("Failed to extract info from audit.fvdl", e);
-        }
+        extractInfoFromAuditFvdlStreaming(fprHandle);
     }
 
     /**
@@ -70,22 +71,22 @@ public class FPRInfo {
      * - Build information (BuildID, SourceBasePath, NumberFiles, ScanTime)
      *
      * @param fprHandle for getting path
-     * @throws Exception if parsing fails
+     * @throws AviatorTechnicalException if parsing fails
      */
-    private void extractInfoFromAuditFvdlStreaming(FprHandle fprHandle) throws Exception {
+    private void extractInfoFromAuditFvdlStreaming(FprHandle fprHandle) {
         Path auditPath = fprHandle.getPath("/audit.fvdl");
 
         if (!Files.exists(auditPath)) {
-            throw new IllegalStateException("audit.fvdl not found in FPR: " + fprHandle.getFprPath());
+            throw new AviatorTechnicalException("audit.fvdl not found in FPR: " + fprHandle.getFprPath());
         }
 
-        javax.xml.stream.XMLInputFactory factory = javax.xml.stream.XMLInputFactory.newInstance();
+        XMLInputFactory factory = XMLInputFactory.newInstance();
         // Security: Disable external entity processing
-        factory.setProperty(javax.xml.stream.XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
-        factory.setProperty(javax.xml.stream.XMLInputFactory.SUPPORT_DTD, false);
+        factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
 
-        try (java.io.InputStream inputStream = Files.newInputStream(auditPath)) {
-            javax.xml.stream.XMLStreamReader reader = factory.createXMLStreamReader(inputStream);
+        try (InputStream inputStream = Files.newInputStream(auditPath)) {
+            XMLStreamReader reader = factory.createXMLStreamReader(inputStream);
 
             boolean inBuild = false;
             String currentElement = null;
@@ -93,7 +94,7 @@ public class FPRInfo {
             while (reader.hasNext()) {
                 int event = reader.next();
 
-                if (event == javax.xml.stream.XMLStreamConstants.START_ELEMENT) {
+                if (event == XMLStreamConstants.START_ELEMENT) {
                     String localName = reader.getLocalName();
 
                     if ("UUID".equals(localName)) {
@@ -109,7 +110,7 @@ public class FPRInfo {
                         currentElement = localName;
                     }
 
-                } else if (event == javax.xml.stream.XMLStreamConstants.CHARACTERS && inBuild && currentElement != null) {
+                } else if (event == XMLStreamConstants.CHARACTERS && inBuild && currentElement != null) {
                     // Read text content for Build child elements
                     String text = reader.getText().trim();
                     if (!text.isEmpty()) {
@@ -129,7 +130,7 @@ public class FPRInfo {
                         }
                     }
 
-                } else if (event == javax.xml.stream.XMLStreamConstants.END_ELEMENT) {
+                } else if (event == XMLStreamConstants.END_ELEMENT) {
                     String localName = reader.getLocalName();
 
                     if ("Build".equals(localName)) {
@@ -149,8 +150,8 @@ public class FPRInfo {
 
             reader.close();
 
-        } catch (javax.xml.stream.XMLStreamException e) {
-            throw new Exception("Failed to parse audit.fvdl using streaming parser", e);
+        } catch (IOException | XMLStreamException e) {
+            throw new AviatorTechnicalException("Failed to parse audit.fvdl using streaming parser", e);
         }
 
         if (buildId == null) {
@@ -164,15 +165,15 @@ public class FPRInfo {
      *
      * @param reader XMLStreamReader positioned at START_ELEMENT
      * @return Text content of the element, or empty string if no text
-     * @throws javax.xml.stream.XMLStreamException if reading fails
+     * @throws XMLStreamException if reading fails
      */
-    private String readElementText(javax.xml.stream.XMLStreamReader reader) throws javax.xml.stream.XMLStreamException {
+    private String readElementText(XMLStreamReader reader) throws XMLStreamException {
         StringBuilder text = new StringBuilder();
         while (reader.hasNext()) {
             int event = reader.next();
-            if (event == javax.xml.stream.XMLStreamConstants.CHARACTERS) {
+            if (event == XMLStreamConstants.CHARACTERS) {
                 text.append(reader.getText());
-            } else if (event == javax.xml.stream.XMLStreamConstants.END_ELEMENT) {
+            } else if (event == XMLStreamConstants.END_ELEMENT) {
                 break;
             }
         }
@@ -183,7 +184,7 @@ public class FPRInfo {
         Path auditPath = fprHandle.getPath("/audit.fvdl");
 
         if (!Files.exists(auditPath)) {
-            throw new IllegalStateException("audit.fvdl not found in FPR: " + fprHandle.getFprPath());
+            throw new AviatorTechnicalException("audit.fvdl not found in FPR: " + fprHandle.getFprPath());
         }
 
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/AuditProcessor.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/AuditProcessor.java
@@ -915,7 +915,7 @@ public class AuditProcessor {
             byte[] digest = md.digest(content.getBytes(StandardCharsets.UTF_8));
             return Base64.getEncoder().encodeToString(digest);
         } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(algorithm + " algorithm not found", e);
+            throw new AviatorTechnicalException("Hashing algorithm not available: " + algorithm, e);
         }
     }
 

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/FilterTemplateParser.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/FilterTemplateParser.java
@@ -39,6 +39,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import com.fortify.cli.aviator._common.exception.AviatorTechnicalException;
 import com.fortify.cli.aviator.fpr.filter.Filter;
 import com.fortify.cli.aviator.fpr.filter.FilterSet;
 import com.fortify.cli.aviator.fpr.filter.FilterTemplate;
@@ -114,9 +115,11 @@ public class FilterTemplateParser {
             auditProcessor.setFilterTemplateDoc(doc);
 
             return Optional.of(filterTemplate);
+        } catch (AviatorTechnicalException e) {
+            throw e;
         } catch (Exception e) {
             logger.error("Error parsing filtertemplate.xml", e);
-            throw new RuntimeException("Failed to parse filtertemplate.xml", e);
+            throw new AviatorTechnicalException("Failed to parse filtertemplate.xml", e);
         }
     }
 
@@ -230,7 +233,7 @@ public class FilterTemplateParser {
             logger.info("Successfully saved updated filtertemplate.xml");
         } catch (Exception e) {
             logger.error("Error saving XML document: {}", e.getMessage(), e);
-            throw new RuntimeException("Failed to save XML document", e);
+            throw new AviatorTechnicalException("Failed to save XML document", e);
         }
     }
 

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/RemediationProcessor.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/RemediationProcessor.java
@@ -197,7 +197,7 @@ public class RemediationProcessor {
             hash = Base64.getEncoder().encodeToString(digest);
             return hash;
         } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(algorithm + " algorithm not found", e);
+            throw new AviatorTechnicalException("Hashing algorithm not available: " + algorithm, e);
         }
     }
 

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/filter/comparer/NumberRangeComparerTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/filter/comparer/NumberRangeComparerTest.java
@@ -18,6 +18,7 @@ import java.math.BigDecimal;
 
 import org.junit.jupiter.api.Test;
 
+import com.fortify.cli.aviator._common.exception.AviatorSimpleException;
 import com.fortify.cli.aviator.fpr.filter.comparer.NumberRangeComparer;
 import com.fortify.cli.aviator.fpr.filter.comparer.SearchComparer;
 
@@ -86,17 +87,17 @@ class NumberRangeComparerTest {
 
     @Test
     void testThrowsExceptionOnMalformedRangeMissingEnd() {
-        assertThrows(IllegalArgumentException.class, () -> new NumberRangeComparer("[1,5"));
+        assertThrows(AviatorSimpleException.class, () -> new NumberRangeComparer("[1,5"));
     }
 
     @Test
     void testThrowsExceptionOnMalformedRangeMissingStart() {
-        assertThrows(IllegalArgumentException.class, () -> new NumberRangeComparer("1,5]"));
+        assertThrows(AviatorSimpleException.class, () -> new NumberRangeComparer("1,5]"));
     }
 
     @Test
     void testThrowsExceptionOnMalformedRangeMissingSeparator() {
-        assertThrows(IllegalArgumentException.class, () -> new NumberRangeComparer("[1 5]"));
+        assertThrows(AviatorSimpleException.class, () -> new NumberRangeComparer("[1 5]"));
     }
 
 }

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/fpr/model/FPRInfoTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/fpr/model/FPRInfoTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.aviator.fpr.model;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.fortify.cli.aviator._common.exception.AviatorTechnicalException;
+import com.fortify.cli.aviator.util.FprHandle;
+
+@DisplayName("FPRInfo")
+class FPRInfoTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    @DisplayName("throws AviatorTechnicalException when audit.fvdl is missing")
+    void throwsTechnicalExceptionWhenAuditFvdlIsMissing() throws Exception {
+        Path fprPath = createFpr(null);
+
+        try (FprHandle fprHandle = new FprHandle(fprPath)) {
+            AviatorTechnicalException exception = assertThrows(AviatorTechnicalException.class, () -> new FPRInfo(fprHandle));
+
+            assertTrue(exception.getMessage().contains("audit.fvdl"));
+        }
+    }
+
+    private Path createFpr(String auditFvdlContent) throws IOException {
+        Path fprPath = tempDir.resolve("test.fpr");
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(Files.newOutputStream(fprPath))) {
+            if (auditFvdlContent != null) {
+                writeEntry(zipOutputStream, "audit.fvdl", auditFvdlContent);
+            }
+            writeEntry(zipOutputStream, "src-archive/index.xml", """
+                <?xml version=\"1.0\" encoding=\"UTF-8\"?>
+                <index>
+                    <entry key=\"Test.java\">src-archive/Test.java</entry>
+                </index>
+                """);
+            writeEntry(zipOutputStream, "src-archive/Test.java", "public class Test {}\n");
+        }
+        return fprPath;
+    }
+
+    private void writeEntry(ZipOutputStream zipOutputStream, String entryName, String content) throws IOException {
+        zipOutputStream.putNextEntry(new ZipEntry(entryName));
+        zipOutputStream.write(content.getBytes(StandardCharsets.UTF_8));
+        zipOutputStream.closeEntry();
+    }
+}

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/fpr/processor/FilterTemplateParserTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/fpr/processor/FilterTemplateParserTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.aviator.fpr.processor;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.fortify.cli.aviator._common.exception.AviatorTechnicalException;
+import com.fortify.cli.aviator.util.FprHandle;
+
+@DisplayName("FilterTemplateParser")
+class FilterTemplateParserTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    @DisplayName("throws AviatorTechnicalException on malformed filtertemplate.xml")
+    void throwsTechnicalExceptionOnMalformedFilterTemplateXml() throws Exception {
+        Path fprPath = createFpr("<FilterTemplate>");
+
+        try (FprHandle fprHandle = new FprHandle(fprPath)) {
+            FilterTemplateParser parser = new FilterTemplateParser(fprHandle, new AuditProcessor(fprHandle));
+            AviatorTechnicalException exception = assertThrows(AviatorTechnicalException.class, parser::parseFilterTemplate);
+
+            assertTrue(exception.getMessage().contains("filtertemplate.xml"));
+        }
+    }
+
+    private Path createFpr(String filterTemplateXml) throws IOException {
+        Path fprPath = tempDir.resolve("test.fpr");
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(Files.newOutputStream(fprPath))) {
+            writeEntry(zipOutputStream, "filtertemplate.xml", filterTemplateXml);
+            writeEntry(zipOutputStream, "src-archive/index.xml", """
+                <?xml version=\"1.0\" encoding=\"UTF-8\"?>
+                <index>
+                    <entry key=\"Test.java\">src-archive/Test.java</entry>
+                </index>
+                """);
+            writeEntry(zipOutputStream, "src-archive/Test.java", "public class Test {}\n");
+        }
+        return fprPath;
+    }
+
+    private void writeEntry(ZipOutputStream zipOutputStream, String entryName, String content) throws IOException {
+        zipOutputStream.putNextEntry(new ZipEntry(entryName));
+        zipOutputStream.write(content.getBytes(StandardCharsets.UTF_8));
+        zipOutputStream.closeEntry();
+    }
+}

--- a/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/_common/util/AviatorGrpcUtils.java
+++ b/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/_common/util/AviatorGrpcUtils.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fortify.cli.aviator._common.exception.AviatorTechnicalException;
 import com.fortify.cli.common.log.LogMaskHelper;
 import com.fortify.cli.common.log.LogMaskSource;
 import com.fortify.cli.common.log.LogSensitivityLevel;
@@ -41,8 +42,8 @@ public class AviatorGrpcUtils {
             ).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     public static JsonNode grpcToJsonNode(Message message) {
-        registerLogMaskFields(message);
         try {
+            registerLogMaskFields(message);
             Set<Descriptors.FieldDescriptor> allFields =
                     new HashSet<>(message.getDescriptorForType().getFields());
 
@@ -54,7 +55,7 @@ public class AviatorGrpcUtils {
             return objectMapper.readTree(jsonString);
         } catch (Exception e) {
             LOG.error("Error converting gRPC message to JSON: {}", e.getMessage(), e);
-            throw new IllegalStateException("Failed to convert gRPC message to JSON", e);
+            throw new AviatorTechnicalException("Failed to convert gRPC message to JSON", e);
         }
     }
 

--- a/fcli-core/fcli-aviator/src/test/java/com/fortify/cli/aviator/_common/util/AviatorGrpcUtilsTest.java
+++ b/fcli-core/fcli-aviator/src/test/java/com/fortify/cli/aviator/_common/util/AviatorGrpcUtilsTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.aviator._common.util;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.fortify.cli.aviator._common.exception.AviatorTechnicalException;
+
+@DisplayName("AviatorGrpcUtils")
+class AviatorGrpcUtilsTest {
+    @Test
+    @DisplayName("wraps conversion failures in AviatorTechnicalException")
+    void wrapsConversionFailuresInTechnicalException() {
+        AviatorTechnicalException exception = assertThrows(AviatorTechnicalException.class, () -> AviatorGrpcUtils.grpcToJsonNode(null));
+
+        assertTrue(exception.getMessage().contains("Failed to convert gRPC message to JSON"));
+        assertTrue(exception.getCause() instanceof NullPointerException);
+    }
+}


### PR DESCRIPTION
## Summary
- replace raw `RuntimeException` and `IllegalStateException` wrappers at Aviator technical-failure boundaries with `AviatorTechnicalException`
- use `AviatorSimpleException` for direct user/config validation failures in `Priority` and `NumberRangeComparer`
- add focused regression coverage for the changed technical-exception boundaries
- update the existing `NumberRangeComparer` test to expect `AviatorSimpleException`

## Details
This change keeps Aviator exception handling aligned with fcli conventions:

- technical failures remain technical:
  - FPR metadata parsing
  - filtertemplate.xml parse/save failures
  - hashing helper failures
  - gRPC message-to-JSON conversion failures
  - direct invalid input/config validation is surfaced as simple:
  - invalid priority values
  - malformed numeric range syntax