### PR TITLE
fix: `fcli ai mcp start-stdio` Add support for --server-name for custom MCP server name or default module specific name

### DIFF
--- a/fcli-core/fcli-ai-assist/src/main/java/com/fortify/cli/ai_assist/mcp/cli/cmd/AiAssistMCPStartHttpCommand.java
+++ b/fcli-core/fcli-ai-assist/src/main/java/com/fortify/cli/ai_assist/mcp/cli/cmd/AiAssistMCPStartHttpCommand.java
@@ -65,15 +65,8 @@ public class AiAssistMCPStartHttpCommand extends AbstractRunnableCommand impleme
     @Option(names = {"--config", "-c"}, required = true)
     private Path configPath;
 
-    @Option(names = {"--server-name"})
-    private String serverName;
-
     @Override
     public Integer call() throws Exception {
-        // Set dynamic default for serverName
-        if (serverName == null) {
-            serverName = "fcli-imported-functions";
-        }
         suppressProgressOutput();
         var config = MCPServerHttpConfigLoader.load(configPath);
         var asyncJobManager = new AsyncJobManager(AsyncJobManager.Config.builder()
@@ -84,7 +77,7 @@ public class AiAssistMCPStartHttpCommand extends AbstractRunnableCommand impleme
         var scopeCleanupScheduler = scheduleScopeCleanup(config, sessionDescriptorResolver);
         var specs = collectMcpSpecs(config, jobManager, sessionDescriptorResolver, authHeaderParser);
         var transport = createTransport(config);
-        buildAndStartServer(config, transport, specs, serverName);
+        buildAndStartServer(config, transport, specs);
         awaitShutdown(transport, asyncJobManager, scopeCleanupScheduler, sessionDescriptorResolver);
         return 0;
     }
@@ -159,10 +152,10 @@ public class AiAssistMCPStartHttpCommand extends AbstractRunnableCommand impleme
     }
 
     private void buildAndStartServer(MCPServerHttpConfig config,
-            JdkHttpServerMcpStatelessTransport transport, McpSpecs specs, String serverName) {
+            JdkHttpServerMcpStatelessTransport transport, McpSpecs specs) {
         var tlsConfigured = config.getServer().getTls() != null;
         var serverBuilder = McpServer.sync(transport)
-                .serverInfo(serverName, FcliBuildProperties.INSTANCE.getFcliVersion())
+                .serverInfo("fcli", FcliBuildProperties.INSTANCE.getFcliVersion())
                 .requestTimeout(Duration.ofSeconds(120))
                 .instructions("HTTP MCP server exposing imported fcli action functions")
                 .capabilities(getServerCapabilities(!specs.resourceTemplates().isEmpty()))

--- a/fcli-core/fcli-ai-assist/src/main/java/com/fortify/cli/ai_assist/mcp/cli/cmd/AiAssistMCPStartHttpCommand.java
+++ b/fcli-core/fcli-ai-assist/src/main/java/com/fortify/cli/ai_assist/mcp/cli/cmd/AiAssistMCPStartHttpCommand.java
@@ -65,8 +65,15 @@ public class AiAssistMCPStartHttpCommand extends AbstractRunnableCommand impleme
     @Option(names = {"--config", "-c"}, required = true)
     private Path configPath;
 
+    @Option(names = {"--server-name"})
+    private String serverName;
+
     @Override
     public Integer call() throws Exception {
+        // Set dynamic default for serverName
+        if (serverName == null) {
+            serverName = "fcli-imported-functions";
+        }
         suppressProgressOutput();
         var config = MCPServerHttpConfigLoader.load(configPath);
         var asyncJobManager = new AsyncJobManager(AsyncJobManager.Config.builder()
@@ -77,7 +84,7 @@ public class AiAssistMCPStartHttpCommand extends AbstractRunnableCommand impleme
         var scopeCleanupScheduler = scheduleScopeCleanup(config, sessionDescriptorResolver);
         var specs = collectMcpSpecs(config, jobManager, sessionDescriptorResolver, authHeaderParser);
         var transport = createTransport(config);
-        buildAndStartServer(config, transport, specs);
+        buildAndStartServer(config, transport, specs, serverName);
         awaitShutdown(transport, asyncJobManager, scopeCleanupScheduler, sessionDescriptorResolver);
         return 0;
     }
@@ -152,10 +159,10 @@ public class AiAssistMCPStartHttpCommand extends AbstractRunnableCommand impleme
     }
 
     private void buildAndStartServer(MCPServerHttpConfig config,
-            JdkHttpServerMcpStatelessTransport transport, McpSpecs specs) {
+            JdkHttpServerMcpStatelessTransport transport, McpSpecs specs, String serverName) {
         var tlsConfigured = config.getServer().getTls() != null;
         var serverBuilder = McpServer.sync(transport)
-                .serverInfo("fcli", FcliBuildProperties.INSTANCE.getFcliVersion())
+                .serverInfo(serverName, FcliBuildProperties.INSTANCE.getFcliVersion())
                 .requestTimeout(Duration.ofSeconds(120))
                 .instructions("HTTP MCP server exposing imported fcli action functions")
                 .capabilities(getServerCapabilities(!specs.resourceTemplates().isEmpty()))

--- a/fcli-core/fcli-ai-assist/src/main/java/com/fortify/cli/ai_assist/mcp/cli/cmd/AiAssistMCPStartStdioCommand.java
+++ b/fcli-core/fcli-ai-assist/src/main/java/com/fortify/cli/ai_assist/mcp/cli/cmd/AiAssistMCPStartStdioCommand.java
@@ -116,7 +116,7 @@ public class AiAssistMCPStartStdioCommand extends AbstractRunnableCommand implem
             if (module != null) {
                 serverName = "fcli-" + module.toString();
             } else {
-                serverName = "fcli-imported-functions";
+                serverName = "fcli";
             }
         }
         var rawOut = StdioHelper.getRawOut();

--- a/fcli-core/fcli-ai-assist/src/main/java/com/fortify/cli/ai_assist/mcp/cli/cmd/AiAssistMCPStartStdioCommand.java
+++ b/fcli-core/fcli-ai-assist/src/main/java/com/fortify/cli/ai_assist/mcp/cli/cmd/AiAssistMCPStartStdioCommand.java
@@ -112,11 +112,12 @@ public class AiAssistMCPStartStdioCommand extends AbstractRunnableCommand implem
         if (module == null && (importFiles == null || importFiles.isEmpty())) {
             throw new FcliSimpleException("At least one of --module or --import must be specified");
         }
-        if (serverName != null && module == null) {
-            throw new FcliSimpleException("--server-name requires --module to be specified");
-        }
-        if (serverName == null && module != null) {
-            serverName = "fcli-" + module.toString();
+        if (serverName == null) {
+            if (module != null) {
+                serverName = "fcli-" + module.toString();
+            } else {
+                serverName = "fcli-imported-functions";
+            }
         }
         var rawOut = StdioHelper.getRawOut();
         var rawErr = StdioHelper.getRawErr();

--- a/fcli-core/fcli-ai-assist/src/main/java/com/fortify/cli/ai_assist/mcp/cli/cmd/AiAssistMCPStartStdioCommand.java
+++ b/fcli-core/fcli-ai-assist/src/main/java/com/fortify/cli/ai_assist/mcp/cli/cmd/AiAssistMCPStartStdioCommand.java
@@ -93,6 +93,7 @@ public class AiAssistMCPStartStdioCommand extends AbstractRunnableCommand implem
     @Option(names={"--module", "-m"}, required = false) private McpModule module;
     @DisableTest(TestType.MULTI_OPT_PLURAL_NAME)
     @Option(names={"--import"}, split=",") private List<String> importFiles;
+    @Option(names={"--server-name"}) private String serverName;
     @Option(names={"--work-threads"}, defaultValue="10") private int workThreads;
     @Option(names={"--progress-threads"}, defaultValue="4") private int progressThreads;
     @Option(names={"--job-safe-return"}, defaultValue="25s") private String jobSafeReturnPeriod;
@@ -110,6 +111,12 @@ public class AiAssistMCPStartStdioCommand extends AbstractRunnableCommand implem
     public Integer call() throws Exception {
         if (module == null && (importFiles == null || importFiles.isEmpty())) {
             throw new FcliSimpleException("At least one of --module or --import must be specified");
+        }
+        if (serverName != null && module == null) {
+            throw new FcliSimpleException("--server-name requires --module to be specified");
+        }
+        if (serverName == null && module != null) {
+            serverName = "fcli-" + module.toString();
         }
         var rawOut = StdioHelper.getRawOut();
         var rawErr = StdioHelper.getRawErr();
@@ -147,7 +154,7 @@ public class AiAssistMCPStartStdioCommand extends AbstractRunnableCommand implem
         // Use rawOut to bypass the delegation/masking stack, ensuring
         // MCP JSON-RPC responses are never corrupted by masking
         var serverBuilder = McpServer.sync(new StdioServerTransportProvider(new JacksonMcpJsonMapper(objectMapper), wrappedIn, rawOut))
-                .serverInfo("fcli", FcliBuildProperties.INSTANCE.getFcliVersion())
+                .serverInfo(serverName, FcliBuildProperties.INSTANCE.getFcliVersion())
                 .requestTimeout(Duration.ofSeconds(120))
                 .instructions("""
                         - For tools that accept a --*-session option and user hasn't asked for a specific \

--- a/fcli-core/fcli-ai-assist/src/main/resources/com/fortify/cli/ai_assist/i18n/AiAssistMessages.properties
+++ b/fcli-core/fcli-ai-assist/src/main/resources/com/fortify/cli/ai_assist/i18n/AiAssistMessages.properties
@@ -83,7 +83,6 @@ fcli.ai-assist.mcp.start-stdio.progress-interval = Interval between internal pro
 fcli.ai-assist.mcp.start-stdio.async-bg-threads = Number of background threads for running async streaming jobs. Default: 2.
 fcli.ai-assist.mcp.start-stdio.server-name = Custom name for this MCP server instance. If not specified, defaults to 'fcli-<module-name>' when --module is provided, or 'fcli-imported-functions' when only --import is provided.
 
-fcli.ai-assist.mcp.start-http.server-name = Custom name for this MCP server instance. If not specified, defaults to 'fcli-imported-functions'.
 fcli.ai-assist.mcp.start-http.usage.header = Start fcli HTTP MCP server.
 fcli.ai-assist.mcp.start-http.usage.description = Start an HTTP MCP server exposing only exported functions from imported action YAML files defined in a config file. Generate a sample config file with 'fcli ai-assist mcp create-http-config --type <ssc|fod>' and customize the generated YAML for your environment. The server listens for MCP POST requests on the /mcp endpoint. Each request must include the product-specific auth header as semicolon-separated key=value pairs; escape literal '\\', ';', or '=' characters as '\\\\', '\\;', or '\\='.\
   %n%n${fcli.ai-assist.mcp.skills.note}\

--- a/fcli-core/fcli-ai-assist/src/main/resources/com/fortify/cli/ai_assist/i18n/AiAssistMessages.properties
+++ b/fcli-core/fcli-ai-assist/src/main/resources/com/fortify/cli/ai_assist/i18n/AiAssistMessages.properties
@@ -81,6 +81,7 @@ fcli.ai-assist.mcp.start-stdio.progress-threads = Number of threads used for upd
 fcli.ai-assist.mcp.start-stdio.job-safe-return = Maximum time to wait synchronously for a job result before returning an in_progress placeholder. Specify duration like 25s, 2m, 1h.
 fcli.ai-assist.mcp.start-stdio.progress-interval = Interval between internal progress counter updates for long-running jobs. Specify duration (e.g. 500ms, 1s, 2s).
 fcli.ai-assist.mcp.start-stdio.async-bg-threads = Number of background threads for running async streaming jobs. Default: 2.
+fcli.ai-assist.mcp.start-stdio.server-name = Custom name for this MCP server instance. If not specified, defaults to 'fcli-<module-name>' when --module is provided. Requires --module to be specified.
 
 fcli.ai-assist.mcp.start-http.usage.header = Start fcli HTTP MCP server.
 fcli.ai-assist.mcp.start-http.usage.description = Start an HTTP MCP server exposing only exported functions from imported action YAML files defined in a config file. Generate a sample config file with 'fcli ai-assist mcp create-http-config --type <ssc|fod>' and customize the generated YAML for your environment. The server listens for MCP POST requests on the /mcp endpoint. Each request must include the product-specific auth header as semicolon-separated key=value pairs; escape literal '\\', ';', or '=' characters as '\\\\', '\\;', or '\\='.\

--- a/fcli-core/fcli-ai-assist/src/main/resources/com/fortify/cli/ai_assist/i18n/AiAssistMessages.properties
+++ b/fcli-core/fcli-ai-assist/src/main/resources/com/fortify/cli/ai_assist/i18n/AiAssistMessages.properties
@@ -81,8 +81,9 @@ fcli.ai-assist.mcp.start-stdio.progress-threads = Number of threads used for upd
 fcli.ai-assist.mcp.start-stdio.job-safe-return = Maximum time to wait synchronously for a job result before returning an in_progress placeholder. Specify duration like 25s, 2m, 1h.
 fcli.ai-assist.mcp.start-stdio.progress-interval = Interval between internal progress counter updates for long-running jobs. Specify duration (e.g. 500ms, 1s, 2s).
 fcli.ai-assist.mcp.start-stdio.async-bg-threads = Number of background threads for running async streaming jobs. Default: 2.
-fcli.ai-assist.mcp.start-stdio.server-name = Custom name for this MCP server instance. If not specified, defaults to 'fcli-<module-name>' when --module is provided. Requires --module to be specified.
+fcli.ai-assist.mcp.start-stdio.server-name = Custom name for this MCP server instance. If not specified, defaults to 'fcli-<module-name>' when --module is provided, or 'fcli-imported-functions' when only --import is provided.
 
+fcli.ai-assist.mcp.start-http.server-name = Custom name for this MCP server instance. If not specified, defaults to 'fcli-imported-functions'.
 fcli.ai-assist.mcp.start-http.usage.header = Start fcli HTTP MCP server.
 fcli.ai-assist.mcp.start-http.usage.description = Start an HTTP MCP server exposing only exported functions from imported action YAML files defined in a config file. Generate a sample config file with 'fcli ai-assist mcp create-http-config --type <ssc|fod>' and customize the generated YAML for your environment. The server listens for MCP POST requests on the /mcp endpoint. Each request must include the product-specific auth header as semicolon-separated key=value pairs; escape literal '\\', ';', or '=' characters as '\\\\', '\\;', or '\\='.\
   %n%n${fcli.ai-assist.mcp.skills.note}\


### PR DESCRIPTION
Added support for a new `--server-name` option to the `fcli ai mcp start-stdio` command. This optional parameter can only be used together with the `--module` option. When specified, it creates the MCP server for the selected module using the provided server name. If not supplied, the server name defaults to `fcli-<module-name>`.