### PR TITLE
fix: Fix `--auto-required-attrs` default values for INTEGER and DATE attribute types

### DIFF
--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/attribute/helper/SSCAttributeUpdateBuilder.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/attribute/helper/SSCAttributeUpdateBuilder.java
@@ -12,7 +12,7 @@
  */
 package com.fortify.cli.ssc.attribute.helper;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -147,9 +147,9 @@ public final class SSCAttributeUpdateBuilder {
             return options.get(0).get("guid").asText();
         } else {
             switch ( descriptor.getType() ) {
-                case INTEGER: return null;
+                case INTEGER: return "0";
                 case BOOLEAN: return "true";
-                case DATE: return new Date().toString();
+                case DATE: return LocalDate.now().toString();
                 default: return "fcli auto-value";
             }
         }


### PR DESCRIPTION
- INTEGER: change default from null to "0"; null caused Integer.parseInt(null)
  to throw NumberFormatException, surfacing as a misleading "must be an integer" error
- DATE: change default from new Date().toString() (locale-formatted string) to
  LocalDate.now().toString() (ISO-8601 yyyy-MM-dd), which satisfies the pattern
  validation enforced by getOptionDateValue()
- Replace unused java.util.Date import with java.time.LocalDate