### PR TITLE
feat: Add `fcli fod app list-users` command to list users assigned to an application

### DIFF
--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/rest/FoDUrls.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/rest/FoDUrls.java
@@ -40,6 +40,7 @@ public class FoDUrls {
     public static final String SCAN = ApiBase + "/scans/{scanId}";
     public static final String V3_SCAN = "/api/v3scans/{scanId}";
     public static final String APP_SCANS = APPLICATION + "/scans";
+    public static final String APP_USERS = APPLICATION + "/users";
     public static final String RELEASE_SCANS = RELEASE + "/scans";
     public static final String STATIC_SCANS = ApiBase + "/releases/{relId}/static-scans";
     public static final String STATIC_SCANS_IMPORT = STATIC_SCANS + "/import-scan";

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/app/cli/cmd/FoDAppCommands.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/app/cli/cmd/FoDAppCommands.java
@@ -24,7 +24,8 @@ import picocli.CommandLine;
                 FoDAppCreateCommand.class,
                 FoDAppUpdateCommand.class,
                 FoDAppDeleteCommand.class,
-                FoDAppScanListCommand.class
+                FoDAppScanListCommand.class,
+                FoDAppUserListCommand.class
         }
 )
 @DefaultVariablePropertyName("applicationId")

--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/app/cli/cmd/FoDAppUserListCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/app/cli/cmd/FoDAppUserListCommand.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.fod.app.cli.cmd;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fortify.cli.common.cli.util.CommandGroup;
+import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
+import com.fortify.cli.common.output.transform.IInputTransformer;
+import com.fortify.cli.common.variable.DefaultVariablePropertyName;
+import com.fortify.cli.fod._common.output.cli.cmd.AbstractFoDBaseRequestOutputCommand;
+import com.fortify.cli.fod._common.rest.FoDUrls;
+import com.fortify.cli.fod.app.cli.mixin.FoDAppResolverMixin;
+
+import kong.unirest.HttpRequest;
+import kong.unirest.UnirestInstance;
+import lombok.Getter;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+
+/**
+ * Command to list users with access to an application.
+ * @author Sangamesh Vijaykumar
+ */
+@Command(name = "list-users", aliases = "lsu") @CommandGroup("user")
+@DefaultVariablePropertyName("userId")
+public class FoDAppUserListCommand extends AbstractFoDBaseRequestOutputCommand implements IInputTransformer {
+    @Getter @Mixin private OutputHelperMixins.TableWithQuery outputHelper;
+    @Mixin private FoDAppResolverMixin.RequiredOption appResolver;
+
+    @Override
+    public HttpRequest<?> getBaseRequest(UnirestInstance unirest) {
+        return unirest.get(FoDUrls.APP_USERS)
+                .routeParam("appId", appResolver.getAppId(unirest));
+    }
+
+    @Override
+    public JsonNode transformInput(JsonNode input) {
+        if ( input != null && input.has("users") ) { return input.get("users"); }
+        return input;
+    }
+
+    @Override
+    public boolean isSingular() {
+        return false;
+    }
+}

--- a/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
+++ b/fcli-core/fcli-fod/src/main/resources/com/fortify/cli/fod/i18n/FoDMessages.properties
@@ -284,6 +284,11 @@ fcli.fod.app.output.table.header.businessCriticalityType = Criticality
 fcli.fod.app.output.table.header.applicationDescription = Description
 fcli.fod.app.output.table.header.releaseName = Release
 fcli.fod.app.output.table.header.microserviceName = Microservice
+fcli.fod.app.user.output.table.header.userId = Id
+fcli.fod.app.user.output.table.header.firstName = First Name
+fcli.fod.app.user.output.table.header.lastName = Last Name
+fcli.fod.app.user.output.table.header.emailId = Email
+fcli.fod.app.user.output.table.header.roleName = Role
 
 fcli.fod.app.create.usage.header = Create a new application.
 fcli.fod.app.create.usage.description = This command allows a new application and its first release to be created. \
@@ -329,6 +334,7 @@ fcli.fod.app.update.attrs = Set of application attribute id's or names and their
 fcli.fod.app.update.auto-required-attrs = For each mandatory application attribute that does not already \
   have a value, read the default value from the server and set it automatically.
 fcli.fod.app.list-scans.usage.header = List scans for a given application.
+fcli.fod.app.list-users.usage.header = List users assigned to a given application.
 
 # fcli fod microservice
 fcli.fod.microservice.usage.header = Manage FoD application microservices.
@@ -1059,6 +1065,7 @@ fcli.fod.access-control.group.output.table.args = id,name,assignedUsersCount,ass
 fcli.fod.access-control.role.output.table.args = id,name
 fcli.fod.app.output.table.args = applicationId,applicationName,fcliApplicationType,businessCriticalityType
 fcli.fod.app.scan.output.table.args = scanId,scanType,analysisStatusType,applicationName,microserviceName,releaseName,startedDateTime,completedDateTime,scanMethodTypeName
+fcli.fod.app.user.output.table.args = userId,firstName,lastName,emailId,roleName
 fcli.fod.microservice.output.table.args = microserviceId,microserviceName,applicationName
 fcli.fod.release.output.table.args = releaseId,releaseName,microserviceName,applicationName,sdlcStatusType
 fcli.fod.release.wait-for.output.table.args = releaseId,releaseName,microserviceName,applicationName,suspended


### PR DESCRIPTION
This PR introduces a new command, `fcli fod app list-users` (alias: lsu), to retrieve and display users assigned to a given FoD application. This merge resolves #1008.

Currently, FCLI provides commands to list and manage applications but lacks visibility into user assignments for a specific application. This enhancement improves usability by enabling users to easily view application-level user access directly from the CLI.

<img width="717" height="318" alt="image" src="https://github.com/user-attachments/assets/abd53965-3786-4eb4-9fba-a3fb8c9fd53d" />


Displays user details including:
- Id
- First Name
- Last Name
- Email
- Role
<img width="891" height="41" alt="list-users-of-app-for" src="https://github.com/user-attachments/assets/fd780e93-42df-4c25-8440-83ad8b9dff77" />

**Usage Example**
`fcli fod app lsu --app <appNameOrId>`


**Sample Output**
| Id  | First Name | Last Name | Email               | Role      |
|-----|------------|-----------|----------------------|-----------|
| 123 | John       | Doe       | john.doe@test.com    | Developer |
| 456 | Jane       | Smith     | jane.smith@test.com  | Manager   


**Impact**
- Enhances FoD application management capabilities
- Provides better visibility into user assignments
- Enables easier auditing and troubleshooting of access control


**Testing**
- Verified command help output (fcli fod app -h) includes list-users
- Validated user listing for existing applications
- Tested alias (lsu) functionality
- Confirmed output formatting and data accuracy


**Notes**
- This change is fully backwards-compatible
- No impact on existing commands