### PR TITLE
chore: enforce HTTPS-only URL validation and stage logging

### DIFF
--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/_common/exception/UnsupportedAviatorUrlSchemeException.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/_common/exception/UnsupportedAviatorUrlSchemeException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.aviator._common.exception;
+
+/**
+ * User-facing rejection of a non-{@code https} Aviator target scheme.
+ * <p>
+ * Typed so diagnose can map endpoint UX without parsing exception message text.
+ */
+public class UnsupportedAviatorUrlSchemeException extends AviatorSimpleException {
+    private static final long serialVersionUID = 1L;
+
+    public static final String STAGE_SUMMARY = "Unsupported URL scheme";
+    public static final String STAGE_GUIDANCE = "Use a supported Aviator URL (https://host[:port])";
+
+    private final String scheme;
+    private final String providedUrl;
+
+    public UnsupportedAviatorUrlSchemeException(String scheme, String providedUrl) {
+        super(STAGE_SUMMARY+" '"+scheme+"'. "+STAGE_GUIDANCE+". Provided URL: "+providedUrl);
+        this.scheme = scheme;
+        this.providedUrl = providedUrl;
+    }
+
+    public String getScheme() {
+        return scheme;
+    }
+
+    public String getProvidedUrl() {
+        return providedUrl;
+    }
+}

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/diagnose/AviatorConnectionDiagnostics.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/diagnose/AviatorConnectionDiagnostics.java
@@ -20,6 +20,7 @@ import java.util.List;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fortify.cli.aviator._common.exception.AviatorBugException;
 import com.fortify.cli.aviator._common.exception.AviatorSimpleException;
+import com.fortify.cli.aviator._common.exception.UnsupportedAviatorUrlSchemeException;
 import com.fortify.cli.aviator.grpc.AviatorGrpcClientHelper;
 import com.fortify.cli.aviator.grpc.AviatorGrpcClientHelper.AviatorConnectionPlan;
 import com.fortify.cli.common.json.JsonHelper;
@@ -44,14 +45,14 @@ public class AviatorConnectionDiagnostics {
     }
 
     public AviatorDiagnosticReport diagnose(String url, int timeoutSeconds, String sourceType) {
+        var report = new AviatorDiagnosticReport();
+        report.begin(AviatorDiagnosticStage.ENDPOINT);
         try {
-            return diagnose(AviatorGrpcClientHelper.createConnectionPlan(url), timeoutSeconds, sourceType);
+            return diagnoseValidated(report, AviatorGrpcClientHelper.createConnectionPlan(url), timeoutSeconds,
+                sourceType);
         } catch (AviatorSimpleException e) {
-            var report = new AviatorDiagnosticReport();
-            report.fail(AviatorDiagnosticStage.ENDPOINT,
-                "Endpoint is invalid", "Use a valid Aviator host name and optional port",
-                AviatorDiagnosticEvidence.errorEvidence(e));
-            skipAfter(report, null, AviatorDiagnosticStage.ENDPOINT, "endpoint configuration failed");
+            failEndpoint(report, e);
+            skipAfter(report, null, AviatorDiagnosticStage.ENDPOINT, "endpoint validation failed");
             return report;
         }
     }
