### PR TITLE
fix: Make user option non-mandatory in FOD issue update command

### DIFF
--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/issue/cli/cmd/FoDIssueUpdateCommand.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/issue/cli/cmd/FoDIssueUpdateCommand.java
@@ -57,7 +57,7 @@ public class FoDIssueUpdateCommand extends AbstractFoDJsonNodeOutputCommand impl
     @Mixin private FoDReleaseByQualifiedNameOrIdResolverMixin.RequiredOption releaseResolver;
     @Mixin private FoDAttributeUpdateOptions.OptionalAttrOption issueAttrsUpdate;
 
-    @Option(names = {"--user"}, required = true)
+    @Option(names = {"--user"}, required = false)
     protected String user;
     @Option(names = {"--dev-status"}, required = false)
     protected String developerStatus;


### PR DESCRIPTION
This PR updates the FoD issue update command by making the user option optional (mandatory = false) to align with the FOD portal behavior, where this field is not mandatory when updating an issue.