### PR TITLE
Add Scan Central Dast attribute in ssc attribute list definition command

### DIFF
--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/attribute/cli/cmd/SSCAttributeDefinitionListCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/attribute/cli/cmd/SSCAttributeDefinitionListCommand.java
@@ -30,6 +30,7 @@ import picocli.CommandLine.Mixin;
 
 @Command(name = OutputHelperMixins.ListDefinitions.CMD_NAME) @CommandGroup("definition")
 public class SSCAttributeDefinitionListCommand extends AbstractSSCBaseRequestOutputCommand implements IServerSideQueryParamGeneratorSupplier {
+    private static final String EXTRA_ATTRIBUTE_CATEGORIES = "SCANCENTRAL_DAST";
     @Getter @Mixin private OutputHelperMixins.ListDefinitions outputHelper; 
     @Mixin private SSCFetchRangeMixin fetchRangeMixin;
     @Mixin private SSCQParamMixin qParamMixin;
@@ -43,7 +44,8 @@ public class SSCAttributeDefinitionListCommand extends AbstractSSCBaseRequestOut
 
     @Override
     public HttpRequest<?> getBaseRequest(UnirestInstance unirest) {
-        return unirest.get("/api/v1/attributeDefinitions?orderby=category,name");
+        return unirest.get("/api/v1/attributeDefinitions?orderby=category,name")
+                .queryString("extraCategories", EXTRA_ATTRIBUTE_CATEGORIES);
     }
     
     @Override

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/attribute/helper/SSCAttributeDefinitionHelper.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/attribute/helper/SSCAttributeDefinitionHelper.java
@@ -40,6 +40,7 @@ import lombok.Getter;
  */
 // TODO Properly embed option handling/retrieval in SSCAttributeDefinitionDescriptor
 public final class SSCAttributeDefinitionHelper {
+    private static final String EXTRA_ATTRIBUTE_CATEGORIES = "SCANCENTRAL_DAST";
     private final Set<String> attrDuplicateNames = new HashSet<>();
     private final Set<SSCAttributeDefinitionDescriptor> requiredAttrDefWithoutDefaultValueDescriptors = new HashSet<>();
     private final Map<String, SSCAttributeDefinitionDescriptor> descriptorsById = new HashMap<>();
@@ -70,7 +71,8 @@ public final class SSCAttributeDefinitionHelper {
      * an SSC bulk request.
      */
     public static final HttpRequest<?> getAttributeDefinitionsRequest(UnirestInstance unirest) {
-        return unirest.get("/api/v1/attributeDefinitions?limit=-1&orderby=category,name&fields=id,guid,name,category,type,required,hidden,hasDefault,options");
+        return unirest.get("/api/v1/attributeDefinitions?limit=-1&orderby=category,name&fields=id,guid,name,category,type,required,hidden,hasDefault,options")
+                .queryString("extraCategories", EXTRA_ATTRIBUTE_CATEGORIES);
     }
     
     /**


### PR DESCRIPTION
This change adds support for retrieving ScanCentral DAST attributes from SSC by including the required `extraCategories` parameter in the attributes API request. As a result, `ssc attr lsd` now lists ScanCentral DAST attributes, and applications created using these attributes are populated correctly.

fix: Add Scan Central Dast attribute in ssc attribute list definition command