@@ -61,6 +62,12 @@ public class AviatorConnectionDiagnostics {
      */
     public AviatorDiagnosticReport diagnose(AviatorConnectionPlan connectionPlan, int timeoutSeconds, String sourceType) {
         var report = new AviatorDiagnosticReport();
+        report.begin(AviatorDiagnosticStage.ENDPOINT);
+        return diagnoseValidated(report, connectionPlan, timeoutSeconds, sourceType);
+    }
+
+    private AviatorDiagnosticReport diagnoseValidated(AviatorDiagnosticReport report,
+            AviatorConnectionPlan connectionPlan, int timeoutSeconds, String sourceType) {
         report.pass(AviatorDiagnosticStage.ENDPOINT,
             "Endpoint is valid", "No action required", endpointEvidence(connectionPlan, sourceType));
 
@@ -79,7 +86,23 @@ public class AviatorConnectionDiagnostics {
         return report;
     }
 
+    private static void failEndpoint(AviatorDiagnosticReport report, AviatorSimpleException e) {
+        var evidence = AviatorDiagnosticEvidence.errorEvidence(e);
+        if (e instanceof UnsupportedAviatorUrlSchemeException schemeFailure) {
+            evidence.put("scheme", schemeFailure.getScheme());
+            evidence.put("providedUrl", schemeFailure.getProvidedUrl());
+            report.fail(AviatorDiagnosticStage.ENDPOINT,
+                UnsupportedAviatorUrlSchemeException.STAGE_SUMMARY,
+                UnsupportedAviatorUrlSchemeException.STAGE_GUIDANCE,
+                evidence);
+            return;
+        }
+        report.fail(AviatorDiagnosticStage.ENDPOINT,
+            "Endpoint is invalid", "Use a valid Aviator host name and optional port", evidence);
+    }
+
     private boolean runDns(AviatorDiagnosticReport report, AviatorConnectionPlan connectionPlan) {
+        report.begin(AviatorDiagnosticStage.DNS);
         try {
             var evidence = JsonHelper.getObjectMapper().createObjectNode();
             addAddresses(evidence, "resolvedAddresses", probe.resolve(connectionPlan.target().host()));
@@ -105,6 +128,7 @@ public class AviatorConnectionDiagnostics {
      * handshake failure. Do not fold TCP into the tunnel solely to avoid a double connect.
      */
     private boolean runTcp(AviatorDiagnosticReport report, AviatorConnectionPlan connectionPlan, int timeoutSeconds) {
+        report.begin(AviatorDiagnosticStage.TCP);
         var proxyDescriptor = connectionPlan.proxyDescriptor();
         var nextHopHost = proxyDescriptor.map(proxy -> proxy.getProxyHost()).orElse(connectionPlan.target().host());
         var nextHopPort = proxyDescriptor.map(proxy -> proxy.getProxyPort()).orElse(connectionPlan.effectivePort());
@@ -132,6 +156,9 @@ public class AviatorConnectionDiagnostics {
      */
     private boolean runTunnelStages(AviatorDiagnosticReport report, AviatorConnectionPlan connectionPlan,
             int timeoutSeconds) {
+        var hasProxy = connectionPlan.proxyDescriptor().isPresent();
+        // First stage that will be recorded from this shared tunnel session.
+        report.begin(hasProxy ? AviatorDiagnosticStage.PROXY : AviatorDiagnosticStage.TLS);
         var tunnel = probe.probeTunnel(connectionPlan, timeoutSeconds);
         if (tunnel instanceof AviatorTunnelResult.ProxyConnectFailed failed) {
             appendProxyFailure(report, connectionPlan, failed);
@@ -139,6 +166,9 @@ public class AviatorConnectionDiagnostics {
             return false;
         }
         appendProxyPassIfConfigured(report, connectionPlan, tunnel);
+        if (hasProxy) {
+            report.begin(AviatorDiagnosticStage.TLS);
+        }
         if (tunnel instanceof AviatorTunnelResult.TlsFailed failed) {
             appendTlsFailure(report, connectionPlan, failed);
             skipAfter(report, connectionPlan, AviatorDiagnosticStage.TLS, "TLS handshake failed");
@@ -207,6 +237,7 @@ public class AviatorConnectionDiagnostics {
     }
 
     private void runGrpc(AviatorDiagnosticReport report, AviatorConnectionPlan connectionPlan, int timeoutSeconds) {
+        report.begin(AviatorDiagnosticStage.GRPC);
         try {
             applyGrpc(report, probe.probeGrpc(connectionPlan.originalUrl(), timeoutSeconds));
         } catch (Exception e) {
@@ -275,7 +306,7 @@ public class AviatorConnectionDiagnostics {
             if (stage == AviatorDiagnosticStage.PROXY && !hasProxy) {
                 continue;
             }
-            report.skipWarn(stage, "Skipped because " + reason,
+            report.skipWarn(stage, reason,
                 "Resolve the previous failed required stage first",
                 AviatorDiagnosticEvidence.empty());
         }

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/diagnose/AviatorConnectionDiagnostics.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/diagnose/AviatorConnectionDiagnostics.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.List;
+import java.util.StringJoiner;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fortify.cli.aviator._common.exception.AviatorBugException;
@@ -69,7 +70,8 @@ public class AviatorConnectionDiagnostics {
     private AviatorDiagnosticReport diagnoseValidated(AviatorDiagnosticReport report,
             AviatorConnectionPlan connectionPlan, int timeoutSeconds, String sourceType) {
         report.pass(AviatorDiagnosticStage.ENDPOINT,
-            "Endpoint is valid", "No action required", endpointEvidence(connectionPlan, sourceType));
+            "Endpoint is valid: "+connectionPlan.normalizedUrl(), "No action required",
+            endpointEvidence(connectionPlan, sourceType));
 
         if (!runDns(report, connectionPlan)) {
             skipAfter(report, connectionPlan, AviatorDiagnosticStage.DNS, "DNS resolution failed");
@@ -110,7 +112,8 @@ public class AviatorConnectionDiagnostics {
                 var proxy = connectionPlan.proxyDescriptor().get();
                 addAddresses(evidence, "proxyResolvedAddresses", probe.resolve(proxy.getProxyHost()));
             }
-            report.pass(AviatorDiagnosticStage.DNS, "Host name resolved", "No action required", evidence);
+            report.pass(AviatorDiagnosticStage.DNS,
+                "Host name resolved: "+addresses(evidence, "resolvedAddresses"), "No action required", evidence);
             return true;
         } catch (IOException e) {
             report.fail(AviatorDiagnosticStage.DNS,
@@ -135,7 +138,8 @@ public class AviatorConnectionDiagnostics {
         var evidence = nextHopEvidence(nextHopHost, nextHopPort, proxyDescriptor.isPresent());
         try {
             probe.connect(nextHopHost, nextHopPort, timeoutSeconds);
-            report.pass(AviatorDiagnosticStage.TCP, "TCP connection opened", "No action required", evidence);
+            report.pass(AviatorDiagnosticStage.TCP,
+                "TCP connection opened to "+nextHopHost+":"+nextHopPort, "No action required", evidence);
             return true;
         } catch (Exception e) {
             putError(evidence, e);
@@ -197,7 +201,8 @@ public class AviatorConnectionDiagnostics {
         var evidence = JsonHelper.getObjectMapper().createObjectNode();
         evidence.put("proxyConnectStatus", tunnel.proxyConnectStatus());
         putProxyEvidence(evidence, connectionPlan);
-        report.pass(AviatorDiagnosticStage.PROXY, "Proxy CONNECT succeeded", "No action required", evidence);
+        report.pass(AviatorDiagnosticStage.PROXY,
+            "Proxy CONNECT succeeded through "+proxyEndpoint(evidence), "No action required", evidence);
     }
 
     private void appendTlsSuccess(AviatorDiagnosticReport report, AviatorTunnelResult.TlsSucceeded ok) {
@@ -210,10 +215,11 @@ public class AviatorConnectionDiagnostics {
         evidence.put("tlsPhase", AviatorTlsPhase.HANDSHAKE.id());
         if (!"h2".equals(ok.applicationProtocol())) {
             report.warn(AviatorDiagnosticStage.TLS,
-                "TLS works, but HTTP/2 was not enabled",
+                tlsSummary("TLS works, but HTTP/2 was not enabled", ok),
                 "Allow ALPN h2 through the proxy or gateway to aviator-grpc-server", true, evidence);
         } else {
-            report.pass(AviatorDiagnosticStage.TLS, "TLS and HTTP/2 are available", "No action required", evidence);
+            report.pass(AviatorDiagnosticStage.TLS,
+                tlsSummary("TLS and HTTP/2 are available", ok), "No action required", evidence);
         }
     }
 
@@ -251,10 +257,11 @@ public class AviatorConnectionDiagnostics {
         if (grpc.pattern() != null) {
             evidence.put("pattern", grpc.pattern().wireId());
         }
+        var summary = grpc.stageSummary();
         if (grpc.stagePass()) {
-            report.pass(AviatorDiagnosticStage.GRPC, grpc.stageSummary(), grpc.stageGuidance(), evidence);
+            report.pass(AviatorDiagnosticStage.GRPC, summary, grpc.stageGuidance(), evidence);
         } else {
-            report.fail(AviatorDiagnosticStage.GRPC, grpc.stageSummary(), grpc.stageGuidance(), evidence);
+            report.fail(AviatorDiagnosticStage.GRPC, summary, grpc.stageGuidance(), evidence);
         }
     }
 
@@ -315,5 +322,19 @@ public class AviatorConnectionDiagnostics {
     private static void addAddresses(ObjectNode evidence, String fieldName, InetAddress[] addresses) {
         var array = evidence.putArray(fieldName);
         Arrays.stream(addresses).map(InetAddress::getHostAddress).forEach(array::add);
+    }
+
+    private static String addresses(ObjectNode evidence, String fieldName) {
+        var result = new StringJoiner(", ");
+        evidence.withArray(fieldName).forEach(address -> result.add(address.asText()));
+        return result.toString();
+    }
+
+    private static String proxyEndpoint(ObjectNode evidence) {
+        return evidence.path("proxyHost").asText()+":"+evidence.path("proxyPort").asInt();
+    }
+
+    private static String tlsSummary(String summary, AviatorTunnelResult.TlsSucceeded result) {
+        return summary+": "+result.protocol()+", ALPN "+result.applicationProtocol();
     }
 }

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/diagnose/AviatorDiagnosticReport.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/diagnose/AviatorDiagnosticReport.java
@@ -15,13 +15,10 @@ package com.fortify.cli.aviator.diagnose;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fortify.cli.common.json.JsonHelper;
@@ -69,7 +66,7 @@ public final class AviatorDiagnosticReport {
             return;
         }
         switch (result.status()) {
-        case PASS -> LOG.info("{}: PASS{}", name, passDetail(result));
+        case PASS -> LOG.info("{}: PASS - {}", name, nullToEmpty(result.summary()));
         case FAIL -> LOG.error("{}: FAIL - {}", name, failDetail(result));
         case WARN -> LOG.info("{}: WARN - {}", name, nullToEmpty(result.summary()));
         }
@@ -86,21 +83,6 @@ public final class AviatorDiagnosticReport {
             return summary;
         }
         return summary+" ("+exceptionMessage+")";
-    }
-
-    private static String passDetail(AviatorDiagnosticStageResult result) {
-        var evidence = result.evidence();
-        if (evidence == null || !evidence.has("resolvedAddresses") || !evidence.get("resolvedAddresses").isArray()) {
-            return "";
-        }
-        var addresses = StreamSupport.stream(evidence.get("resolvedAddresses").spliterator(), false)
-            .map(JsonNode::asText)
-            .filter(s -> s != null && !s.isBlank())
-            .collect(Collectors.toList());
-        if (addresses.isEmpty()) {
-            return "";
-        }
-        return " ("+String.join(", ", addresses)+")";
     }
 
     private static String nullToEmpty(String value) {

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/diagnose/AviatorDiagnosticReport.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/diagnose/AviatorDiagnosticReport.java
@@ -15,23 +15,96 @@ package com.fortify.cli.aviator.diagnose;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fortify.cli.common.json.JsonHelper;
 
 /**
- * Owns stage order and collects diagnostic rows for one diagnose run.
+ * Owns stage order, collects diagnostic rows, and emits support log lines for one diagnose run.
+ * <p>
+ * Call {@link #begin(AviatorDiagnosticStage)} (or the string overload) before running a stage;
+ * {@code pass}/{@code fail}/{@code warn}/{@code skip*} record the row and log the outcome.
+ * Skip APIs take a structured {@code reason} so log formatting never parses summary English.
  */
 public final class AviatorDiagnosticReport {
+    private static final Logger LOG = LoggerFactory.getLogger(AviatorDiagnosticReport.class);
+
     private final List<AviatorDiagnosticStageResult> stages = new ArrayList<>();
 
     public int nextOrder() {
         return stages.size() + 1;
     }
 
+    /** DEBUG start line before a stage is executed (not for pure skip rows). */
+    public void begin(AviatorDiagnosticStage stage) {
+        LOG.debug("Starting {} diagnostic", stage.displayName());
+    }
+
+    /** DEBUG start line for product stages (token/admin) that are not transport enums. */
+    public void begin(String stageId) {
+        LOG.debug("Starting {} diagnostic", AviatorDiagnosticStage.displayNameFor(stageId));
+    }
+
     public void add(AviatorDiagnosticStageResult result) {
         stages.add(result);
+        logStageOutcome(result, false, null);
+    }
+
+    private void addSkip(AviatorDiagnosticStageResult result, String reason) {
+        stages.add(result);
+        logStageOutcome(result, true, reason);
+    }
+
+    private static void logStageOutcome(AviatorDiagnosticStageResult result, boolean skipped, String skipReason) {
+        var name = AviatorDiagnosticStage.displayNameFor(result.stage());
+        if (skipped) {
+            LOG.info("{} skipped because {}", name, nullToEmpty(skipReason));
+            return;
+        }
+        switch (result.status()) {
+        case PASS -> LOG.info("{}: PASS{}", name, passDetail(result));
+        case FAIL -> LOG.error("{}: FAIL - {}", name, failDetail(result));
+        case WARN -> LOG.info("{}: WARN - {}", name, nullToEmpty(result.summary()));
+        }
+    }
+
+    private static String failDetail(AviatorDiagnosticStageResult result) {
+        var summary = nullToEmpty(result.summary());
+        var evidence = result.evidence();
+        if (evidence == null || !evidence.hasNonNull("exceptionMessage")) {
+            return summary;
+        }
+        var exceptionMessage = evidence.get("exceptionMessage").asText();
+        if (exceptionMessage == null || exceptionMessage.isBlank()) {
+            return summary;
+        }
+        return summary+" ("+exceptionMessage+")";
+    }
+
+    private static String passDetail(AviatorDiagnosticStageResult result) {
+        var evidence = result.evidence();
+        if (evidence == null || !evidence.has("resolvedAddresses") || !evidence.get("resolvedAddresses").isArray()) {
+            return "";
+        }
+        var addresses = StreamSupport.stream(evidence.get("resolvedAddresses").spliterator(), false)
+            .map(JsonNode::asText)
+            .filter(s -> s != null && !s.isBlank())
+            .collect(Collectors.toList());
+        if (addresses.isEmpty()) {
+            return "";
+        }
+        return " ("+String.join(", ", addresses)+")";
+    }
+
+    private static String nullToEmpty(String value) {
+        return value == null ? "" : value;
     }
 
     public void pass(AviatorDiagnosticStage stage, String summary, String guidance, ObjectNode evidence) {
@@ -43,11 +116,12 @@ public final class AviatorDiagnosticReport {
     }
 
     /**
-     * Transport skip WARN. {@code required=true} documents the stage as part of the required
-     * pipeline; WARN itself never drives process exit (only required FAIL does).
+     * Required transport skip WARN. Builds summary {@code Skipped because {reason}} and logs
+     * as a skip without parsing summary text.
      */
-    public void skipWarn(AviatorDiagnosticStage stage, String summary, String guidance, ObjectNode evidence) {
-        add(AviatorDiagnosticStageResult.warn(nextOrder(), stage, summary, guidance, true, evidence));
+    public void skipWarn(AviatorDiagnosticStage stage, String reason, String guidance, ObjectNode evidence) {
+        addSkip(AviatorDiagnosticStageResult.warn(nextOrder(), stage, skipSummary(reason), guidance, true, evidence),
+            reason);
     }
 
     public void warn(AviatorDiagnosticStage stage, String summary, String guidance, boolean required,
@@ -63,8 +137,16 @@ public final class AviatorDiagnosticReport {
         add(AviatorDiagnosticStageResult.optionalFail(nextOrder(), stage, description, summary, guidance, evidence));
     }
 
-    public void optionalSkipWarn(String stage, String description, String summary, String guidance, ObjectNode evidence) {
-        add(AviatorDiagnosticStageResult.warn(nextOrder(), stage, description, summary, guidance, false, evidence));
+    /**
+     * Optional product-stage skip WARN. Builds summary {@code Skipped because {reason}}.
+     */
+    public void optionalSkipWarn(String stage, String description, String reason, String guidance, ObjectNode evidence) {
+        addSkip(AviatorDiagnosticStageResult.warn(nextOrder(), stage, description, skipSummary(reason), guidance, false,
+            evidence), reason);
+    }
+
+    private static String skipSummary(String reason) {
+        return "Skipped because "+reason;
     }
 
     public List<AviatorDiagnosticStageResult> stages() {

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/diagnose/AviatorDiagnosticStage.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/diagnose/AviatorDiagnosticStage.java
@@ -20,19 +20,22 @@ package com.fortify.cli.aviator.diagnose;
  * string stage ids from the connection diagnose helper only.
  */
 public enum AviatorDiagnosticStage {
-    ENDPOINT("endpoint", "Aviator endpoint configuration validation"),
-    DNS("dns", "DNS resolution"),
-    TCP("tcp", "TCP connectivity"),
-    PROXY("proxy", "HTTP proxy CONNECT"),
-    TLS("tls", "TLS handshake"),
-    GRPC("grpc", "gRPC request/response reachability");
+    ENDPOINT("endpoint", "Aviator endpoint configuration validation", "Endpoint"),
+    DNS("dns", "DNS resolution", "DNS"),
+    TCP("tcp", "TCP connectivity", "TCP"),
+    PROXY("proxy", "HTTP proxy CONNECT", "Proxy"),
+    TLS("tls", "TLS handshake", "TLS"),
+    GRPC("grpc", "gRPC request/response reachability", "gRPC");
 
     private final String id;
     private final String description;
+    /** Human-readable label for log lines (e.g. {@code Endpoint}, {@code gRPC}). */
+    private final String displayName;
 
-    AviatorDiagnosticStage(String id, String description) {
+    AviatorDiagnosticStage(String id, String description, String displayName) {
         this.id = id;
         this.description = description;
+        this.displayName = displayName;
     }
 
     public String id() {
@@ -41,5 +44,22 @@ public enum AviatorDiagnosticStage {
 
     public String description() {
         return description;
+    }
+
+    public String displayName() {
+        return displayName;
+    }
+
+    /** Resolve wire id to display name; falls back to a simple capitalization of {@code stageId}. */
+    public static String displayNameFor(String stageId) {
+        if (stageId == null || stageId.isBlank()) {
+            return "Stage";
+        }
+        for (var stage : values()) {
+            if (stage.id.equals(stageId)) {
+                return stage.displayName;
+            }
+        }
+        return Character.toUpperCase(stageId.charAt(0)) + stageId.substring(1);
     }
 }

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/grpc/AviatorGrpcClient.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/grpc/AviatorGrpcClient.java
@@ -91,7 +91,7 @@ public class AviatorGrpcClient implements AutoCloseable {
     final AtomicBoolean isShutdown = new AtomicBoolean(false);
 
     public AviatorGrpcClient(ManagedChannel channel, long defaultTimeoutSeconds, IAviatorLogger logger, long pingIntervalSeconds) {
-        LOG.info("Initializing AviatorGrpcClient with ManagedChannel");
+        LOG.debug("Initializing AviatorGrpcClient with ManagedChannel");
         this.logger = logger;
         this.channel = channel;
         this.asyncStub = AuditorServiceGrpc.newStub(channel).withCompression("gzip").withMaxInboundMessageSize(Constants.MAX_MESSAGE_SIZE).withMaxOutboundMessageSize(Constants.MAX_MESSAGE_SIZE).withWaitForReady();
@@ -116,7 +116,7 @@ public class AviatorGrpcClient implements AutoCloseable {
 
     public AviatorGrpcClient(String host, int port, long defaultTimeoutSeconds, IAviatorLogger logger, long pingIntervalSeconds) {
         this(ManagedChannelBuilder.forAddress(host, port).useTransportSecurity().maxInboundMessageSize(Constants.MAX_MESSAGE_SIZE).keepAliveTime(30, TimeUnit.SECONDS).keepAliveTimeout(10, TimeUnit.SECONDS).keepAliveWithoutCalls(true).enableRetry().compressorRegistry(CompressorRegistry.getDefaultInstance()).decompressorRegistry(DecompressorRegistry.getDefaultInstance()).build(), defaultTimeoutSeconds, logger, pingIntervalSeconds);
-        LOG.info("Initialized AviatorGrpcClient - Host: {}, Port: {}", host, port);
+        LOG.debug("Initialized AviatorGrpcClient - Host: {}, Port: {}", host, port);
     }
 
     public AviatorGrpcClient(ManagedChannel channel, long defaultTimeoutSeconds, IAviatorLogger logger) {
@@ -172,7 +172,7 @@ public class AviatorGrpcClient implements AutoCloseable {
             }
         }
 
-        LOG.info("Client closed");
+        LOG.debug("Client closed");
     }
 
     public Application createApplication(String name, String tenantName, String signature, String message) {

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/grpc/AviatorGrpcClientHelper.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/grpc/AviatorGrpcClientHelper.java
@@ -24,8 +24,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fortify.cli.aviator._common.exception.AviatorSimpleException;
+import com.fortify.cli.aviator._common.exception.UnsupportedAviatorUrlSchemeException;
 import com.fortify.cli.aviator.config.IAviatorLogger;
 import com.fortify.cli.aviator.util.Constants;
+import com.fortify.cli.common.http.UrlSchemes;
 import com.fortify.cli.common.http.proxy.helper.ProxyDescriptor;
 import com.fortify.cli.common.http.proxy.helper.ProxyHelper;
 import com.fortify.cli.common.http.ssl.trust.FcliTrustManager;
@@ -103,12 +105,29 @@ public class AviatorGrpcClientHelper {
         }
     }
 
+    /**
+     * Normalizes an Aviator target to an https URL.
+     * <ul>
+     *   <li>Scheme-less input ({@code host} or {@code host:port}) gets {@code https://} prepended.</li>
+     *   <li>{@code https} (any casing) is accepted and canonicalized to lowercase {@code https}.</li>
+     *   <li>Any other scheme ({@code http}, {@code ftp}, typos like {@code mttp}, …) is rejected.</li>
+     * </ul>
+     */
     public static String normalizeUrl(String url) {
         var trimmed = url.trim();
-        if ( trimmed.matches("^[a-zA-Z][a-zA-Z0-9+\\-.]*://.*$") ) {
+        if ( !UrlSchemes.hasScheme(trimmed) ) {
+            return "https://"+trimmed;
+        }
+        var schemeSeparator = trimmed.indexOf("://");
+        var scheme = trimmed.substring(0, schemeSeparator);
+        if ( !"https".equalsIgnoreCase(scheme) ) {
+            throw new UnsupportedAviatorUrlSchemeException(scheme, url);
+        }
+        if ( "https".equals(scheme) ) {
             return trimmed;
         }
-        return "https://"+trimmed;
+        // Canonicalize scheme casing (HTTPS://host → https://host)
+        return "https"+trimmed.substring(schemeSeparator);
     }
 
     private static NettyChannelBuilder configureBuilder(NettyChannelBuilder builder, Optional<ProxyDescriptor> proxyDescriptor) {

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/diagnose/AviatorConnectionDiagnosticsTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/diagnose/AviatorConnectionDiagnosticsTest.java
@@ -23,6 +23,7 @@ import javax.net.ssl.SSLHandshakeException;
 
 import org.junit.jupiter.api.Test;
 
+import com.fortify.cli.aviator._common.exception.UnsupportedAviatorUrlSchemeException;
 import com.fortify.cli.aviator.diagnose.support.ConfigurableDiagnosticProbe;
 import com.fortify.cli.aviator.diagnose.support.OfflineConnectionPlan;
 
@@ -35,11 +36,59 @@ class AviatorConnectionDiagnosticsTest {
 
         assertEquals(5, results.size());
         assertStage(results.get(0), AviatorDiagnosticStage.ENDPOINT, AviatorDiagnosticStatus.FAIL);
+        assertEquals("Endpoint is invalid", results.get(0).summary());
         assertStage(results.get(1), AviatorDiagnosticStage.DNS, AviatorDiagnosticStatus.WARN);
+        assertTrue(results.get(1).summary().contains("endpoint validation failed"));
         assertStage(results.get(2), AviatorDiagnosticStage.TCP, AviatorDiagnosticStatus.WARN);
         assertStage(results.get(3), AviatorDiagnosticStage.TLS, AviatorDiagnosticStatus.WARN);
         assertStage(results.get(4), AviatorDiagnosticStage.GRPC, AviatorDiagnosticStatus.WARN);
         assertTrue(report.hasRequiredFailure());
+        assertFalse(probe.tunnelCalled);
+    }
+
+    @Test
+    void shouldFailEndpointForUnsupportedUrlScheme() {
+        var probe = new ConfigurableDiagnosticProbe();
+        var report = new AviatorConnectionDiagnostics(probe).diagnose("mttp://vacant", 5, "url");
+        var results = report.stages();
+
+        assertEquals(5, results.size());
+        assertStage(results.get(0), AviatorDiagnosticStage.ENDPOINT, AviatorDiagnosticStatus.FAIL);
+        assertEquals(UnsupportedAviatorUrlSchemeException.STAGE_SUMMARY, results.get(0).summary());
+        assertEquals(UnsupportedAviatorUrlSchemeException.STAGE_GUIDANCE, results.get(0).guidance());
+        assertEquals("mttp", results.get(0).evidence().path("scheme").asText());
+        assertEquals("mttp://vacant", results.get(0).evidence().path("providedUrl").asText());
+        assertStage(results.get(1), AviatorDiagnosticStage.DNS, AviatorDiagnosticStatus.WARN);
+        assertEquals("Skipped because endpoint validation failed", results.get(1).summary());
+        assertStage(results.get(2), AviatorDiagnosticStage.TCP, AviatorDiagnosticStatus.WARN);
+        assertStage(results.get(3), AviatorDiagnosticStage.TLS, AviatorDiagnosticStatus.WARN);
+        assertStage(results.get(4), AviatorDiagnosticStage.GRPC, AviatorDiagnosticStatus.WARN);
+        assertTrue(report.hasRequiredFailure());
+        assertFalse(probe.tunnelCalled);
+        assertFalse(probe.grpcCalled);
+    }
+
+    @Test
+    void shouldFailEndpointForFtpSchemeEvenWithValidLookingHost() {
+        var probe = new ConfigurableDiagnosticProbe();
+        var report = new AviatorConnectionDiagnostics(probe)
+            .diagnose("ftp://aviator-qa01.example.com", 5, "url");
+
+        assertStage(report.stages().get(0), AviatorDiagnosticStage.ENDPOINT, AviatorDiagnosticStatus.FAIL);
+        assertEquals(UnsupportedAviatorUrlSchemeException.STAGE_SUMMARY, report.stages().get(0).summary());
+        assertEquals("ftp", report.stages().get(0).evidence().path("scheme").asText());
+        assertTrue(report.hasRequiredFailure());
+        assertFalse(probe.tunnelCalled);
+    }
+
+    @Test
+    void shouldFailEndpointForHttpScheme() {
+        var probe = new ConfigurableDiagnosticProbe();
+        var report = new AviatorConnectionDiagnostics(probe).diagnose("http://aviator.invalid", 5, "url");
+
+        assertStage(report.stages().get(0), AviatorDiagnosticStage.ENDPOINT, AviatorDiagnosticStatus.FAIL);
+        assertEquals(UnsupportedAviatorUrlSchemeException.STAGE_SUMMARY, report.stages().get(0).summary());
+        assertEquals("http", report.stages().get(0).evidence().path("scheme").asText());
         assertFalse(probe.tunnelCalled);
     }
 

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/grpc/AviatorGrpcClientHelperTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/grpc/AviatorGrpcClientHelperTest.java
@@ -15,12 +15,17 @@ package com.fortify.cli.aviator.grpc;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import com.fortify.cli.aviator._common.exception.UnsupportedAviatorUrlSchemeException;
 import com.fortify.cli.common.http.proxy.helper.ProxyDescriptor;
 
 import io.grpc.HttpConnectProxiedSocketAddress;
@@ -62,6 +67,26 @@ class AviatorGrpcClientHelperTest {
         assertEquals("aviator.invalid", plan.target().host());
         assertEquals(8443, plan.target().port());
         assertEquals(8443, plan.effectivePort());
+    }
+
+    @Test
+    void shouldCanonicalizeHttpsSchemeCasing() {
+        assertEquals("https://aviator.invalid", AviatorGrpcClientHelper.normalizeUrl("HTTPS://aviator.invalid"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "mttp://vacant",
+        "ftp://aviator.invalid",
+        "http://aviator.invalid",
+        "grpc://aviator.invalid"
+    })
+    void shouldRejectNonHttpsSchemes(String url) {
+        var ex = assertThrows(UnsupportedAviatorUrlSchemeException.class,
+            () -> AviatorGrpcClientHelper.createConnectionPlan(url));
+        assertEquals(url.substring(0, url.indexOf("://")), ex.getScheme());
+        assertEquals(url, ex.getProvidedUrl());
+        assertTrue(ex.getMessage().contains(UnsupportedAviatorUrlSchemeException.STAGE_SUMMARY));
     }
 
     @Test

--- a/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/connection/helper/AviatorConnectionDiagnoseHelper.java
+++ b/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/connection/helper/AviatorConnectionDiagnoseHelper.java
@@ -77,9 +77,10 @@ public class AviatorConnectionDiagnoseHelper {
     /** Skip when gRPC did not respond; otherwise run {@code validate}. */
     private void runCredentialStage(AviatorDiagnosticReport report, String stage, String description,
             Runnable validate) {
+        report.begin(stage);
         if (!report.hasGrpcStagePass()) {
             report.optionalSkipWarn(stage, description,
-                "Credential check skipped",
+                "gRPC did not respond",
                 "Fix the gRPC connection first", AviatorDiagnosticEvidence.empty());
             return;
         }

--- a/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/connection/helper/AviatorConnectionDiagnoseHelper.java
+++ b/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/connection/helper/AviatorConnectionDiagnoseHelper.java
@@ -100,7 +100,7 @@ public class AviatorConnectionDiagnoseHelper {
             evidence.put("tenantNamePresent", validationResult.tenantName() != null);
             if (validationResult.response().getValid()) {
                 report.optionalPass(STAGE_TOKEN, STAGE_TOKEN_DESCRIPTION,
-                    "Aviator token is valid", "No action required", evidence);
+                    "Aviator token is valid for the requested tenant", "No action required", evidence);
                 return;
             }
             var errorMessage = validationResult.response().getErrorMessage();
@@ -125,7 +125,7 @@ public class AviatorConnectionDiagnoseHelper {
             var evidence = AviatorDiagnosticEvidence.empty();
             evidence.put("tenant", configDescriptor.getTenant());
             report.optionalPass(STAGE_ADMIN, STAGE_ADMIN_DESCRIPTION,
-                "Aviator admin credentials are valid", "No action required", evidence);
+                "Aviator admin credentials are valid for tenant "+configDescriptor.getTenant(), "No action required", evidence);
         } catch (RuntimeException e) {
             rethrowIfBug(e);
             report.optionalFail(STAGE_ADMIN, STAGE_ADMIN_DESCRIPTION,

--- a/fcli-core/fcli-common-core/src/main/java/com/fortify/cli/common/http/UrlSchemes.java
+++ b/fcli-core/fcli-common-core/src/main/java/com/fortify/cli/common/http/UrlSchemes.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.common.http;
+
+/**
+ * Shared URL scheme detection (RFC 3986 scheme production, lenient for CLI inputs).
+ * Policy after detection (prepend https, reject non-https, …) stays with the caller.
+ */
+public final class UrlSchemes {
+    private static final String SCHEME_PREFIX = "^[a-zA-Z][a-zA-Z0-9+\\-.]*://.*$";
+
+    private UrlSchemes() {}
+
+    /** True when {@code url} starts with a scheme and {@code ://}. */
+    public static boolean hasScheme(String url) {
+        return url != null && url.matches(SCHEME_PREFIX);
+    }
+}

--- a/fcli-core/fcli-common-core/src/main/java/com/fortify/cli/common/http/proxy/helper/ProxyHelper.java
+++ b/fcli-core/fcli-common-core/src/main/java/com/fortify/cli/common/http/proxy/helper/ProxyHelper.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fortify.cli.common.exception.FcliSimpleException;
+import com.fortify.cli.common.http.UrlSchemes;
 import com.fortify.cli.common.util.FcliDataHelper;
 
 import kong.unirest.UnirestInstance;
@@ -75,14 +76,10 @@ public final class ProxyHelper {
 
     private static String normalizeTargetUrl(String targetUrlString) {
         var trimmed = StringUtils.trimToEmpty(targetUrlString);
-        if ( !hasScheme(trimmed) ) {
+        if ( !UrlSchemes.hasScheme(trimmed) ) {
             return "https://"+trimmed;
         }
         return trimmed;
-    }
-
-    private static boolean hasScheme(String url) {
-        return url.matches("^[a-zA-Z][a-zA-Z0-9+\\-.]*://.*$");
     }
 
     static Optional<String> getProxyEnvVarName(String targetScheme, Map<String, String> env) {
@@ -108,7 +105,7 @@ public final class ProxyHelper {
 
     private static String normalizeProxyUri(String envVarName, String proxyString) {
         var trimmed = StringUtils.trimToEmpty(proxyString);
-        if ( hasScheme(trimmed) ) {
+        if ( UrlSchemes.hasScheme(trimmed) ) {
             return trimmed;
         }
         if ( envVarName.toLowerCase(Locale.ROOT).startsWith("https_") ) {


### PR DESCRIPTION
This PR Improves Aviator connection diagnostics by enforcing HTTPS endpoints and adding clearer stage-level logging.

## Changes

- Enforce HTTPS-only Aviator URLs.
- Continue supporting scheme-less hosts by normalizing them to `https://`.
- Normalize uppercase HTTPS schemes to lowercase.
- Reject unsupported schemes such as `http`, `ftp`, and invalid scheme values with a dedicated exception.
- Add shared URL scheme detection for Aviator and proxy handling.
- Include URL scheme and provided URL details in endpoint failure evidence.
- Add diagnostic start and completion logging for endpoint, DNS, TCP, proxy, TLS, gRPC, and credential stages.
- Improve PASS, FAIL, WARN, and skipped-stage log messages.
- Include resolved DNS addresses and exception details in diagnostic logs where available.
- Preserve structured skip reasons in diagnostic results.
- Add and update regression tests for URL validation, diagnostic reporting, stage logging, and proxy handling.

## Testing

- Added and updated focused unit tests for Aviator URL normalization and connection diagnostics.