### PR TITLE
Aviator auto-remediation Fix

### DIFF
--- a/fcli-core/fcli-app/src/main/resources/META-INF/native-image/fcli/fcli-app/static/native-image.properties
+++ b/fcli-core/fcli-app/src/main/resources/META-INF/native-image/fcli/fcli-app/static/native-image.properties
@@ -8,4 +8,5 @@ Args=--enable-http --enable-https \
   --enable-native-access=ALL-UNNAMED \
   -H:+IncludeAllLocales \
   --no-fallback \
-  --add-opens=java.base/java.util=ALL-UNNAMED --allow-incomplete-classpath
+  --add-opens=java.base/java.util=ALL-UNNAMED --allow-incomplete-classpath \
+  --enable-all-charsets

--- a/fcli-core/fcli-app/src/main/resources/META-INF/native-image/fcli/fcli-app/static/native-image.properties
+++ b/fcli-core/fcli-app/src/main/resources/META-INF/native-image/fcli/fcli-app/static/native-image.properties
@@ -9,5 +9,4 @@ Args=--enable-http --enable-https \
   -H:+IncludeAllLocales \
   -H:+AddAllCharsets \
   --no-fallback \
-  --add-opens=java.base/java.util=ALL-UNNAMED --allow-incomplete-classpath \
-  
+  --add-opens=java.base/java.util=ALL-UNNAMED --allow-incomplete-classpath

--- a/fcli-core/fcli-app/src/main/resources/META-INF/native-image/fcli/fcli-app/static/native-image.properties
+++ b/fcli-core/fcli-app/src/main/resources/META-INF/native-image/fcli/fcli-app/static/native-image.properties
@@ -7,6 +7,7 @@ Args=--enable-http --enable-https \
   --initialize-at-build-time=org.codehaus.stax2.typed.Base64Variants,org.codehaus.stax2.typed.Base64Variant \
   --enable-native-access=ALL-UNNAMED \
   -H:+IncludeAllLocales \
+  -H:+AddAllCharsets \
   --no-fallback \
   --add-opens=java.base/java.util=ALL-UNNAMED --allow-incomplete-classpath \
