### PR TITLE
fix: start DAST scan on release with no prior scans

### DIFF
--- a/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/dast/FoDScanDastAutomatedHelper.java
+++ b/fcli-core/fcli-fod/src/main/java/com/fortify/cli/fod/_common/scan/helper/dast/FoDScanDastAutomatedHelper.java
@@ -80,7 +80,7 @@ public class FoDScanDastAutomatedHelper extends FoDScanHelper {
                     .queryString("fields", "scanId,scanType,analysisStatusType")
                     .asObject(JsonNode.class).getBody();
             JsonNode itemsNode = response.path("items");
-            if (!itemsNode.isArray() || itemsNode.isEmpty()) continue;
+            if (!itemsNode.isArray() || itemsNode.isEmpty()) return null; // no scans exist, so it's fine to run a new scan
 
             boolean foundActive = false;
             for (JsonNode node : itemsNode) {


### PR DESCRIPTION
fcli fod dast-scan start threw FcliSimpleException: Unable to start Dynamic scan after 30 attempts on releases that had no previous scans.

Changed the empty-items guard from continue to return null. An empty scan list means no active scan exists for the release, so the method now immediately signals that a new scan can proceed.

fix: start DAST scan on release with no prior scans(#1058 )