### PR TITLE
fix: fix potential 'out of range' error for custom tag id in issue-template update (int to long)

### DIFF
--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/issue_template/cli/cmd/AbstractSSCIssueTemplateUpdateCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/issue_template/cli/cmd/AbstractSSCIssueTemplateUpdateCommand.java
@@ -16,7 +16,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.LongNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fortify.cli.common.json.JsonHelper;
 import com.fortify.cli.common.output.transform.IActionCommandResultSupplier;
@@ -63,7 +63,7 @@ public abstract class AbstractSSCIssueTemplateUpdateCommand extends AbstractSSCJ
                 currentTags,
                 addTagsMixin.getTagSpecs(),
                 rmTagsMixin.getTagSpecs()
-        ).map(tag -> new IntNode(Integer.valueOf(tag.getId()))).collect(JsonHelper.arrayNodeCollector());
+        ).map(tag -> new LongNode(Long.valueOf(tag.getId()))).collect(JsonHelper.arrayNodeCollector());
     }
     
     @Override


### PR DESCRIPTION
Fixes a potential overflow bug when updating custom tags on an issue template. Custom tag IDs from SSC are numeric and were being parsed as Java int. Changed it to use long instead.