-  --enable-all-charsets
+  

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/model/FVDLMetadata.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/model/FVDLMetadata.java
@@ -60,6 +60,12 @@ public class FVDLMetadata {
     private Set<String> ambiguousSourceBaseNamesIgnoreCase = ConcurrentHashMap.newKeySet();
     private Set<String> ambiguousSourceExtensions = ConcurrentHashMap.newKeySet();
 
+    // Source file encodings from Build/SourceFiles/File Name + @encoding
+    private Map<String, String> sourceFileEncodingsByPath = new ConcurrentHashMap<>();
+    private Map<String, String> sourceFileEncodingsByPathIgnoreCase = new ConcurrentHashMap<>();
+    private Set<String> ambiguousSourceEncodingPaths = ConcurrentHashMap.newKeySet();
+    private Set<String> ambiguousSourceEncodingPathsIgnoreCase = ConcurrentHashMap.newKeySet();
+
     // Statistics
     private long totalVulnerabilities;
     private long totalNodes;
@@ -91,6 +97,22 @@ public class FVDLMetadata {
         if (!extension.isEmpty()) {
             registerUniqueMapping(sourceFileTypesByExtension, ambiguousSourceExtensions, extension, normalizedType);
         }
+    }
+
+    public void registerSourceFileEncoding(String fileName, String encoding) {
+        if (fileName == null || encoding == null) {
+            return;
+        }
+
+        String normalizedPath = normalizeFileName(fileName);
+        String normalizedEncoding = normalizeEncoding(encoding);
+        if (normalizedPath.isEmpty() || normalizedEncoding.isEmpty()) {
+            return;
+        }
+
+        registerUniqueMapping(sourceFileEncodingsByPath, ambiguousSourceEncodingPaths, normalizedPath, normalizedEncoding);
+        registerUniqueMapping(sourceFileEncodingsByPathIgnoreCase, ambiguousSourceEncodingPathsIgnoreCase,
+            foldCase(normalizedPath), normalizedEncoding);
     }
 
     public String findSourceFileTypeForFileName(String fileName) {
@@ -133,6 +155,21 @@ public class FVDLMetadata {
         return getUniqueMapping(sourceFileTypesByExtension, ambiguousSourceExtensions, normalizedExtension);
     }
 
+    public String findSourceFileEncodingForFileName(String fileName) {
+        String normalizedPath = normalizeFileName(fileName);
+        if (normalizedPath.isEmpty()) {
+            return null;
+        }
+
+        String exactPathEncoding = getUniqueMapping(sourceFileEncodingsByPath, ambiguousSourceEncodingPaths, normalizedPath);
+        if (exactPathEncoding != null) {
+            return exactPathEncoding;
+        }
+
+        return getUniqueMapping(sourceFileEncodingsByPathIgnoreCase, ambiguousSourceEncodingPathsIgnoreCase,
+            foldCase(normalizedPath));
+    }
+
     private static void registerUniqueMapping(Map<String, String> mappings, Set<String> ambiguousKeys,
                                               String key, String value) {
         if (ambiguousKeys.contains(key)) {
@@ -166,6 +203,10 @@ public class FVDLMetadata {
 
     private static String normalizeType(String fileType) {
         return fileType == null ? "" : fileType.trim().toUpperCase(Locale.ROOT);
+    }
+
+    private static String normalizeEncoding(String encoding) {
+        return encoding == null ? "" : encoding.trim();
     }
 
     private static String extractBaseName(String normalizedPath) {

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/RemediationProcessor.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/RemediationProcessor.java
@@ -14,6 +14,11 @@ package com.fortify.cli.aviator.fpr.processor;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -26,6 +31,7 @@ import java.util.Base64;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.zip.ZipFile;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -39,6 +45,7 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import com.fortify.cli.aviator._common.exception.AviatorTechnicalException;
+import com.fortify.cli.aviator.fpr.model.FVDLMetadata;
 import com.fortify.cli.aviator.util.FprHandle;
 import com.fortify.cli.aviator.util.FuzzyContextSearcher;
 public class RemediationProcessor {
@@ -70,6 +77,8 @@ public class RemediationProcessor {
             trimmedSourceDir = trimmedSourceDir.substring(1, trimmedSourceDir.length() - 1);
         }
         final Path sourceBasePath = Paths.get(trimmedSourceDir).toAbsolutePath().normalize();
+        logger.debug("Applying remediations from {} to source directory {}", remediationPath, sourceBasePath);
+        final FVDLMetadata fvdlMetadata = loadFvdlMetadata();
 
         try (InputStream remediationStream = Files.newInputStream(remediationPath)) {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
@@ -84,6 +93,7 @@ public class RemediationProcessor {
 
             NodeList remediationNodes = remediationDoc.getElementsByTagNameNS(NAMESPACE_URI, "Remediation");
             totalRemediations = remediationNodes.getLength();
+            logger.debug("Loaded {} remediation entries from {}", totalRemediations, remediationPath);
             appliedRemediations=0;
             for (int i = 0; i < remediationNodes.getLength(); i++) {
                 Element remediation = (Element) remediationNodes.item(i);
@@ -94,6 +104,8 @@ public class RemediationProcessor {
                     String filename = fileChanges.getElementsByTagNameNS(NAMESPACE_URI, "Filename").item(0).getTextContent();
 
                     Path filePath = sourceBasePath.resolve(filename).normalize();
+                    String instanceId = remediation.getAttribute("instanceId");
+                    logger.debug("Processing remediation {} file change for '{}' resolved to '{}'", instanceId, filename, filePath);
 
                     if (!filePath.startsWith(sourceBasePath)) {
                         logger.error("Skipping file '{}' as it resolves to a path outside the source directory (potential path traversal attack)", filename);
@@ -106,23 +118,33 @@ public class RemediationProcessor {
                     }
 
                     String fileHash = fileChanges.getElementsByTagNameNS(NAMESPACE_URI, "Hash").item(0).getTextContent();
-                    String instanceId = remediation.getAttribute("instanceId");
+                    Charset sourceEncoding = getRequiredSourceEncoding(filename, fvdlMetadata);
 
                     NodeList changesNodes = fileChanges.getElementsByTagNameNS(NAMESPACE_URI, "Change");
+                    logger.debug("Remediation {} has {} change(s) for '{}' using FVDL encoding {}", instanceId, changesNodes.getLength(), filename,
+                            sourceEncoding.name());
                     for (int k = 0; k < changesNodes.getLength(); k++) {
                         Element change = (Element) changesNodes.item(k);
 
 
-                        String content = Files.readString(filePath, StandardCharsets.UTF_8).replace("\r\n", "\n");
+                        String originalContent = readSourceFile(filePath, filename, sourceEncoding);
+                        String lineSeparator = detectLineSeparator(originalContent);
+                        String content = normalizeLineEndings(originalContent);
 
-                        List<String> originalLines = Arrays.asList(content.split("\n"));
+                        List<String> originalLines = Arrays.asList(content.split("\n", -1));
+                        logger.debug("Decoded '{}' using {}; lineSeparator={}, normalizedLines={}", filename, sourceEncoding.name(),
+                                describeLineSeparator(lineSeparator), originalLines.size());
 
                         int lineFrom = Integer.parseInt(change.getElementsByTagNameNS(NAMESPACE_URI, "LineFrom").item(0).getTextContent());
                         int lineTo = Integer.parseInt(change.getElementsByTagNameNS(NAMESPACE_URI, "LineTo").item(0).getTextContent());
+                        logger.debug("Remediation {} change {} for '{}' targets lines {}-{}", instanceId, k + 1, filename, lineFrom, lineTo);
 
 
-                        if (!calculateHashBase64(content, "SHA-256").equals(fileHash)) {
-                            logger.trace("File hash mismatch for remediation {} in {}; searching changed source content", instanceId, filename);
+                        String calculatedHash = calculateHashBase64(content, "SHA-256");
+                        boolean fileHashMatches = calculatedHash.equals(fileHash);
+                        logger.debug("Remediation {} hash check for '{}': {}", instanceId, filename, fileHashMatches ? "matched" : "mismatched");
+                        if (!fileHashMatches) {
+                            logger.debug("File hash mismatch for remediation {} in {}; searching changed source content", instanceId, filename);
                             Element contextElem = (Element) change.getElementsByTagNameNS(NAMESPACE_URI, "Context").item(0);
                             String contextText = contextElem.getTextContent();
 
@@ -130,12 +152,12 @@ public class RemediationProcessor {
                             List<String> contextLine = Arrays.asList(contextText.split("\\r?\\n"));
                             int contextLineFrom = FuzzyContextSearcher.fuzzySearchContext(originalLines, contextLine, 0) ;
                             if(contextLineFrom==-1) {
-                                logger.trace("Context search failed for remediation {} in {}; context lines={}, source lines={}", instanceId, filename,
+                                logger.debug("Context search failed for remediation {} in {}; context lines={}, source lines={}", instanceId, filename,
                                         contextLine.size(), originalLines.size());
                                 logger.info("File content has changed. Context Lines not found. Remediation not possible for {}", instanceId);
                                 continue;
                             }
-                            logger.trace("Context for remediation {} in {} matched at line {}", instanceId, filename, contextLineFrom + 1);
+                            logger.debug("Context for remediation {} in {} matched at line {}", instanceId, filename, contextLineFrom + 1);
                             Element OriginalCodeElem = (Element) change.getElementsByTagNameNS(NAMESPACE_URI, "OriginalCode").item(0);
                             String OriginalCodeText = OriginalCodeElem.getTextContent();
 
@@ -144,14 +166,14 @@ public class RemediationProcessor {
 
                             int[] lineFromTo = FuzzyContextSearcher.fuzzySearchOriginalCode(originalLines, OriginalCodeLine, 0, contextLineFrom);
                             if(lineFromTo[0]==-1 || lineFromTo[1]==-1) {
-                                logger.trace("Original code search failed for remediation {} in {}; context line={}, original code lines={}, source lines={}",
+                                logger.debug("Original code search failed for remediation {} in {}; context line={}, original code lines={}, source lines={}",
                                         instanceId, filename, contextLineFrom + 1, OriginalCodeLine.size(), originalLines.size());
                                 logger.info("File content has changed. Original Code lines not found. Remediation not possible for {}", instanceId);
                                 continue;
                             }
                             lineFrom = lineFromTo[0]+1; //Adding 1 for 1-based indexing
                             lineTo = lineFromTo[1] + 1; //Adding 1 for 1-based indexing
-                            logger.trace("Original code for remediation {} in {} matched at lines {}-{}", instanceId, filename, lineFrom, lineTo);
+                            logger.debug("Original code for remediation {} in {} matched at lines {}-{}", instanceId, filename, lineFrom, lineTo);
                         }
 
 
@@ -167,7 +189,10 @@ public class RemediationProcessor {
                         updatedLines.addAll(originalLines.subList(0, lineFrom - 1));
                         updatedLines.addAll(newCodeLines);
                         updatedLines.addAll(originalLines.subList(lineTo, originalLines.size()));
-                        Files.write(filePath, updatedLines);
+                        byte[] updatedBytes = encodeStrict(String.join(lineSeparator, updatedLines), sourceEncoding, filename);
+                        logger.debug("Writing remediation {} to '{}' using FVDL encoding {}; updatedLines={}, encodedBytes={}", instanceId, filename,
+                            sourceEncoding.name(), updatedLines.size(), updatedBytes.length);
+                        Files.write(filePath, updatedBytes);
                         modifiedFiles.add(filename);
                         logger.info("Remediation applied for {} in file {}", instanceId, filename);
                         if(!remediationAppliedOnIssue) {
@@ -193,6 +218,104 @@ public class RemediationProcessor {
 
     private boolean isFilePresent(Path path) {
         return Files.exists(path) && Files.isRegularFile(path);
+    }
+
+    private FVDLMetadata loadFvdlMetadata() {
+        if (!Files.exists(fprHandle.getPath("/audit.fvdl"))) {
+            throw new AviatorTechnicalException("FVDL file '/audit.fvdl' is missing; cannot determine source file encodings for applying remediations");
+        }
+
+        try (ZipFile zipFile = new ZipFile(fprHandle.getFprPath().toFile())) {
+            logger.debug("Loading FVDL build metadata from '{}' to resolve source encodings", fprHandle.getFprPath());
+            StreamingFVDLProcessor processor = new StreamingFVDLProcessor(fprHandle);
+            processor.parseBuildMetadata(zipFile, "audit.fvdl");
+            logger.debug("Loaded FVDL build metadata from '{}'", fprHandle.getFprPath());
+            return processor.getFvdlMetadata();
+        } catch (Exception e) {
+            throw new AviatorTechnicalException("Error reading source file encodings from audit.fvdl", e);
+        }
+    }
+
+    private Charset getRequiredSourceEncoding(String filename, FVDLMetadata fvdlMetadata) {
+        String encoding = fvdlMetadata.findSourceFileEncodingForFileName(filename);
+        if (encoding == null || encoding.isBlank()) {
+            logger.debug("FVDL source encoding lookup failed for '{}'", filename);
+            throw new AviatorTechnicalException("FVDL does not declare a source encoding for file '" + filename + "'; cannot safely apply remediation");
+        }
+
+        try {
+            Charset charset = Charset.forName(encoding);
+            logger.debug("FVDL source encoding for '{}' resolved to '{}'", filename, charset.name());
+            return charset;
+        } catch (Exception e) {
+            throw new AviatorTechnicalException("FVDL declares unsupported source encoding '" + encoding + "' for file '" + filename + "'", e);
+        }
+    }
+
+    private String readSourceFile(Path filePath, String filename, Charset sourceEncoding) {
+        try {
+            byte[] sourceBytes = Files.readAllBytes(filePath);
+            String decodedContent = decodeStrict(sourceBytes, sourceEncoding);
+            logger.debug("Strict decoded '{}' using {}; sourceBytes={}, decodedChars={}", filename, sourceEncoding.name(), sourceBytes.length,
+                    decodedContent.length());
+            return decodedContent;
+        } catch (CharacterCodingException e) {
+            throw new AviatorTechnicalException("FVDL declares source encoding '" + sourceEncoding.name() + "' for file '" + filename + "', but the source file cannot be decoded using that encoding", e);
+        } catch (IOException e) {
+            throw new AviatorTechnicalException("Error reading source code file '" + filePath + "'", e);
+        }
+    }
+
+    private String decodeStrict(byte[] bytes, Charset charset) throws CharacterCodingException {
+        return charset.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT)
+                .decode(ByteBuffer.wrap(bytes))
+                .toString();
+    }
+
+    private byte[] encodeStrict(String content, Charset charset, String filename) {
+        try {
+            ByteBuffer buffer = charset.newEncoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .encode(CharBuffer.wrap(content));
+            byte[] result = new byte[buffer.remaining()];
+            buffer.get(result);
+            return result;
+        } catch (CharacterCodingException e) {
+            throw new AviatorTechnicalException("Remediation content for file '" + filename + "' cannot be encoded using FVDL source encoding '" + charset.name() + "'", e);
+        }
+    }
+
+    private String detectLineSeparator(String content) {
+        int crlfIndex = content.indexOf("\r\n");
+        int lfIndex = content.indexOf('\n');
+        int crIndex = content.indexOf('\r');
+
+        if (crlfIndex >= 0 && (lfIndex == crlfIndex + 1 || lfIndex < 0) && (crIndex == crlfIndex || crIndex < 0)) {
+            return "\r\n";
+        }
+        if (lfIndex >= 0 && (crIndex < 0 || lfIndex < crIndex)) {
+            return "\n";
+        }
+        if (crIndex >= 0) {
+            return "\r";
+        }
+        return System.lineSeparator();
+    }
+
+    private String normalizeLineEndings(String content) {
+        return content.replace("\r\n", "\n").replace('\r', '\n');
+    }
+
+    private String describeLineSeparator(String lineSeparator) {
+        return switch (lineSeparator) {
+            case "\r\n" -> "CRLF";
+            case "\n" -> "LF";
+            case "\r" -> "CR";
+            default -> "system";
+        };
     }
 
     private String calculateHashBase64(String content, String algorithm) {

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/StreamingFVDLProcessor.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/StreamingFVDLProcessor.java
@@ -403,6 +403,36 @@ public class StreamingFVDLProcessor {
         }
     }
 
+    public void parseBuildMetadata(ZipFile zipFile, String entryName) throws Exception {
+        logger.debug("Parsing FVDL build metadata entry '{}'", entryName);
+        ZipEntry fvdlEntry = zipFile.getEntry(entryName);
+        if (fvdlEntry == null) {
+            throw new IOException("audit.fvdl not found in FPR file");
+        }
+
+        try (InputStream inputStream = zipFile.getInputStream(fvdlEntry)) {
+            parseBuildMetadata(inputStream);
+        }
+        logger.debug("Parsed FVDL build metadata entry '{}'", entryName);
+    }
+
+    private void parseBuildMetadata(InputStream inputStream) throws XMLStreamException {
+        XMLStreamReader reader = xmlInputFactory.createXMLStreamReader(inputStream);
+
+        try {
+            while (reader.hasNext()) {
+                int event = reader.next();
+                if (event == XMLStreamConstants.START_ELEMENT && "Build".equals(reader.getLocalName())) {
+                    parseBuild(reader);
+                    return;
+                }
+            }
+            logger.debug("No Build section found while parsing FVDL build metadata");
+        } finally {
+            reader.close();
+        }
+    }
+
     private void parseRuntimeConfiguration(XMLStreamReader reader) throws XMLStreamException {
         updateAnalysisType("SECURITYSCOPE");
         skipSection(reader, "RuntimeConfiguration");
@@ -456,6 +486,7 @@ public class StreamingFVDLProcessor {
 
     private void parseSourceFile(XMLStreamReader reader) throws XMLStreamException {
         String fileType = reader.getAttributeValue(null, "type");
+        String fileEncoding = reader.getAttributeValue(null, "encoding");
         String fileName = null;
 
         while (reader.hasNext()) {
@@ -469,6 +500,7 @@ public class StreamingFVDLProcessor {
         }
 
         fvdlMetadata.registerSourceFileType(fileName, fileType);
+        fvdlMetadata.registerSourceFileEncoding(fileName, fileEncoding);
     }
 
     /**


### PR DESCRIPTION
> Note: These needs to go as Hotfix in dev/v3.x
## Summary

This change makes Aviator auto-remediation apply source edits using the encoding declared in `audit.fvdl` instead of assuming UTF-8. It reuses the existing streaming FVDL parser to read source file encoding metadata, applies strict decode/encode validation, and preserves the source file’s existing line endings when writing remediated content.

https://almoctane-ams.saas.microfocus.com/ui/entity-navigation?p=206015/2001&entityType=work_item&id=2311032

fix: `fcli aviator ssc apply-remediations`: apply source edits using the encoding declared in `audit.fvdl` instead of assuming UTF-8
fix: `fcli fod aviator apply-remediations`: apply source edits using the encoding declared in `audit.fvdl` instead of assuming UTF-8
 
