### PR TITLE
feat: Add `--force-reaudit` to re-audit Aviator-processed issues 

### DIFF
--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/AuditFPR.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/AuditFPR.java
@@ -74,7 +74,7 @@ public class AuditFPR {
         Map<String, AuditResponse> auditResponses = new ConcurrentHashMap<>();
         AuditOutcome auditOutcome = performAviatorAudit(
                 parsedData, options.getLogger(), options.getToken(), options.getAppVersion(), options.getUrl(), options.getSscAppName(), options.getSscAppVersion(),
-            auditResponses, filterSelection, options.getFprHandle(), options.getFolderPriorityOrder(), sourceDecoder
+            auditResponses, filterSelection, options.getFprHandle(), options.getFolderPriorityOrder(), sourceDecoder, options.isForceReaudit()
         );
 
         // --- STAGE 4: FINALIZATION ---
@@ -131,7 +131,7 @@ public class AuditFPR {
             ParsedFprData parsedData, IAviatorLogger logger,
             String token, String appVersion, String url, String sscAppName, String sscAppVersion,
             Map<String, AuditResponse> auditResponsesToFill, FilterSelection filterSelection, FprHandle fprHandle,
-            List<String> folderPriorityOrder, ISourceDecoder sourceDecoder) {
+            List<String> folderPriorityOrder, ISourceDecoder sourceDecoder, boolean forceReaudit) {
         SourceLanguageResolver sourceLanguageResolver =
             new SourceLanguageResolver(parsedData.streamingFVDLProcessor.getFvdlMetadata());
         parsedData.streamingFVDLProcessor.getFvdlMetadata().clearSourceFileTypeIndexes();
@@ -148,7 +148,8 @@ public class AuditFPR {
                 folderPriorityOrder,
                 sourceLanguageResolver,
                 sourceDecoder,
-                parsedData.streamingFVDLProcessor.getFvdlMetadata()
+                parsedData.streamingFVDLProcessor.getFvdlMetadata(),
+                forceReaudit
         );
         return issueAuditor.performAudit(
                 auditResponsesToFill, token, appVersion, parsedData.fprInfo.getBuildId(), url, fprHandle

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/AuditFPR.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/AuditFPR.java
@@ -129,16 +129,16 @@ public class AuditFPR {
             new SourceLanguageResolver(parsedData.streamingFVDLProcessor.getFvdlMetadata());
         parsedData.streamingFVDLProcessor.getFvdlMetadata().clearSourceFileTypeIndexes();
 
-        IssueAuditor issueAuditor = new IssueAuditor(
-                parsedData.vulnerabilities,
-                parsedData.auditProcessor,
-                parsedData.auditIssueMap,
-                parsedData.fprInfo,
-                filterSelection,
-                sourceLanguageResolver,
-                parsedData.streamingFVDLProcessor.getFvdlMetadata(),
-                options
-        );
+        IssueAuditor issueAuditor = IssueAuditor.builder()
+                .vulnerabilities(parsedData.vulnerabilities)
+                .auditProcessor(parsedData.auditProcessor)
+                .auditIssueMap(parsedData.auditIssueMap)
+                .fprInfo(parsedData.fprInfo)
+                .filterSelection(filterSelection)
+                .sourceLanguageResolver(sourceLanguageResolver)
+                .fvdlMetadata(parsedData.streamingFVDLProcessor.getFvdlMetadata())
+                .options(options)
+                .build();
         return issueAuditor.performAudit(auditResponsesToFill);
     }
 

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/AuditFPR.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/AuditFPR.java
@@ -139,10 +139,7 @@ public class AuditFPR {
                 parsedData.streamingFVDLProcessor.getFvdlMetadata(),
                 options
         );
-        return issueAuditor.performAudit(
-                auditResponsesToFill, options.getToken(), options.getAppVersion(),
-                parsedData.fprInfo.getBuildId(), options.getUrl(), options.getFprHandle()
-        );
+        return issueAuditor.performAudit(auditResponsesToFill);
     }
 
     private static FPRAuditResult finalizeFprAudit(

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/AuditFPR.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/AuditFPR.java
@@ -31,7 +31,6 @@ import com.fortify.cli.aviator.audit.model.AuditResponse;
 import com.fortify.cli.aviator.audit.model.FPRAuditResult;
 import com.fortify.cli.aviator.audit.model.FilterSelection;
 import com.fortify.cli.aviator.audit.model.ParsedFprData;
-import com.fortify.cli.aviator.config.IAviatorLogger;
 import com.fortify.cli.aviator.config.TagMappingConfig;
 import com.fortify.cli.aviator.fpr.FPRProcessor;
 import com.fortify.cli.aviator.fpr.Vulnerability;
@@ -72,10 +71,7 @@ public class AuditFPR {
 
         // --- STAGE 3: AUDITING ---
         Map<String, AuditResponse> auditResponses = new ConcurrentHashMap<>();
-        AuditOutcome auditOutcome = performAviatorAudit(
-                parsedData, options.getLogger(), options.getToken(), options.getAppVersion(), options.getUrl(), options.getSscAppName(), options.getSscAppVersion(),
-            auditResponses, filterSelection, options.getFprHandle(), options.getFolderPriorityOrder(), sourceDecoder, options.isForceReaudit()
-        );
+        AuditOutcome auditOutcome = performAviatorAudit(parsedData, auditResponses, filterSelection, options);
 
         // --- STAGE 4: FINALIZATION ---
         return finalizeFprAudit(
@@ -127,11 +123,8 @@ public class AuditFPR {
         return issueCategoryLookup;
     }
 
-    private static AuditOutcome performAviatorAudit(
-            ParsedFprData parsedData, IAviatorLogger logger,
-            String token, String appVersion, String url, String sscAppName, String sscAppVersion,
-            Map<String, AuditResponse> auditResponsesToFill, FilterSelection filterSelection, FprHandle fprHandle,
-            List<String> folderPriorityOrder, ISourceDecoder sourceDecoder, boolean forceReaudit) {
+    private static AuditOutcome performAviatorAudit(ParsedFprData parsedData, Map<String, AuditResponse> auditResponsesToFill,
+            FilterSelection filterSelection, AuditFprOptions options) {
         SourceLanguageResolver sourceLanguageResolver =
             new SourceLanguageResolver(parsedData.streamingFVDLProcessor.getFvdlMetadata());
         parsedData.streamingFVDLProcessor.getFvdlMetadata().clearSourceFileTypeIndexes();
@@ -141,18 +134,14 @@ public class AuditFPR {
                 parsedData.auditProcessor,
                 parsedData.auditIssueMap,
                 parsedData.fprInfo,
-                sscAppName,
-                sscAppVersion,
                 filterSelection,
-                logger,
-                folderPriorityOrder,
                 sourceLanguageResolver,
-                sourceDecoder,
                 parsedData.streamingFVDLProcessor.getFvdlMetadata(),
-                forceReaudit
+                options
         );
         return issueAuditor.performAudit(
-                auditResponsesToFill, token, appVersion, parsedData.fprInfo.getBuildId(), url, fprHandle
+                auditResponsesToFill, options.getToken(), options.getAppVersion(),
+                parsedData.fprInfo.getBuildId(), options.getUrl(), options.getFprHandle()
         );
     }
 

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/IssueAuditor.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/IssueAuditor.java
@@ -14,9 +14,11 @@ package com.fortify.cli.aviator.audit;
 
 import static com.fortify.cli.aviator.util.Constants.DEFAULT_PING_INTERVAL_SECONDS;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -41,7 +43,7 @@ import com.fortify.cli.aviator.audit.model.AuditOutcome;
 import com.fortify.cli.aviator.audit.model.AuditResponse;
 import com.fortify.cli.aviator.audit.model.FilterSelection;
 import com.fortify.cli.aviator.audit.model.UserPrompt;
-import com.fortify.cli.aviator.config.IAviatorLogger;
+import com.fortify.cli.aviator.config.TagMappingConfig;
 import com.fortify.cli.aviator.fpr.Vulnerability;
 import com.fortify.cli.aviator.fpr.filter.Filter;
 import com.fortify.cli.aviator.fpr.filter.FilterSet;
@@ -52,11 +54,10 @@ import com.fortify.cli.aviator.fpr.model.AuditIssue;
 import com.fortify.cli.aviator.fpr.model.FPRInfo;
 import com.fortify.cli.aviator.fpr.model.FVDLMetadata;
 import com.fortify.cli.aviator.fpr.processor.AuditProcessor;
-import com.fortify.cli.aviator.fpr.utils.ISourceDecoder;
 import com.fortify.cli.aviator.grpc.AviatorGrpcClient;
 import com.fortify.cli.aviator.grpc.AviatorGrpcClientHelper;
 import com.fortify.cli.aviator.util.Constants;
-import com.fortify.cli.aviator.util.FprHandle;
+import com.fortify.cli.aviator.util.ResourceUtil;
 import com.fortify.cli.aviator.util.StringUtil;
 
 
@@ -84,19 +85,16 @@ public class IssueAuditor {
     private TagDefinition humanAuditTag;
     private TagDefinition aviatorStatusTag;
     private final SourceLanguageResolver sourceLanguageResolver;
-    private final ISourceDecoder sourceDecoder;
     private final FVDLMetadata fvdlMetadata;
-    private final boolean forceReaudit;
-
-    private final IAviatorLogger logger;
-    private final List<String> customPriorityOrder;
+    private final AuditFprOptions options;
+    private final Set<String> resultTagIds;
 
     public IssueAuditor(List<Vulnerability> vulnerabilities, AuditProcessor auditProcessor, Map<String, AuditIssue> auditIssueMap,
             FPRInfo fprInfo, FilterSelection filterSelection, SourceLanguageResolver sourceLanguageResolver,
             FVDLMetadata fvdlMetadata, AuditFprOptions options) {
         Objects.requireNonNull(options, "options");
-        this.logger = options.getLogger();
-        this.customPriorityOrder = options.getFolderPriorityOrder();
+        Objects.requireNonNull(options.getSourceDecoder(), "sourceDecoder");
+        this.options = options;
         this.MAX_PER_CATEGORY = Constants.MAX_PER_CATEGORY;
         this.MAX_TOTAL = Constants.MAX_TOTAL;
         this.MAX_PER_CATEGORY_EXCEEDED = Constants.MAX_PER_CATEGORY_EXCEEDED;
@@ -110,11 +108,10 @@ public class IssueAuditor {
         this.SSCApplicationName = options.getSscAppName();
         this.SSCApplicationVersion = options.getSscAppVersion();
         this.sourceLanguageResolver = sourceLanguageResolver;
-        this.sourceDecoder = Objects.requireNonNull(options.getSourceDecoder(), "sourceDecoder");
         this.fvdlMetadata = fvdlMetadata;
-        this.forceReaudit = options.isForceReaudit();
         this.analysisTag = fprInfo.getFilterTemplate().getTagDefinitions().stream().filter(t -> "Analysis".equalsIgnoreCase(t.getName())).findFirst().orElse(null);
         this.resultsTag = resolveResultTag("", "", analysisTag);
+        this.resultTagIds = resolveResultTagIds();
     }
 
     private TagDefinition resolveResultTag(String tagName, String tagGuid, TagDefinition analysisTag) {
@@ -158,30 +155,30 @@ public class IssueAuditor {
         return new TagDefinition(name, id, values, false);
     }
 
-    public AuditOutcome performAudit(Map<String, AuditResponse> auditResponses, String token,
-                                     String projectName, String projectBuildId, String url, FprHandle fprHandle) {
-        projectName = StringUtil.isEmpty(projectName) ? projectBuildId : projectName;
-        logger.progress("Starting audit for project: %s", projectName);
+    public AuditOutcome performAudit(Map<String, AuditResponse> auditResponses) {
+        String projectName = StringUtil.isEmpty(options.getAppVersion()) ? fprInfo.getBuildId() : options.getAppVersion();
+        options.getLogger().progress("Starting audit for project: %s", projectName);
 
         ConcurrentLinkedDeque<UserPrompt> promptsToAudit = prepareAndFilterPrompts();
         int totalIssuesToAudit = promptsToAudit.size();
-        logger.progress("Final count of issues to be audited: %d", totalIssuesToAudit);
+        options.getLogger().progress("Final count of issues to be audited: %d", totalIssuesToAudit);
 
         if (promptsToAudit.isEmpty()) {
-            logger.progress("Audit skipped - no issues to process after filtering.");
+            options.getLogger().progress("Audit skipped - no issues to process after filtering.");
         } else {
-            try (AviatorGrpcClient client = AviatorGrpcClientHelper.createClient(url, logger, DEFAULT_PING_INTERVAL_SECONDS)) {
+            try (AviatorGrpcClient client = AviatorGrpcClientHelper.createClient(options.getUrl(), options.getLogger(), DEFAULT_PING_INTERVAL_SECONDS)) {
                 CompletableFuture<Map<String, AuditResponse>> future =
                         client.processBatchRequests(promptsToAudit, projectName, fprInfo.getBuildId(), SSCApplicationName,
-                            SSCApplicationVersion, token, fprHandle, customPriorityOrder, sourceDecoder, fvdlMetadata);
+                            SSCApplicationVersion, options.getToken(), options.getFprHandle(),
+                            options.getFolderPriorityOrder(), options.getSourceDecoder(), fvdlMetadata);
                 Map<String, AuditResponse> responses = future.get(500, TimeUnit.MINUTES);
                 responses.forEach((requestId, response) -> auditResponses.put(response.getIssueId(), response));
-                logger.progress("Audit completed");
+                options.getLogger().progress("Audit completed");
             } catch (ExecutionException e) {
                 Throwable cause = e.getCause();
                 // Handle quota filtering exception (all issues filtered out)
                 if (cause instanceof AviatorQuotaFilterException) {
-                    logger.progress("All issues filtered out due to quota constraints: %s", cause.getMessage());
+                    options.getLogger().progress("All issues filtered out due to quota constraints: %s", cause.getMessage());
                     // Update totalIssuesToAudit to reflect actual auditable count (0)
                     totalIssuesToAudit = 0;
                 } else if (cause instanceof AviatorSimpleException) {
@@ -192,10 +189,10 @@ public class IssueAuditor {
                     throw new AviatorTechnicalException("Unexpected error during audit execution", cause);
                 }
             } catch (TimeoutException e) {
-                logger.error("Audit failed due to timeout after 500 minutes");
+                options.getLogger().error("Audit failed due to timeout after 500 minutes");
                 throw new AviatorTechnicalException("Audit timed out after 500 minutes", e);
             } catch (InterruptedException e) {
-                logger.error("Audit failed due to interruption");
+                options.getLogger().error("Audit failed due to interruption");
                 Thread.currentThread().interrupt();
                 throw new AviatorTechnicalException("Audit interrupted", e);
             }
@@ -236,15 +233,18 @@ public class IssueAuditor {
 
 
     private boolean shouldInclude(UserPrompt userPrompt) {
-        if (forceReaudit && isProcessedByAviator(userPrompt)) {
-            if (isProtectedFromForceReaudit(userPrompt)) {
-                LOG.debug("Skipping force re-audit for suppressed or manually audited issue ID: {}",
+        AuditIssue auditIssue = auditIssue(userPrompt);
+        if (options.isForceReaudit()) {
+            if (hasHumanTriage(auditIssue)) {
+                LOG.debug("Skipping force re-audit for suppressed or human-triaged issue ID: {}",
                         userPrompt.getIssueData().getInstanceID());
                 return false;
             }
-            LOG.debug("Including previously processed Aviator issue for force re-audit: {}",
-                    userPrompt.getIssueData().getInstanceID());
-            return true;
+            if (isAviatorWork(auditIssue)) {
+                LOG.debug("Including previously processed Aviator issue for force re-audit: {}",
+                        userPrompt.getIssueData().getInstanceID());
+                return true;
+            }
         }
 
         if (isAudited(userPrompt)) {
@@ -252,12 +252,12 @@ public class IssueAuditor {
             return false;
         }
 
-        if (humanAuditTag != null && isManuallyAudited(userPrompt)) {
+        if (humanAuditTag != null && isManuallyAudited(auditIssue)) {
             LOG.debug("Skipping because already manually audited: {}", userPrompt.getIssueData().getInstanceID());
             return false;
         }
 
-        if (aviatorStatusTag != null && isProcessedByAviator(userPrompt)) {
+        if (aviatorStatusTag != null && isProcessedByAviator(auditIssue)) {
             LOG.debug("Skipping already processed by Aviator: {}", userPrompt.getIssueData().getInstanceID());
             return false;
         }
@@ -265,40 +265,99 @@ public class IssueAuditor {
         return true;
     }
 
-    private boolean isManuallyAudited(UserPrompt userPrompt) {
-        String issueId = userPrompt.getIssueData().getInstanceID();
-        String status = Optional.ofNullable(auditIssueMap.get(issueId)).map(AuditIssue::getTags)
-                .map(tags -> tags.get(Constants.FOD_TAG_ID)).orElse(null);
-        return !StringUtil.isPendingReviewValue(status);
+    private AuditIssue auditIssue(UserPrompt userPrompt) {
+        return auditIssueMap.get(userPrompt.getIssueData().getInstanceID());
     }
 
-    private boolean isProcessedByAviator(UserPrompt userPrompt) {
-        String issueId = userPrompt.getIssueData().getInstanceID();
-        String status = Optional.ofNullable(auditIssueMap.get(issueId)).map(AuditIssue::getTags)
-                .map(tags -> tags.get(Constants.AVIATOR_STATUS_TAG_ID)).orElse(null);
+    private static boolean isManuallyAudited(AuditIssue auditIssue) {
+        if (auditIssue == null || auditIssue.getTags() == null) {
+            return false;
+        }
+        return !StringUtil.isPendingReviewValue(auditIssue.getTags().get(Constants.FOD_TAG_ID));
+    }
+
+    private boolean isProcessedByAviator(AuditIssue auditIssue) {
+        if (auditIssue == null || auditIssue.getTags() == null) {
+            return false;
+        }
+        String status = auditIssue.getTags().get(Constants.AVIATOR_STATUS_TAG_ID);
         return !StringUtil.isEmpty(status) && Constants.PROCESSED_BY_AVIATOR.equalsIgnoreCase(status);
     }
 
-    private boolean isProtectedFromForceReaudit(UserPrompt userPrompt) {
-        AuditIssue auditIssue = auditIssueMap.get(userPrompt.getIssueData().getInstanceID());
+    private boolean hasHumanTriage(AuditIssue auditIssue) {
         if (auditIssue == null) {
             return false;
         }
         if (auditIssue.isSuppressed()) {
             return true;
         }
-
-        Map<String, String> tags = auditIssue.getTags();
-        if (tags == null) {
-            return false;
+        boolean processedByAviator = isProcessedByAviator(auditIssue);
+        for (String tagId : resultTagIds) {
+            if (!isResultTagSet(auditIssue, tagId)) {
+                continue;
+            }
+            String username = lastWriterUsername(auditIssue, tagId);
+            if (Constants.isAviatorAuditUsername(username)) {
+                continue;
+            }
+            if (!StringUtil.isEmpty(username) || Constants.FOD_TAG_ID.equalsIgnoreCase(tagId) || !processedByAviator) {
+                return true;
+            }
         }
+        return false;
+    }
 
-        String auditorStatus = tags.get(Constants.AUDITOR_STATUS_TAG_ID);
-        if (!StringUtil.isPendingReviewValue(auditorStatus)) {
+    private boolean isAviatorWork(AuditIssue auditIssue) {
+        if (isProcessedByAviator(auditIssue)) {
             return true;
         }
+        for (String tagId : resultTagIds) {
+            if (isResultTagSet(auditIssue, tagId) && Constants.isAviatorAuditUsername(lastWriterUsername(auditIssue, tagId))) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-        return isManuallyAudited(userPrompt);
+    private boolean isResultTagSet(AuditIssue auditIssue, String tagId) {
+        Map<String, String> tags = auditIssue.getTags();
+        return tags != null && !StringUtil.isPendingReviewValue(tags.get(tagId));
+    }
+
+    private String lastWriterUsername(AuditIssue auditIssue, String tagId) {
+        Map<String, String> lastTagUsernames = auditIssue.getLastTagUsernames();
+        if (lastTagUsernames == null) {
+            return null;
+        }
+        String username = lastTagUsernames.get(tagId);
+        return StringUtil.isEmpty(username) ? null : username;
+    }
+
+    private Set<String> resolveResultTagIds() {
+        Set<String> tagIds = new LinkedHashSet<>(List.of(
+                Constants.ANALYSIS_TAG_ID, Constants.AUDITOR_STATUS_TAG_ID, Constants.FOD_TAG_ID));
+        if (analysisTag != null && !StringUtil.isEmpty(analysisTag.getId())) {
+            tagIds.add(analysisTag.getId());
+        }
+        String mappedTagId = mappedTagId();
+        if (!StringUtil.isEmpty(mappedTagId)) {
+            tagIds.add(mappedTagId);
+        }
+        return Set.copyOf(tagIds);
+    }
+
+    private String mappedTagId() {
+        String tagMappingPath = options.getTagMappingPath();
+        if (tagMappingPath == null || tagMappingPath.isBlank()) {
+            return null;
+        }
+        try {
+            TagMappingConfig config = ResourceUtil.loadYamlFile(new File(tagMappingPath), TagMappingConfig.class);
+            return config == null ? null : config.getTag_id();
+        } catch (Exception e) {
+            LOG.debug("Could not read tag mapping file {}", tagMappingPath, e);
+            return null;
+        }
     }
 
     private boolean isAudited(UserPrompt userPrompt) {
@@ -383,7 +442,7 @@ public class IssueAuditor {
                 .flatMap(List::stream)
                 .distinct()
                 .collect(Collectors.toList());
-            logger.info("FilterSet '{}' applied. {} of {} total vulnerabilities remain.", fs.getTitle(), result.size(), allVulnerabilities.size());
+            options.getLogger().info("FilterSet '{}' applied. {} of {} total vulnerabilities remain.", fs.getTitle(), result.size(), allVulnerabilities.size());
             return result;
         } else {
             Set<String> targetFolderIds = fs.getFolderDefinitions().stream()
@@ -402,7 +461,7 @@ public class IssueAuditor {
                 .distinct()
                 .collect(Collectors.toList());
 
-            logger.info("Filtered by folder(s) '{}'. {} vulnerabilities remain.", targetFolderNames, result.size());
+            options.getLogger().info("Filtered by folder(s) '{}'. {} vulnerabilities remain.", targetFolderNames, result.size());
             return result;
         }
     }

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/IssueAuditor.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/IssueAuditor.java
@@ -343,7 +343,7 @@ public class IssueAuditor {
         if (!StringUtil.isEmpty(mappedTagId)) {
             tagIds.add(mappedTagId);
         }
-        return Set.copyOf(tagIds);
+        return tagIds;
     }
 
     private String mappedTagId() {

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/IssueAuditor.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/IssueAuditor.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import com.fortify.cli.aviator._common.exception.AviatorQuotaFilterException;
 import com.fortify.cli.aviator._common.exception.AviatorSimpleException;
 import com.fortify.cli.aviator._common.exception.AviatorTechnicalException;
+import com.fortify.cli.aviator.audit.model.AuditFprOptions;
 import com.fortify.cli.aviator.audit.model.AuditOutcome;
 import com.fortify.cli.aviator.audit.model.AuditResponse;
 import com.fortify.cli.aviator.audit.model.FilterSelection;
@@ -91,12 +92,11 @@ public class IssueAuditor {
     private final List<String> customPriorityOrder;
 
     public IssueAuditor(List<Vulnerability> vulnerabilities, AuditProcessor auditProcessor, Map<String, AuditIssue> auditIssueMap,
-            FPRInfo fprInfo, String SSCApplicationName, String SSCApplicationVersion,
-            FilterSelection filterSelection, IAviatorLogger logger, List<String> customPriorityOrder,
-            SourceLanguageResolver sourceLanguageResolver, ISourceDecoder sourceDecoder,
-            FVDLMetadata fvdlMetadata, boolean forceReaudit) {
-        this.logger = logger;
-        this.customPriorityOrder = customPriorityOrder;
+            FPRInfo fprInfo, FilterSelection filterSelection, SourceLanguageResolver sourceLanguageResolver,
+            FVDLMetadata fvdlMetadata, AuditFprOptions options) {
+        Objects.requireNonNull(options, "options");
+        this.logger = options.getLogger();
+        this.customPriorityOrder = options.getFolderPriorityOrder();
         this.MAX_PER_CATEGORY = Constants.MAX_PER_CATEGORY;
         this.MAX_TOTAL = Constants.MAX_TOTAL;
         this.MAX_PER_CATEGORY_EXCEEDED = Constants.MAX_PER_CATEGORY_EXCEEDED;
@@ -107,12 +107,12 @@ public class IssueAuditor {
         this.auditIssueMap = auditIssueMap;
         this.fprInfo = fprInfo;
         this.filterSelection = filterSelection;
-        this.SSCApplicationName = SSCApplicationName;
-        this.SSCApplicationVersion = SSCApplicationVersion;
+        this.SSCApplicationName = options.getSscAppName();
+        this.SSCApplicationVersion = options.getSscAppVersion();
         this.sourceLanguageResolver = sourceLanguageResolver;
-        this.sourceDecoder = Objects.requireNonNull(sourceDecoder, "sourceDecoder");
+        this.sourceDecoder = Objects.requireNonNull(options.getSourceDecoder(), "sourceDecoder");
         this.fvdlMetadata = fvdlMetadata;
-        this.forceReaudit = forceReaudit;
+        this.forceReaudit = options.isForceReaudit();
         this.analysisTag = fprInfo.getFilterTemplate().getTagDefinitions().stream().filter(t -> "Analysis".equalsIgnoreCase(t.getName())).findFirst().orElse(null);
         this.resultsTag = resolveResultTag("", "", analysisTag);
     }

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/IssueAuditor.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/IssueAuditor.java
@@ -52,7 +52,6 @@ import com.fortify.cli.aviator.fpr.model.FPRInfo;
 import com.fortify.cli.aviator.fpr.model.FVDLMetadata;
 import com.fortify.cli.aviator.fpr.processor.AuditProcessor;
 import com.fortify.cli.aviator.fpr.utils.ISourceDecoder;
-import com.fortify.cli.aviator.fpr.utils.SourceDecoders;
 import com.fortify.cli.aviator.grpc.AviatorGrpcClient;
 import com.fortify.cli.aviator.grpc.AviatorGrpcClientHelper;
 import com.fortify.cli.aviator.util.Constants;
@@ -90,23 +89,6 @@ public class IssueAuditor {
 
     private final IAviatorLogger logger;
     private final List<String> customPriorityOrder;
-
-    public IssueAuditor(List<Vulnerability> vulnerabilities, AuditProcessor auditProcessor, Map<String, AuditIssue> auditIssueMap,
-                        FPRInfo fprInfo, String SSCApplicationName, String SSCApplicationVersion,
-                        FilterSelection filterSelection, IAviatorLogger logger, List<String> customPriorityOrder,
-                        SourceLanguageResolver sourceLanguageResolver) {
-        this(vulnerabilities, auditProcessor, auditIssueMap, fprInfo, SSCApplicationName, SSCApplicationVersion,
-            filterSelection, logger, customPriorityOrder, sourceLanguageResolver, SourceDecoders.defaults(), null, false);
-    }
-
-    public IssueAuditor(List<Vulnerability> vulnerabilities, AuditProcessor auditProcessor, Map<String, AuditIssue> auditIssueMap,
-                        FPRInfo fprInfo, String SSCApplicationName, String SSCApplicationVersion,
-                        FilterSelection filterSelection, IAviatorLogger logger, List<String> customPriorityOrder,
-                        SourceLanguageResolver sourceLanguageResolver, ISourceDecoder sourceDecoder,
-                        FVDLMetadata fvdlMetadata) {
-        this(vulnerabilities, auditProcessor, auditIssueMap, fprInfo, SSCApplicationName, SSCApplicationVersion,
-            filterSelection, logger, customPriorityOrder, sourceLanguageResolver, sourceDecoder, fvdlMetadata, false);
-    }
 
     public IssueAuditor(List<Vulnerability> vulnerabilities, AuditProcessor auditProcessor, Map<String, AuditIssue> auditIssueMap,
             FPRInfo fprInfo, String SSCApplicationName, String SSCApplicationVersion,

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/IssueAuditor.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/IssueAuditor.java
@@ -60,6 +60,8 @@ import com.fortify.cli.aviator.util.Constants;
 import com.fortify.cli.aviator.util.ResourceUtil;
 import com.fortify.cli.aviator.util.StringUtil;
 
+import lombok.Builder;
+
 
 public class IssueAuditor {
 
@@ -89,6 +91,7 @@ public class IssueAuditor {
     private final AuditFprOptions options;
     private final Set<String> resultTagIds;
 
+    @Builder
     public IssueAuditor(List<Vulnerability> vulnerabilities, AuditProcessor auditProcessor, Map<String, AuditIssue> auditIssueMap,
             FPRInfo fprInfo, FilterSelection filterSelection, SourceLanguageResolver sourceLanguageResolver,
             FVDLMetadata fvdlMetadata, AuditFprOptions options) {

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/IssueAuditor.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/IssueAuditor.java
@@ -86,6 +86,7 @@ public class IssueAuditor {
     private final SourceLanguageResolver sourceLanguageResolver;
     private final ISourceDecoder sourceDecoder;
     private final FVDLMetadata fvdlMetadata;
+    private final boolean forceReaudit;
 
     private final IAviatorLogger logger;
     private final List<String> customPriorityOrder;
@@ -95,7 +96,7 @@ public class IssueAuditor {
                         FilterSelection filterSelection, IAviatorLogger logger, List<String> customPriorityOrder,
                         SourceLanguageResolver sourceLanguageResolver) {
         this(vulnerabilities, auditProcessor, auditIssueMap, fprInfo, SSCApplicationName, SSCApplicationVersion,
-                filterSelection, logger, customPriorityOrder, sourceLanguageResolver, SourceDecoders.defaults(), null);
+            filterSelection, logger, customPriorityOrder, sourceLanguageResolver, SourceDecoders.defaults(), null, false);
     }
 
     public IssueAuditor(List<Vulnerability> vulnerabilities, AuditProcessor auditProcessor, Map<String, AuditIssue> auditIssueMap,
@@ -103,6 +104,15 @@ public class IssueAuditor {
                         FilterSelection filterSelection, IAviatorLogger logger, List<String> customPriorityOrder,
                         SourceLanguageResolver sourceLanguageResolver, ISourceDecoder sourceDecoder,
                         FVDLMetadata fvdlMetadata) {
+        this(vulnerabilities, auditProcessor, auditIssueMap, fprInfo, SSCApplicationName, SSCApplicationVersion,
+            filterSelection, logger, customPriorityOrder, sourceLanguageResolver, sourceDecoder, fvdlMetadata, false);
+    }
+
+    public IssueAuditor(List<Vulnerability> vulnerabilities, AuditProcessor auditProcessor, Map<String, AuditIssue> auditIssueMap,
+            FPRInfo fprInfo, String SSCApplicationName, String SSCApplicationVersion,
+            FilterSelection filterSelection, IAviatorLogger logger, List<String> customPriorityOrder,
+            SourceLanguageResolver sourceLanguageResolver, ISourceDecoder sourceDecoder,
+            FVDLMetadata fvdlMetadata, boolean forceReaudit) {
         this.logger = logger;
         this.customPriorityOrder = customPriorityOrder;
         this.MAX_PER_CATEGORY = Constants.MAX_PER_CATEGORY;
@@ -120,6 +130,7 @@ public class IssueAuditor {
         this.sourceLanguageResolver = sourceLanguageResolver;
         this.sourceDecoder = Objects.requireNonNull(sourceDecoder, "sourceDecoder");
         this.fvdlMetadata = fvdlMetadata;
+        this.forceReaudit = forceReaudit;
         this.analysisTag = fprInfo.getFilterTemplate().getTagDefinitions().stream().filter(t -> "Analysis".equalsIgnoreCase(t.getName())).findFirst().orElse(null);
         this.resultsTag = resolveResultTag("", "", analysisTag);
     }
@@ -243,31 +254,69 @@ public class IssueAuditor {
 
 
     private boolean shouldInclude(UserPrompt userPrompt) {
+        if (forceReaudit && isProcessedByAviator(userPrompt)) {
+            if (isProtectedFromForceReaudit(userPrompt)) {
+                LOG.debug("Skipping force re-audit for suppressed or manually audited issue ID: {}",
+                        userPrompt.getIssueData().getInstanceID());
+                return false;
+            }
+            LOG.debug("Including previously processed Aviator issue for force re-audit: {}",
+                    userPrompt.getIssueData().getInstanceID());
+            return true;
+        }
 
         if (isAudited(userPrompt)) {
             LOG.debug("Skipping already audited issue ID: {}", userPrompt.getIssueData().getInstanceID());
             return false;
         }
 
-        if (humanAuditTag != null) {
-            String issueId = userPrompt.getIssueData().getInstanceID();
-            String status = Optional.ofNullable(auditIssueMap.get(issueId)).map(AuditIssue::getTags).map(tags -> tags.get("604f0fbe-b5fe-47cd-a9cb-587ad8ebe93a")).orElse(null);
-            if (!StringUtil.isEmpty(status) && !Constants.PENDING_REVIEW.equalsIgnoreCase(status)) {
-                LOG.debug("Skipping because already manually audited: {}", issueId);
-                return false;
-            }
+        if (humanAuditTag != null && isManuallyAudited(userPrompt)) {
+            LOG.debug("Skipping because already manually audited: {}", userPrompt.getIssueData().getInstanceID());
+            return false;
         }
 
-        if (aviatorStatusTag != null) {
-            String issueId = userPrompt.getIssueData().getInstanceID();
-            String status = Optional.ofNullable(auditIssueMap.get(issueId)).map(AuditIssue::getTags).map(tags -> tags.get("FB7B0462-2C2E-46D9-811A-DCC1F3C83051")).orElse(null);
-            if (!StringUtil.isEmpty(status) && Constants.PROCESSED_BY_AVIATOR.equalsIgnoreCase(status)) {
-                LOG.debug("Skipping already PROCESSED_BY_AVIATOR: {}", issueId);
-                return false;
-            }
+        if (aviatorStatusTag != null && isProcessedByAviator(userPrompt)) {
+            LOG.debug("Skipping already processed by Aviator: {}", userPrompt.getIssueData().getInstanceID());
+            return false;
         }
 
         return true;
+    }
+
+    private boolean isManuallyAudited(UserPrompt userPrompt) {
+        String issueId = userPrompt.getIssueData().getInstanceID();
+        String status = Optional.ofNullable(auditIssueMap.get(issueId)).map(AuditIssue::getTags)
+                .map(tags -> tags.get(Constants.FOD_TAG_ID)).orElse(null);
+        return !StringUtil.isPendingReviewValue(status);
+    }
+
+    private boolean isProcessedByAviator(UserPrompt userPrompt) {
+        String issueId = userPrompt.getIssueData().getInstanceID();
+        String status = Optional.ofNullable(auditIssueMap.get(issueId)).map(AuditIssue::getTags)
+                .map(tags -> tags.get(Constants.AVIATOR_STATUS_TAG_ID)).orElse(null);
+        return !StringUtil.isEmpty(status) && Constants.PROCESSED_BY_AVIATOR.equalsIgnoreCase(status);
+    }
+
+    private boolean isProtectedFromForceReaudit(UserPrompt userPrompt) {
+        AuditIssue auditIssue = auditIssueMap.get(userPrompt.getIssueData().getInstanceID());
+        if (auditIssue == null) {
+            return false;
+        }
+        if (auditIssue.isSuppressed()) {
+            return true;
+        }
+
+        Map<String, String> tags = auditIssue.getTags();
+        if (tags == null) {
+            return false;
+        }
+
+        String auditorStatus = tags.get(Constants.AUDITOR_STATUS_TAG_ID);
+        if (!StringUtil.isPendingReviewValue(auditorStatus)) {
+            return true;
+        }
+
+        return isManuallyAudited(userPrompt);
     }
 
     private boolean isAudited(UserPrompt userPrompt) {
@@ -282,7 +331,7 @@ public class IssueAuditor {
         String auditorStatusTag = Constants.AUDITOR_STATUS_TAG_ID;
 
         String auditorStatusValue = tags.get(auditorStatusTag);
-        if (auditorStatusValue != null && !auditorStatusValue.equalsIgnoreCase("Pending Review")) {
+        if (!StringUtil.isPendingReviewValue(auditorStatusValue)) {
             return true;
         }
 
@@ -299,12 +348,12 @@ public class IssueAuditor {
 
             if (analysisTag != null && tags.containsKey(analysisTag.getId())) {
                 String tagValue = tags.get(analysisTag.getId());
-                if (tagValue != null && !tagValue.equalsIgnoreCase("Not Set") && !tagValue.equalsIgnoreCase(Constants.PENDING_REVIEW) && !tagValue.trim().isEmpty()) {
+                if (!StringUtil.isPendingReviewValue(tagValue)) {
                     return true;
                 }
             }
 
-            if (tags.containsKey(analysisTagS) && !tags.get(analysisTagS).equalsIgnoreCase("Not Set") && !StringUtil.isEmpty(tags.get(analysisTagS))) {
+            if (tags.containsKey(analysisTagS) && !StringUtil.isPendingReviewValue(tags.get(analysisTagS))) {
                 return true;
             }
         }

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/model/AuditFprOptions.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/model/AuditFprOptions.java
@@ -36,5 +36,6 @@ public class AuditFprOptions {
     private final boolean noFilterSet;
     private final List<String> folderNames;
     private final List<String> folderPriorityOrder;
+    @Builder.Default private final boolean forceReaudit = false;
     @Builder.Default private final ISourceDecoder sourceDecoder = SourceDecoders.defaults();
 }

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/FPRProcessor.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/FPRProcessor.java
@@ -146,7 +146,7 @@ public class FPRProcessor {
         }
 
         String auditorStatusValue = tags.get(Constants.AUDITOR_STATUS_TAG_ID);
-        if (!isPendingReviewValue(auditorStatusValue)) {
+        if (!StringUtil.isPendingReviewValue(auditorStatusValue)) {
             return true;
         }
 
@@ -159,16 +159,7 @@ public class FPRProcessor {
         }
 
         String analysisTagValue = tags.get(Constants.ANALYSIS_TAG_ID);
-        return analysisTagValue != null
-            && !analysisTagValue.equalsIgnoreCase("Not Set")
-            && !analysisTagValue.equalsIgnoreCase(Constants.PENDING_REVIEW)
-            && !StringUtil.isEmpty(analysisTagValue);
-    }
-
-    private boolean isPendingReviewValue(String value) {
-        return StringUtil.isEmpty(value)
-            || value.equalsIgnoreCase("Pending Review")
-            || value.equalsIgnoreCase(Constants.PENDING_REVIEW);
+        return !StringUtil.isPendingReviewValue(analysisTagValue);
     }
 
     private String resolveIssueStatus(AuditIssue auditIssue) {

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/model/AuditIssue.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/model/AuditIssue.java
@@ -30,6 +30,7 @@ public class AuditIssue {
     private boolean suppressed;
     private int revision;
     @Builder.Default private Map<String, String> tags = new HashMap<>();
+    @Builder.Default private Map<String, String> lastTagUsernames = new HashMap<>();
     @Builder.Default private List<Comment> threadedComments = new ArrayList<>();
 
     public void addTag(String tagId, String tagValue) {

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/AuditProcessor.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/AuditProcessor.java
@@ -249,6 +249,7 @@ public class AuditProcessor {
             tags.put(tagId, tagValue);
         }
         auditIssueBuilder.tags(tags);
+        auditIssueBuilder.lastTagUsernames(lastTagUsernames(issueElement));
 
         List<AuditIssue.Comment> threadedComments = new ArrayList<>();
         NodeList commentNodes = issueElement.getElementsByTagNameNS(AUDIT_NAMESPACE_URI, "Comment");
@@ -266,6 +267,24 @@ public class AuditProcessor {
         return auditIssueBuilder.build();
     }
 
+
+    private Map<String, String> lastTagUsernames(Element issueElement) {
+        Map<String, String> lastTagUsernames = new HashMap<>();
+        NodeList tagHistories = issueElement.getElementsByTagNameNS(AUDIT_NAMESPACE_URI, "TagHistory");
+        for (int index = 0; index < tagHistories.getLength(); index++) {
+            Element tagHistory = (Element) tagHistories.item(index);
+            NodeList tags = tagHistory.getElementsByTagNameNS(AUDIT_NAMESPACE_URI, "Tag");
+            if (tags.getLength() == 0) {
+                continue;
+            }
+            String tagId = ((Element) tags.item(0)).getAttribute("id");
+            String username = Optional.ofNullable(getFirstElementContentNS(tagHistory, "Username")).orElse("");
+            if (tagId != null && !tagId.isBlank()) {
+                lastTagUsernames.put(tagId, username);
+            }
+        }
+        return lastTagUsernames;
+    }
 
     private String getTagValue(Element tagElement) {
         NodeList valueNodes = tagElement.getElementsByTagNameNS(AUDIT_NAMESPACE_URI, "Value");

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/RemediationProcessor.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/RemediationProcessor.java
@@ -213,7 +213,7 @@ public class RemediationProcessor {
         try {
             Map<Path, PendingFileWrite> pendingWrites = prepareFileChanges(remediation, sourceBasePath, fvdlMetadata);
             if (pendingWrites.isEmpty()) {
-                recordSkipped(skippedByReason, SkipReason.NO_CHANGES);
+                recordSkipped(skippedByReason, SkipReason.NO_CHANGES.displayName);
                 return false;
             }
             try {
@@ -224,15 +224,15 @@ public class RemediationProcessor {
                 throw new SkipRemediationException(SkipReason.SOURCE_WRITE_FAILED, e.getMessage(), e);
             }
         } catch (SkipRemediationException e) {
-            recordSkipped(skippedByReason, e.reason);
-            LOG.info("Skipping remediation {}: {}", instanceId, e.getMessage());
+            recordSkipped(skippedByReason, skipReasonLabel(e));
+            LOG.warn("Skipping remediation {}: {}", instanceId, e.getMessage());
             LOG.debug("Skip reason for remediation {}: {}", instanceId, e.reason.displayName, e);
             return false;
         } catch (RollbackRemediationException e) {
             throw e;
         } catch (Exception e) {
-            recordSkipped(skippedByReason, SkipReason.UNEXPECTED_ERROR);
-            LOG.info("Skipping remediation {} due to an unexpected processing error", instanceId);
+            recordSkipped(skippedByReason, SkipReason.UNEXPECTED_ERROR.displayName);
+            LOG.warn("Skipping remediation {} due to an unexpected processing error", instanceId);
             LOG.debug("Unexpected error while processing remediation {}", instanceId, e);
             return false;
         }
@@ -564,8 +564,15 @@ public class RemediationProcessor {
         }
     }
 
-    private void recordSkipped(Map<String, Integer> skippedByReason, SkipReason reason) {
-        skippedByReason.merge(reason.displayName, 1, Integer::sum);
+    private void recordSkipped(Map<String, Integer> skippedByReason, String reason) {
+        skippedByReason.merge(reason, 1, Integer::sum);
+    }
+
+    private String skipReasonLabel(SkipRemediationException exception) {
+        if (exception.reason == SkipReason.SOURCE_CONTEXT_AMBIGUOUS) {
+            return exception.getMessage();
+        }
+        return exception.reason.displayName;
     }
 
     private String formatSkippedReasons(Map<String, Integer> skippedByReason) {

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/RemediationProcessor.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/RemediationProcessor.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.zip.ZipFile;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -85,6 +86,7 @@ public class RemediationProcessor {
         REMEDIATION_DATA_INVALID("Remediation data invalid"),
         REMEDIATION_LINE_RANGE_INVALID("Remediation line range invalid"),
         SOURCE_CONTEXT_NOT_FOUND("Source context not found"),
+        SOURCE_CONTEXT_AMBIGUOUS("Source context matched multiple locations"),
         ORIGINAL_CODE_NOT_FOUND("Original code not found"),
         REMEDIATION_ENCODE_FAILED("Remediation encode failed"),
         SOURCE_WRITE_FAILED("Source file write failed"),
@@ -307,7 +309,8 @@ public class RemediationProcessor {
         LOG.debug("Remediation {} hash check for '{}': {}", instanceId, filename, fileHashMatches ? "matched" : "mismatched");
         if (!fileHashMatches) {
             LOG.debug("File hash mismatch for remediation {} in {}; searching changed source content", instanceId, filename);
-            String contextText = getRequiredElementText(change, "Context");
+            Element contextElement = getRequiredElement(change, "Context");
+            String contextText = contextElement.getTextContent();
             List<String> contextLine = Arrays.asList(contextText.split("\\r?\\n"));
             int contextLineFrom = fuzzySearchContext(instanceId, filename, originalLines, contextLine);
             if (contextLineFrom == -1) {
@@ -320,7 +323,10 @@ public class RemediationProcessor {
 
             String originalCodeText = getRequiredElementText(change, "OriginalCode");
             List<String> originalCodeLine = Arrays.asList(originalCodeText.split("\\r?\\n"));
-            int[] lineFromTo = fuzzySearchOriginalCode(instanceId, filename, originalLines, originalCodeLine, contextLineFrom);
+            int contextBefore = parseRequiredContextAttribute(contextElement, "before");
+            int contextAfter = parseRequiredContextAttribute(contextElement, "after");
+            int[] lineFromTo = fuzzySearchOriginalCode(instanceId, filename, originalLines, originalCodeLine,
+                    contextLineFrom, contextLine.size(), contextBefore, contextAfter);
             if (lineFromTo[0] == -1 || lineFromTo[1] == -1) {
                 LOG.debug("Original code search failed for remediation {} in {}; context line={}, original code lines={}, source lines={}",
                         instanceId, filename, contextLineFrom + 1, originalCodeLine.size(), originalLines.size());
@@ -387,7 +393,15 @@ public class RemediationProcessor {
 
     private int fuzzySearchContext(String instanceId, String filename, List<String> originalLines, List<String> contextLine) {
         try {
-            return FuzzyContextSearcher.fuzzySearchContext(originalLines, contextLine, 0);
+            List<Integer> matches = FuzzyContextSearcher.fuzzySearchContextMatches(originalLines, contextLine, 0);
+            if (matches.size() > 1) {
+                String candidateLines = matches.stream()
+                        .map(line -> String.valueOf(line + 1))
+                        .collect(Collectors.joining(", "));
+                throw new SkipRemediationException(SkipReason.SOURCE_CONTEXT_AMBIGUOUS,
+                        "Source context matched multiple locations in file '" + filename + "'; candidate lines: " + candidateLines);
+            }
+            return matches.isEmpty() ? -1 : matches.get(0);
         } catch (IOException e) {
             throw new SkipRemediationException(SkipReason.SOURCE_CONTEXT_NOT_FOUND,
                     "Error searching source context for remediation '" + instanceId + "' in file '" + filename + "'", e);
@@ -395,8 +409,19 @@ public class RemediationProcessor {
     }
 
     private int[] fuzzySearchOriginalCode(String instanceId, String filename, List<String> originalLines, List<String> originalCodeLine,
-            int contextLineFrom) {
-        return FuzzyContextSearcher.fuzzySearchOriginalCode(originalLines, originalCodeLine, 0, contextLineFrom);
+            int contextLineFrom, int contextLineCount, int contextBefore, int contextAfter) {
+        int contextStart = contextLineFrom + contextBefore;
+        int contextEnd = contextLineFrom + contextLineCount - contextAfter;
+        if (contextStart < 0 || contextStart >= contextEnd || contextEnd > originalLines.size()) {
+            return new int[] {-1, -1};
+        }
+
+        int[] lineFromTo = FuzzyContextSearcher.fuzzySearchOriginalCode(
+                originalLines.subList(contextStart, contextEnd), originalCodeLine, 0, 0);
+        if (lineFromTo[0] == -1 || lineFromTo[1] == -1) {
+            return lineFromTo;
+        }
+        return new int[] {lineFromTo[0] + contextStart, lineFromTo[1] + contextStart};
     }
 
     private boolean isFilePresent(Path path) {
@@ -447,12 +472,34 @@ public class RemediationProcessor {
     }
 
     private String getRequiredElementText(Element parent, String elementName) {
+        return getRequiredElement(parent, elementName).getTextContent();
+    }
+
+    private Element getRequiredElement(Element parent, String elementName) {
         NodeList nodes = parent.getElementsByTagNameNS(NAMESPACE_URI, elementName);
         if (nodes.getLength() == 0 || nodes.item(0) == null) {
             throw new SkipRemediationException(SkipReason.REMEDIATION_DATA_INVALID,
                     "Missing required remediation element '" + elementName + "'");
         }
-        return nodes.item(0).getTextContent();
+        return (Element) nodes.item(0);
+    }
+
+    private int parseRequiredContextAttribute(Element context, String attributeName) {
+        String value = context.getAttribute(attributeName);
+        if (value == null || value.isBlank()) {
+            throw new SkipRemediationException(SkipReason.REMEDIATION_DATA_INVALID,
+                    "Missing required remediation context attribute '" + attributeName + "'");
+        }
+        try {
+            int parsedValue = Integer.parseInt(value);
+            if (parsedValue < 0) {
+                throw new NumberFormatException("negative value");
+            }
+            return parsedValue;
+        } catch (NumberFormatException e) {
+            throw new SkipRemediationException(SkipReason.REMEDIATION_DATA_INVALID,
+                    "Invalid remediation context attribute '" + attributeName + "': " + value, e);
+        }
     }
 
     private int parseRequiredInt(Element parent, String elementName) {

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/RemediationProcessor.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/RemediationProcessor.java
@@ -569,9 +569,6 @@ public class RemediationProcessor {
     }
 
     private String skipReasonLabel(SkipRemediationException exception) {
-        if (exception.reason == SkipReason.SOURCE_CONTEXT_AMBIGUOUS) {
-            return exception.getMessage();
-        }
         return exception.reason.displayName;
     }
 

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/util/Constants.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/util/Constants.java
@@ -12,6 +12,9 @@
  */
 package com.fortify.cli.aviator.util;
 
+import java.util.Locale;
+import java.util.Set;
+
 public class Constants {
 
     // Audit Result Values
@@ -45,8 +48,19 @@ public class Constants {
     public static final String AUDITOR_STATUS_TAG_ID = "ACB05E55-E74D-468C-8501-52E1FDC27D71";
     public static final String FOD_TAG_ID = "604f0fbe-b5fe-47cd-a9cb-587ad8ebe93a";
 
-    // User Names
+    // User Names written into audit.xml TagHistory / comments
     public static final String USER_NAME = "Fortify Remediation Aviator";
+    public static final String USER_NAME_LEGACY_FORTIFY_AVIATOR = "Fortify Aviator";
+    public static final String USER_NAME_LEGACY_CORE_SAST_AVIATOR = "Core SAST Aviator";
+    private static final Set<String> AVIATOR_AUDIT_USERNAMES = Set.of(
+            USER_NAME.toLowerCase(Locale.ROOT),
+            USER_NAME_LEGACY_FORTIFY_AVIATOR.toLowerCase(Locale.ROOT),
+            USER_NAME_LEGACY_CORE_SAST_AVIATOR.toLowerCase(Locale.ROOT)
+    );
+
+    public static boolean isAviatorAuditUsername(String username) {
+        return username != null && AVIATOR_AUDIT_USERNAMES.contains(username.trim().toLowerCase(Locale.ROOT));
+    }
 
     // Other Constants
     public static final String AUDIT_NAMESPACE_URI = "xmlns://www.fortify.com/schema/audit";

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/util/FuzzyContextSearcher.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/util/FuzzyContextSearcher.java
@@ -28,58 +28,70 @@ public class FuzzyContextSearcher {
      */
 
     public static int fuzzySearchContext(List<String> sourceLines, List<String> contextLines, int maxMismatches) throws IOException {
+        List<Integer> matches = fuzzySearchContextMatches(sourceLines, contextLines, maxMismatches);
+        return matches.isEmpty() ? -1 : matches.get(0);
+    }
+
+    public static List<Integer> fuzzySearchContextMatches(List<String> sourceLines, List<String> contextLines,
+            int maxMismatches) throws IOException {
         List<String> normalizedSource = normalizeLines(sourceLines);
         List<String> normalizedContext = normalizeLines(contextLines);
+        List<Integer> matches = new ArrayList<>();
+        boolean contextStartsWithBlank = !normalizedContext.isEmpty() && normalizedContext.get(0).isEmpty();
 
         for (int i = 0; i < normalizedSource.size(); i++) {
-            int mismatchCount = 0;
-            int sourceIndex = i;
-            int contextIndex = 0;
-            boolean similar = false;
-
-            while (contextIndex < normalizedContext.size() && sourceIndex < normalizedSource.size()) {
-                String contextLine = normalizedContext.get(contextIndex).trim();
-
-                if (contextLine.isEmpty()) {
-                    contextIndex++; // Skip empty context lines
-                    continue;
-                }
-
-                // Skip empty source lines too
-                String sourceLine = normalizedSource.get(sourceIndex).trim();
-                while (sourceLine.isEmpty()) {
-                    sourceIndex++;
-                    if (sourceIndex >= normalizedSource.size()) {
-                        break;
-                    }
-                    sourceLine = normalizedSource.get(sourceIndex).trim();
-                    if(!similar)
-                        i = sourceIndex;
-                }
-
-                if (sourceIndex >= normalizedSource.size()) {
-                    break; // No more source lines to match
-                }
-
-                similar = linesSimilar(sourceLine, contextLine);
-
-                if (!similar) {
-                    mismatchCount++;
-                    if (mismatchCount > maxMismatches) {
-                        break;
-                    }
-                }
-
-                sourceIndex++;
-                contextIndex++;
+            boolean sourceStartsWithBlank = normalizedSource.get(i).isEmpty();
+            if (contextStartsWithBlank
+                    ? !sourceStartsWithBlank || (i > 0 && normalizedSource.get(i - 1).isEmpty())
+                    : sourceStartsWithBlank) {
+                continue;
             }
-
-            if (contextIndex == normalizedContext.size() && mismatchCount <= maxMismatches) {
-                return i; // Found approximate match starting at i (ignoring blanks)
+            Integer matchStart = findContextMatchStart(normalizedSource, normalizedContext, maxMismatches, i);
+            if (matchStart != null && !matches.contains(matchStart)) {
+                matches.add(matchStart);
             }
         }
 
-        return -1; // Not found
+        return List.copyOf(matches);
+    }
+
+    private static Integer findContextMatchStart(List<String> normalizedSource, List<String> normalizedContext,
+            int maxMismatches, int startIndex) {
+        int mismatchCount = 0;
+        int sourceIndex = startIndex;
+        int contextIndex = 0;
+
+        while (contextIndex < normalizedContext.size() && sourceIndex < normalizedSource.size()) {
+            String contextLine = normalizedContext.get(contextIndex).trim();
+            if (contextLine.isEmpty()) {
+                contextIndex++;
+                continue;
+            }
+
+            String sourceLine = normalizedSource.get(sourceIndex).trim();
+            while (sourceLine.isEmpty()) {
+                sourceIndex++;
+                if (sourceIndex >= normalizedSource.size()) {
+                    break;
+                }
+                sourceLine = normalizedSource.get(sourceIndex).trim();
+            }
+            if (sourceIndex >= normalizedSource.size()) {
+                break;
+            }
+
+            if (!linesSimilar(sourceLine, contextLine)) {
+                mismatchCount++;
+                if (mismatchCount > maxMismatches) {
+                    break;
+                }
+            }
+
+            sourceIndex++;
+            contextIndex++;
+        }
+
+        return contextIndex == normalizedContext.size() && mismatchCount <= maxMismatches ? startIndex : null;
     }
 
     public static int[] fuzzySearchOriginalCode(List<String> sourceLines, List<String> originalCodeLine, int maxMismatches, int startIndex) {

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/util/FuzzyContextSearcher.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/util/FuzzyContextSearcher.java
@@ -40,10 +40,7 @@ public class FuzzyContextSearcher {
         boolean contextStartsWithBlank = !normalizedContext.isEmpty() && normalizedContext.get(0).isEmpty();
 
         for (int i = 0; i < normalizedSource.size(); i++) {
-            boolean sourceStartsWithBlank = normalizedSource.get(i).isEmpty();
-            if (contextStartsWithBlank
-                    ? !sourceStartsWithBlank || (i > 0 && normalizedSource.get(i - 1).isEmpty())
-                    : sourceStartsWithBlank) {
+            if (isUnusableContextStart(normalizedSource, i, contextStartsWithBlank)) {
                 continue;
             }
             Integer matchStart = findContextMatchStart(normalizedSource, normalizedContext, maxMismatches, i);
@@ -55,6 +52,14 @@ public class FuzzyContextSearcher {
         return List.copyOf(matches);
     }
 
+    private static boolean isUnusableContextStart(List<String> normalizedSource, int index, boolean contextStartsWithBlank) {
+        boolean sourceStartsWithBlank = normalizedSource.get(index).isEmpty();
+        if (!contextStartsWithBlank) {
+            return sourceStartsWithBlank;
+        }
+        return !sourceStartsWithBlank || (index > 0 && normalizedSource.get(index - 1).isEmpty());
+    }
+
     private static Integer findContextMatchStart(List<String> normalizedSource, List<String> normalizedContext,
             int maxMismatches, int startIndex) {
         int mismatchCount = 0;
@@ -62,25 +67,18 @@ public class FuzzyContextSearcher {
         int contextIndex = 0;
 
         while (contextIndex < normalizedContext.size() && sourceIndex < normalizedSource.size()) {
-            String contextLine = normalizedContext.get(contextIndex).trim();
+            String contextLine = normalizedContext.get(contextIndex);
             if (contextLine.isEmpty()) {
                 contextIndex++;
                 continue;
             }
 
-            String sourceLine = normalizedSource.get(sourceIndex).trim();
-            while (sourceLine.isEmpty()) {
-                sourceIndex++;
-                if (sourceIndex >= normalizedSource.size()) {
-                    break;
-                }
-                sourceLine = normalizedSource.get(sourceIndex).trim();
-            }
+            sourceIndex = skipEmptySourceLines(normalizedSource, sourceIndex);
             if (sourceIndex >= normalizedSource.size()) {
                 break;
             }
 
-            if (!linesSimilar(sourceLine, contextLine)) {
+            if (!linesSimilar(normalizedSource.get(sourceIndex), contextLine)) {
                 mismatchCount++;
                 if (mismatchCount > maxMismatches) {
                     break;
@@ -155,7 +153,7 @@ public class FuzzyContextSearcher {
     private static List<String> normalizeLines(List<String> lines) {
         List<String> result = new ArrayList<>();
         for (String line : lines) {
-                result.add(line.trim().replaceAll("\\s+", " "));
+            result.add(line.trim().replaceAll("\\s+", " "));
         }
         return result;
     }

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/util/StringUtil.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/util/StringUtil.java
@@ -23,6 +23,17 @@ public class StringUtil {
         return test == null || test.length() == 0;
     }
 
+    public static boolean isPendingReviewValue(String value) {
+        if (value == null) {
+            return true;
+        }
+        String normalizedValue = value.trim();
+        return normalizedValue.isEmpty()
+                || "Pending Review".equalsIgnoreCase(normalizedValue)
+                || "Not Set".equalsIgnoreCase(normalizedValue)
+                || Constants.PENDING_REVIEW.equalsIgnoreCase(normalizedValue);
+    }
+
     /**
      * Strips HTML-like tags from a string to clean it up for display.
      *

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/audit/IssueAuditorTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/audit/IssueAuditorTest.java
@@ -127,110 +127,110 @@ class IssueAuditorTest {
         assertEquals("", fprInfo.getBuildId());
     }
 
-        @Test
-        void skipsPreviouslyProcessedAviatorIssueWithoutForceReaudit() throws Exception {
+    @Test
+    void skipsPreviouslyProcessedAviatorIssueWithoutForceReaudit() throws Exception {
         IssueAuditor auditor = createIssueAuditor(false, false,
-            Map.of(Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR));
+                Map.of(Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR));
 
         assertTrue(prepareIssueIds(auditor).isEmpty());
-        }
+    }
 
-        @Test
-        void forceReauditIncludesProcessedAviatorIssueAndIgnoresAviatorOutcomeTag() throws Exception {
+    @Test
+    void forceReauditIncludesProcessedAviatorIssueAndIgnoresAviatorOutcomeTag() throws Exception {
         IssueAuditor auditor = createIssueAuditor(true, false, Map.of(
-            Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR,
-            Constants.AVIATOR_EXPECTED_OUTCOME_TAG_ID, Constants.EXPLOITABLE));
+                Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR,
+                Constants.AVIATOR_EXPECTED_OUTCOME_TAG_ID, Constants.EXPLOITABLE));
 
         assertEquals(List.of(TEST_ISSUE_ID), prepareIssueIds(auditor));
-        }
+    }
 
-        @Test
-        void forceReauditIncludesProcessedAviatorIssueWithAnalysisTag() throws Exception {
+    @Test
+    void forceReauditIncludesProcessedAviatorIssueWithAnalysisTag() throws Exception {
         IssueAuditor auditor = createIssueAuditor(true, false, Map.of(
-            Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR,
-            Constants.ANALYSIS_TAG_ID, Constants.EXPLOITABLE));
+                Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR,
+                Constants.ANALYSIS_TAG_ID, Constants.EXPLOITABLE));
 
         assertEquals(List.of(TEST_ISSUE_ID), prepareIssueIds(auditor));
-        }
+    }
 
-        @Test
-        void forceReauditStillSkipsSuppressedIssue() throws Exception {
+    @Test
+    void forceReauditStillSkipsSuppressedIssue() throws Exception {
         IssueAuditor auditor = createIssueAuditor(true, true,
-            Map.of(Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR));
+                Map.of(Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR));
 
         assertTrue(prepareIssueIds(auditor).isEmpty());
-        }
+    }
 
-        @Test
-        void forceReauditStillSkipsHumanTriagedIssue() throws Exception {
+    @Test
+    void forceReauditStillSkipsHumanTriagedIssue() throws Exception {
         IssueAuditor auditor = createIssueAuditor(true, false, Map.of(
-            Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR,
-            Constants.FOD_TAG_ID, Constants.EXPLOITABLE));
+                Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR,
+                Constants.FOD_TAG_ID, Constants.EXPLOITABLE));
 
         assertTrue(prepareIssueIds(auditor).isEmpty());
-        }
+    }
 
-        @Test
-        void forceReauditIncludesIssueWithPendingReviewState() throws Exception {
-            IssueAuditor auditor = createIssueAuditor(true, false, Map.of(
-                    Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR,
-                    Constants.FOD_TAG_ID, "Pending Review",
-                    Constants.AUDITOR_STATUS_TAG_ID, Constants.PENDING_REVIEW));
-
-            assertEquals(List.of(TEST_ISSUE_ID), prepareIssueIds(auditor));
-        }
-
-        @Test
-        void treatsAllPendingAnalysisValuesAsUnaudited() throws Exception {
-            for (String pendingValue : List.of("Pending Review", "Not Set", "Pending Review/Not Set", " pending review ")) {
-                IssueAuditor auditor = createIssueAuditor(false, false, Map.of(Constants.ANALYSIS_TAG_ID, pendingValue));
-
-                assertEquals(List.of(TEST_ISSUE_ID), prepareIssueIds(auditor), pendingValue);
-            }
-        }
-
-        @Test
-        void forceReauditStillSkipsIssueWithManualAuditorStatus() throws Exception {
+    @Test
+    void forceReauditIncludesIssueWithPendingReviewState() throws Exception {
         IssueAuditor auditor = createIssueAuditor(true, false, Map.of(
-            Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR,
-            Constants.AUDITOR_STATUS_TAG_ID, Constants.EXPLOITABLE),
-            Map.of(Constants.AUDITOR_STATUS_TAG_ID, "analyst.user"));
-
-        assertTrue(prepareIssueIds(auditor).isEmpty());
-        }
-
-        @Test
-        void forceReauditIncludesAviatorWrittenAuditorStatus() throws Exception {
-        IssueAuditor auditor = createIssueAuditor(true, false, Map.of(
-            Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR,
-            Constants.AUDITOR_STATUS_TAG_ID, Constants.EXPLOITABLE),
-            Map.of(Constants.AUDITOR_STATUS_TAG_ID, Constants.USER_NAME));
+                Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR,
+                Constants.FOD_TAG_ID, "Pending Review",
+                Constants.AUDITOR_STATUS_TAG_ID, Constants.PENDING_REVIEW));
 
         assertEquals(List.of(TEST_ISSUE_ID), prepareIssueIds(auditor));
-        }
+    }
 
-        @Test
-        void forceReauditSkipsHumanAnalysisOverrideAfterAviator() throws Exception {
+    @Test
+    void treatsAllPendingAnalysisValuesAsUnaudited() throws Exception {
+        for (String pendingValue : List.of("Pending Review", "Not Set", "Pending Review/Not Set", " pending review ")) {
+            IssueAuditor auditor = createIssueAuditor(false, false, Map.of(Constants.ANALYSIS_TAG_ID, pendingValue));
+
+            assertEquals(List.of(TEST_ISSUE_ID), prepareIssueIds(auditor), pendingValue);
+        }
+    }
+
+    @Test
+    void forceReauditStillSkipsIssueWithManualAuditorStatus() throws Exception {
         IssueAuditor auditor = createIssueAuditor(true, false, Map.of(
-            Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR,
-            Constants.ANALYSIS_TAG_ID, Constants.EXPLOITABLE),
-            Map.of(Constants.ANALYSIS_TAG_ID, "analyst.user"));
+                Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR,
+                Constants.AUDITOR_STATUS_TAG_ID, Constants.EXPLOITABLE),
+                Map.of(Constants.AUDITOR_STATUS_TAG_ID, "analyst.user"));
 
         assertTrue(prepareIssueIds(auditor).isEmpty());
-        }
+    }
 
-        @Test
-        void forceReauditIncludesLegacyFortifyAviatorUsername() throws Exception {
+    @Test
+    void forceReauditIncludesAviatorWrittenAuditorStatus() throws Exception {
         IssueAuditor auditor = createIssueAuditor(true, false, Map.of(
-            Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR,
-            Constants.ANALYSIS_TAG_ID, Constants.EXPLOITABLE),
-            Map.of(Constants.ANALYSIS_TAG_ID, Constants.USER_NAME_LEGACY_FORTIFY_AVIATOR));
+                Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR,
+                Constants.AUDITOR_STATUS_TAG_ID, Constants.EXPLOITABLE),
+                Map.of(Constants.AUDITOR_STATUS_TAG_ID, Constants.USER_NAME));
 
         assertEquals(List.of(TEST_ISSUE_ID), prepareIssueIds(auditor));
-        }
+    }
 
-        @Test
-        void forceReauditIncludesMappedTagWrittenByAviatorWithoutStatusTag() throws Exception {
+    @Test
+    void forceReauditSkipsHumanAnalysisOverrideAfterAviator() throws Exception {
+        IssueAuditor auditor = createIssueAuditor(true, false, Map.of(
+                Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR,
+                Constants.ANALYSIS_TAG_ID, Constants.EXPLOITABLE),
+                Map.of(Constants.ANALYSIS_TAG_ID, "analyst.user"));
+
+        assertTrue(prepareIssueIds(auditor).isEmpty());
+    }
+
+    @Test
+    void forceReauditIncludesLegacyFortifyAviatorUsername() throws Exception {
+        IssueAuditor auditor = createIssueAuditor(true, false, Map.of(
+                Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR,
+                Constants.ANALYSIS_TAG_ID, Constants.EXPLOITABLE),
+                Map.of(Constants.ANALYSIS_TAG_ID, Constants.USER_NAME_LEGACY_FORTIFY_AVIATOR));
+
+        assertEquals(List.of(TEST_ISSUE_ID), prepareIssueIds(auditor));
+    }
+
+    @Test
+    void forceReauditIncludesMappedTagWrittenByAviatorWithoutStatusTag() throws Exception {
         Path mappingFile = writeMappedTagFile();
         try {
             IssueAuditor auditor = createIssueAuditor(true, false,
@@ -241,10 +241,10 @@ class IssueAuditorTest {
         } finally {
             Files.deleteIfExists(mappingFile);
         }
-        }
+    }
 
-        @Test
-        void forceReauditSkipsHumanWriterOnMappedTag() throws Exception {
+    @Test
+    void forceReauditSkipsHumanWriterOnMappedTag() throws Exception {
         Path mappingFile = writeMappedTagFile();
         try {
             IssueAuditor auditor = createIssueAuditor(true, false,
@@ -255,25 +255,25 @@ class IssueAuditorTest {
         } finally {
             Files.deleteIfExists(mappingFile);
         }
-        }
+    }
 
-        private Path writeMappedTagFile() throws IOException {
+    private Path writeMappedTagFile() throws IOException {
         Path mappingFile = Files.createTempFile("tag-mapping", ".yaml");
         Files.writeString(mappingFile, "tag_id: \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\"\n");
         return mappingFile;
-        }
+    }
 
-        private IssueAuditor createIssueAuditor(boolean forceReaudit, boolean suppressed, Map<String, String> tags) {
+    private IssueAuditor createIssueAuditor(boolean forceReaudit, boolean suppressed, Map<String, String> tags) {
         return createIssueAuditor(forceReaudit, suppressed, tags, Map.of(), null);
-        }
+    }
 
-        private IssueAuditor createIssueAuditor(boolean forceReaudit, boolean suppressed, Map<String, String> tags,
-                Map<String, String> lastTagUsernames) {
+    private IssueAuditor createIssueAuditor(boolean forceReaudit, boolean suppressed, Map<String, String> tags,
+            Map<String, String> lastTagUsernames) {
         return createIssueAuditor(forceReaudit, suppressed, tags, lastTagUsernames, null);
-        }
+    }
 
-        private IssueAuditor createIssueAuditor(boolean forceReaudit, boolean suppressed, Map<String, String> tags,
-                Map<String, String> lastTagUsernames, String tagMappingPath) {
+    private IssueAuditor createIssueAuditor(boolean forceReaudit, boolean suppressed, Map<String, String> tags,
+            Map<String, String> lastTagUsernames, String tagMappingPath) {
         FPRInfo fprInfo = new FPRInfo(fprHandle);
         FilterTemplate filterTemplate = new FilterTemplate();
         filterTemplate.setTagDefinitions(new ArrayList<>());
@@ -282,42 +282,46 @@ class IssueAuditorTest {
         Vulnerability vulnerability = new Vulnerability();
         vulnerability.setInstanceID(TEST_ISSUE_ID);
         AuditIssue auditIssue = AuditIssue.builder()
-            .instanceId(TEST_ISSUE_ID)
-            .suppressed(suppressed)
-            .tags(new HashMap<>(tags))
-            .lastTagUsernames(new HashMap<>(lastTagUsernames))
-            .build();
+                .instanceId(TEST_ISSUE_ID)
+                .suppressed(suppressed)
+                .tags(new HashMap<>(tags))
+                .lastTagUsernames(new HashMap<>(lastTagUsernames))
+                .build();
 
-        return new IssueAuditor(
-            List.of(vulnerability), null, Map.of(TEST_ISSUE_ID, auditIssue), fprInfo,
-            new FilterSelection(null, null), new SourceLanguageResolver(new FVDLMetadata()), null,
-            auditOptions(forceReaudit, NO_OP_LOGGER, tagMappingPath));
-        }
+        return IssueAuditor.builder()
+                .vulnerabilities(List.of(vulnerability))
+                .auditIssueMap(Map.of(TEST_ISSUE_ID, auditIssue))
+                .fprInfo(fprInfo)
+                .filterSelection(new FilterSelection(null, null))
+                .sourceLanguageResolver(new SourceLanguageResolver(new FVDLMetadata()))
+                .options(auditOptions(forceReaudit, NO_OP_LOGGER, tagMappingPath))
+                .build();
+    }
 
-        private AuditFprOptions auditOptions(boolean forceReaudit, IAviatorLogger logger) {
+    private AuditFprOptions auditOptions(boolean forceReaudit, IAviatorLogger logger) {
         return auditOptions(forceReaudit, logger, null);
-        }
+    }
 
-        private AuditFprOptions auditOptions(boolean forceReaudit, IAviatorLogger logger, String tagMappingPath) {
+    private AuditFprOptions auditOptions(boolean forceReaudit, IAviatorLogger logger, String tagMappingPath) {
         return AuditFprOptions.builder()
-            .fprHandle(fprHandle)
-            .logger(logger)
-            .sscAppName("TestApp")
-            .sscAppVersion("1.0")
-            .tagMappingPath(tagMappingPath)
-            .forceReaudit(forceReaudit)
-            .build();
-        }
+                .fprHandle(fprHandle)
+                .logger(logger)
+                .sscAppName("TestApp")
+                .sscAppVersion("1.0")
+                .tagMappingPath(tagMappingPath)
+                .forceReaudit(forceReaudit)
+                .build();
+    }
 
-        @SuppressWarnings("unchecked")
-        private List<String> prepareIssueIds(IssueAuditor auditor) throws Exception {
+    @SuppressWarnings("unchecked")
+    private List<String> prepareIssueIds(IssueAuditor auditor) throws Exception {
         Method prepareMethod = IssueAuditor.class.getDeclaredMethod("prepareAndFilterPrompts");
         prepareMethod.setAccessible(true);
         ConcurrentLinkedDeque<UserPrompt> prompts = (ConcurrentLinkedDeque<UserPrompt>) prepareMethod.invoke(auditor);
         return prompts.stream()
-            .map(prompt -> prompt.getIssueData().getInstanceID())
-            .collect(Collectors.toList());
-        }
+                .map(prompt -> prompt.getIssueData().getInstanceID())
+                .collect(Collectors.toList());
+    }
 
     @Test
     void testFilterVulnerabilities_LegacySyntaxWithSpaces() throws Exception {
@@ -365,11 +369,14 @@ class IssueAuditorTest {
 
         List<Vulnerability> inputList = Arrays.asList(targetVuln, hiddenVuln);
 
-        IssueAuditor auditor = new IssueAuditor(
-            inputList, null, new HashMap<>(), fprInfo,
-            selection, new SourceLanguageResolver(new FVDLMetadata()), null,
-            auditOptions(false, dummyLogger)
-        );
+        IssueAuditor auditor = IssueAuditor.builder()
+                .vulnerabilities(inputList)
+                .auditIssueMap(new HashMap<>())
+                .fprInfo(fprInfo)
+                .filterSelection(selection)
+                .sourceLanguageResolver(new SourceLanguageResolver(new FVDLMetadata()))
+                .options(auditOptions(false, dummyLogger))
+                .build();
 
         Method filterMethod = IssueAuditor.class.getDeclaredMethod("filterVulnerabilities", List.class, FilterSet.class);
         filterMethod.setAccessible(true);
@@ -378,8 +385,8 @@ class IssueAuditorTest {
         List<Vulnerability> results = (List<Vulnerability>) filterMethod.invoke(auditor, inputList, filterSet);
 
         List<String> remainingIds = results.stream()
-            .map(Vulnerability::getInstanceID)
-            .collect(Collectors.toList());
+                .map(Vulnerability::getInstanceID)
+                .collect(Collectors.toList());
 
         assertEquals(1, remainingIds.size(), "Should verify that exactly one issue remains");
         assertTrue(remainingIds.contains("TARGET_ISSUE"),

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/audit/IssueAuditorTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/audit/IssueAuditorTest.java
@@ -25,6 +25,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -34,17 +36,29 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.fortify.cli.aviator.audit.model.FilterSelection;
+import com.fortify.cli.aviator.audit.model.UserPrompt;
 import com.fortify.cli.aviator.config.IAviatorLogger;
 import com.fortify.cli.aviator.fpr.Vulnerability;
 import com.fortify.cli.aviator.fpr.filter.Filter;
 import com.fortify.cli.aviator.fpr.filter.FilterSet;
 import com.fortify.cli.aviator.fpr.filter.FilterTemplate;
+import com.fortify.cli.aviator.fpr.model.AuditIssue;
 import com.fortify.cli.aviator.fpr.model.FPRInfo;
 import com.fortify.cli.aviator.fpr.model.FVDLMetadata;
+import com.fortify.cli.aviator.fpr.utils.SourceDecoders;
+import com.fortify.cli.aviator.util.Constants;
 import com.fortify.cli.aviator.util.FprHandle;
 
 
 class IssueAuditorTest {
+
+    private static final String TEST_ISSUE_ID = "PROCESSED_ISSUE";
+    private static final IAviatorLogger NO_OP_LOGGER = new IAviatorLogger() {
+        @Override public void progress(String format, Object... args) {}
+        @Override public void info(String format, Object... args) {}
+        @Override public void warn(String format, Object... args) {}
+        @Override public void error(String format, Object... args) {}
+    };
 
     private Path tempFprFile;
     private FprHandle fprHandle;
@@ -112,6 +126,98 @@ class IssueAuditorTest {
 
         assertEquals("", fprInfo.getBuildId());
     }
+
+        @Test
+        void skipsPreviouslyProcessedAviatorIssueWithoutForceReaudit() throws Exception {
+        IssueAuditor auditor = createIssueAuditor(false, false,
+            Map.of(Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR));
+
+        assertTrue(prepareIssueIds(auditor).isEmpty());
+        }
+
+        @Test
+        void forceReauditIncludesProcessedAviatorIssueAndIgnoresAviatorOutcomeTag() throws Exception {
+        IssueAuditor auditor = createIssueAuditor(true, false, Map.of(
+            Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR,
+            Constants.AVIATOR_EXPECTED_OUTCOME_TAG_ID, Constants.EXPLOITABLE));
+
+        assertEquals(List.of(TEST_ISSUE_ID), prepareIssueIds(auditor));
+        }
+
+        @Test
+        void forceReauditStillSkipsSuppressedIssue() throws Exception {
+        IssueAuditor auditor = createIssueAuditor(true, true,
+            Map.of(Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR));
+
+        assertTrue(prepareIssueIds(auditor).isEmpty());
+        }
+
+        @Test
+        void forceReauditStillSkipsHumanTriagedIssue() throws Exception {
+        IssueAuditor auditor = createIssueAuditor(true, false, Map.of(
+            Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR,
+            Constants.FOD_TAG_ID, Constants.EXPLOITABLE));
+
+        assertTrue(prepareIssueIds(auditor).isEmpty());
+        }
+
+        @Test
+        void forceReauditIncludesIssueWithPendingReviewState() throws Exception {
+            IssueAuditor auditor = createIssueAuditor(true, false, Map.of(
+                    Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR,
+                    Constants.FOD_TAG_ID, "Pending Review",
+                    Constants.AUDITOR_STATUS_TAG_ID, Constants.PENDING_REVIEW));
+
+            assertEquals(List.of(TEST_ISSUE_ID), prepareIssueIds(auditor));
+        }
+
+        @Test
+        void treatsAllPendingAnalysisValuesAsUnaudited() throws Exception {
+            for (String pendingValue : List.of("Pending Review", "Not Set", "Pending Review/Not Set", " pending review ")) {
+                IssueAuditor auditor = createIssueAuditor(false, false, Map.of(Constants.ANALYSIS_TAG_ID, pendingValue));
+
+                assertEquals(List.of(TEST_ISSUE_ID), prepareIssueIds(auditor), pendingValue);
+            }
+        }
+
+        @Test
+        void forceReauditStillSkipsIssueWithManualAuditorStatus() throws Exception {
+        IssueAuditor auditor = createIssueAuditor(true, false, Map.of(
+            Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR,
+            Constants.AUDITOR_STATUS_TAG_ID, Constants.EXPLOITABLE));
+
+        assertTrue(prepareIssueIds(auditor).isEmpty());
+        }
+
+        private IssueAuditor createIssueAuditor(boolean forceReaudit, boolean suppressed, Map<String, String> tags) {
+        FPRInfo fprInfo = new FPRInfo(fprHandle);
+        FilterTemplate filterTemplate = new FilterTemplate();
+        filterTemplate.setTagDefinitions(new ArrayList<>());
+        fprInfo.setFilterTemplate(filterTemplate);
+
+        Vulnerability vulnerability = new Vulnerability();
+        vulnerability.setInstanceID(TEST_ISSUE_ID);
+        AuditIssue auditIssue = AuditIssue.builder()
+            .instanceId(TEST_ISSUE_ID)
+            .suppressed(suppressed)
+            .tags(new HashMap<>(tags))
+            .build();
+
+        return new IssueAuditor(
+            List.of(vulnerability), null, Map.of(TEST_ISSUE_ID, auditIssue), fprInfo,
+            "TestApp", "1.0", new FilterSelection(null, null), NO_OP_LOGGER, null,
+            new SourceLanguageResolver(new FVDLMetadata()), SourceDecoders.defaults(), null, forceReaudit);
+        }
+
+        @SuppressWarnings("unchecked")
+        private List<String> prepareIssueIds(IssueAuditor auditor) throws Exception {
+        Method prepareMethod = IssueAuditor.class.getDeclaredMethod("prepareAndFilterPrompts");
+        prepareMethod.setAccessible(true);
+        ConcurrentLinkedDeque<UserPrompt> prompts = (ConcurrentLinkedDeque<UserPrompt>) prepareMethod.invoke(auditor);
+        return prompts.stream()
+            .map(prompt -> prompt.getIssueData().getInstanceID())
+            .collect(Collectors.toList());
+        }
 
     @Test
     void testFilterVulnerabilities_LegacySyntaxWithSpaces() throws Exception {

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/audit/IssueAuditorTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/audit/IssueAuditorTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.fortify.cli.aviator.audit.model.AuditFprOptions;
 import com.fortify.cli.aviator.audit.model.FilterSelection;
 import com.fortify.cli.aviator.audit.model.UserPrompt;
 import com.fortify.cli.aviator.config.IAviatorLogger;
@@ -45,7 +46,6 @@ import com.fortify.cli.aviator.fpr.filter.FilterTemplate;
 import com.fortify.cli.aviator.fpr.model.AuditIssue;
 import com.fortify.cli.aviator.fpr.model.FPRInfo;
 import com.fortify.cli.aviator.fpr.model.FVDLMetadata;
-import com.fortify.cli.aviator.fpr.utils.SourceDecoders;
 import com.fortify.cli.aviator.util.Constants;
 import com.fortify.cli.aviator.util.FprHandle;
 
@@ -214,8 +214,18 @@ class IssueAuditorTest {
 
         return new IssueAuditor(
             List.of(vulnerability), null, Map.of(TEST_ISSUE_ID, auditIssue), fprInfo,
-            "TestApp", "1.0", new FilterSelection(null, null), NO_OP_LOGGER, null,
-            new SourceLanguageResolver(new FVDLMetadata()), SourceDecoders.defaults(), null, forceReaudit);
+            new FilterSelection(null, null), new SourceLanguageResolver(new FVDLMetadata()), null,
+            auditOptions(forceReaudit, NO_OP_LOGGER));
+        }
+
+        private AuditFprOptions auditOptions(boolean forceReaudit, IAviatorLogger logger) {
+        return AuditFprOptions.builder()
+            .fprHandle(fprHandle)
+            .logger(logger)
+            .sscAppName("TestApp")
+            .sscAppVersion("1.0")
+            .forceReaudit(forceReaudit)
+            .build();
         }
 
         @SuppressWarnings("unchecked")
@@ -276,8 +286,8 @@ class IssueAuditorTest {
 
         IssueAuditor auditor = new IssueAuditor(
             inputList, null, new HashMap<>(), fprInfo,
-            "TestApp", "1.0", selection, dummyLogger, null,
-            new SourceLanguageResolver(new FVDLMetadata()), SourceDecoders.defaults(), null, false
+            selection, new SourceLanguageResolver(new FVDLMetadata()), null,
+            auditOptions(false, dummyLogger)
         );
 
         Method filterMethod = IssueAuditor.class.getDeclaredMethod("filterVulnerabilities", List.class, FilterSet.class);

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/audit/IssueAuditorTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/audit/IssueAuditorTest.java
@@ -145,6 +145,15 @@ class IssueAuditorTest {
         }
 
         @Test
+        void forceReauditIncludesProcessedAviatorIssueWithAnalysisTag() throws Exception {
+        IssueAuditor auditor = createIssueAuditor(true, false, Map.of(
+            Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR,
+            Constants.ANALYSIS_TAG_ID, Constants.EXPLOITABLE));
+
+        assertEquals(List.of(TEST_ISSUE_ID), prepareIssueIds(auditor));
+        }
+
+        @Test
         void forceReauditStillSkipsSuppressedIssue() throws Exception {
         IssueAuditor auditor = createIssueAuditor(true, true,
             Map.of(Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR));

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/audit/IssueAuditorTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/audit/IssueAuditorTest.java
@@ -268,7 +268,7 @@ class IssueAuditorTest {
         IssueAuditor auditor = new IssueAuditor(
             inputList, null, new HashMap<>(), fprInfo,
             "TestApp", "1.0", selection, dummyLogger, null,
-            new SourceLanguageResolver(new FVDLMetadata())
+            new SourceLanguageResolver(new FVDLMetadata()), SourceDecoders.defaults(), null, false
         );
 
         Method filterMethod = IssueAuditor.class.getDeclaredMethod("filterVulnerabilities", List.class, FilterSet.class);

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/audit/IssueAuditorTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/audit/IssueAuditorTest.java
@@ -193,12 +193,87 @@ class IssueAuditorTest {
         void forceReauditStillSkipsIssueWithManualAuditorStatus() throws Exception {
         IssueAuditor auditor = createIssueAuditor(true, false, Map.of(
             Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR,
-            Constants.AUDITOR_STATUS_TAG_ID, Constants.EXPLOITABLE));
+            Constants.AUDITOR_STATUS_TAG_ID, Constants.EXPLOITABLE),
+            Map.of(Constants.AUDITOR_STATUS_TAG_ID, "analyst.user"));
 
         assertTrue(prepareIssueIds(auditor).isEmpty());
         }
 
+        @Test
+        void forceReauditIncludesAviatorWrittenAuditorStatus() throws Exception {
+        IssueAuditor auditor = createIssueAuditor(true, false, Map.of(
+            Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR,
+            Constants.AUDITOR_STATUS_TAG_ID, Constants.EXPLOITABLE),
+            Map.of(Constants.AUDITOR_STATUS_TAG_ID, Constants.USER_NAME));
+
+        assertEquals(List.of(TEST_ISSUE_ID), prepareIssueIds(auditor));
+        }
+
+        @Test
+        void forceReauditSkipsHumanAnalysisOverrideAfterAviator() throws Exception {
+        IssueAuditor auditor = createIssueAuditor(true, false, Map.of(
+            Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR,
+            Constants.ANALYSIS_TAG_ID, Constants.EXPLOITABLE),
+            Map.of(Constants.ANALYSIS_TAG_ID, "analyst.user"));
+
+        assertTrue(prepareIssueIds(auditor).isEmpty());
+        }
+
+        @Test
+        void forceReauditIncludesLegacyFortifyAviatorUsername() throws Exception {
+        IssueAuditor auditor = createIssueAuditor(true, false, Map.of(
+            Constants.AVIATOR_STATUS_TAG_ID, Constants.PROCESSED_BY_AVIATOR,
+            Constants.ANALYSIS_TAG_ID, Constants.EXPLOITABLE),
+            Map.of(Constants.ANALYSIS_TAG_ID, Constants.USER_NAME_LEGACY_FORTIFY_AVIATOR));
+
+        assertEquals(List.of(TEST_ISSUE_ID), prepareIssueIds(auditor));
+        }
+
+        @Test
+        void forceReauditIncludesMappedTagWrittenByAviatorWithoutStatusTag() throws Exception {
+        Path mappingFile = writeMappedTagFile();
+        try {
+            IssueAuditor auditor = createIssueAuditor(true, false,
+                    Map.of("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", Constants.EXPLOITABLE),
+                    Map.of("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", Constants.USER_NAME),
+                    mappingFile.toString());
+            assertEquals(List.of(TEST_ISSUE_ID), prepareIssueIds(auditor));
+        } finally {
+            Files.deleteIfExists(mappingFile);
+        }
+        }
+
+        @Test
+        void forceReauditSkipsHumanWriterOnMappedTag() throws Exception {
+        Path mappingFile = writeMappedTagFile();
+        try {
+            IssueAuditor auditor = createIssueAuditor(true, false,
+                    Map.of("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", Constants.EXPLOITABLE),
+                    Map.of("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "analyst.user"),
+                    mappingFile.toString());
+            assertTrue(prepareIssueIds(auditor).isEmpty());
+        } finally {
+            Files.deleteIfExists(mappingFile);
+        }
+        }
+
+        private Path writeMappedTagFile() throws IOException {
+        Path mappingFile = Files.createTempFile("tag-mapping", ".yaml");
+        Files.writeString(mappingFile, "tag_id: \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\"\n");
+        return mappingFile;
+        }
+
         private IssueAuditor createIssueAuditor(boolean forceReaudit, boolean suppressed, Map<String, String> tags) {
+        return createIssueAuditor(forceReaudit, suppressed, tags, Map.of(), null);
+        }
+
+        private IssueAuditor createIssueAuditor(boolean forceReaudit, boolean suppressed, Map<String, String> tags,
+                Map<String, String> lastTagUsernames) {
+        return createIssueAuditor(forceReaudit, suppressed, tags, lastTagUsernames, null);
+        }
+
+        private IssueAuditor createIssueAuditor(boolean forceReaudit, boolean suppressed, Map<String, String> tags,
+                Map<String, String> lastTagUsernames, String tagMappingPath) {
         FPRInfo fprInfo = new FPRInfo(fprHandle);
         FilterTemplate filterTemplate = new FilterTemplate();
         filterTemplate.setTagDefinitions(new ArrayList<>());
@@ -210,20 +285,26 @@ class IssueAuditorTest {
             .instanceId(TEST_ISSUE_ID)
             .suppressed(suppressed)
             .tags(new HashMap<>(tags))
+            .lastTagUsernames(new HashMap<>(lastTagUsernames))
             .build();
 
         return new IssueAuditor(
             List.of(vulnerability), null, Map.of(TEST_ISSUE_ID, auditIssue), fprInfo,
             new FilterSelection(null, null), new SourceLanguageResolver(new FVDLMetadata()), null,
-            auditOptions(forceReaudit, NO_OP_LOGGER));
+            auditOptions(forceReaudit, NO_OP_LOGGER, tagMappingPath));
         }
 
         private AuditFprOptions auditOptions(boolean forceReaudit, IAviatorLogger logger) {
+        return auditOptions(forceReaudit, logger, null);
+        }
+
+        private AuditFprOptions auditOptions(boolean forceReaudit, IAviatorLogger logger, String tagMappingPath) {
         return AuditFprOptions.builder()
             .fprHandle(fprHandle)
             .logger(logger)
             .sscAppName("TestApp")
             .sscAppVersion("1.0")
+            .tagMappingPath(tagMappingPath)
             .forceReaudit(forceReaudit)
             .build();
         }

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/fpr/FPRProcessorTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/fpr/FPRProcessorTest.java
@@ -128,6 +128,20 @@ class FPRProcessorTest {
         assertFalse(vulnerability.isAudited());
     }
 
+    @Test
+    void testProcessTreatsAllPendingAnalysisValuesAsUnaudited() throws Exception {
+        createTestFpr(minimalAuditFvdl());
+
+        for (String pendingValue : List.of("Pending Review", "Not Set", "Pending Review/Not Set", " pending review ")) {
+            AuditIssue auditIssue = AuditIssue.builder()
+                .instanceId("instance-1")
+                .tags(Map.of(Constants.ANALYSIS_TAG_ID, pendingValue))
+                .build();
+
+            assertFalse(processSingleVulnerability(auditIssue).isAudited(), pendingValue);
+        }
+    }
+
     private String minimalAuditFvdl() {
         return """
                 <?xml version="1.0" encoding="UTF-8"?>

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/fpr/processor/AuditProcessorLastTagUsernamesTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/fpr/processor/AuditProcessorLastTagUsernamesTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.aviator.fpr.processor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.fortify.cli.aviator.fpr.model.AuditIssue;
+import com.fortify.cli.aviator.util.Constants;
+import com.fortify.cli.aviator.util.FprHandle;
+
+class AuditProcessorLastTagUsernamesTest {
+    private static final String INSTANCE_ID = "ISSUE-1";
+
+    @TempDir
+    Path tempDir;
+
+    private FprHandle fprHandle;
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (fprHandle != null) {
+            fprHandle.close();
+        }
+    }
+
+    @Test
+    void lastDocumentOrderTagHistoryWinsPerTag() throws Exception {
+        fprHandle = new FprHandle(createTestFpr("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <ns2:Audit xmlns:ns2="xmlns://www.fortify.com/schema/audit" version="4.4">
+                  <ns2:IssueList>
+                    <ns2:Issue instanceId="ISSUE-1" revision="0">
+                      <ns2:Tag id="%s">
+                        <ns2:Value>Exploitable</ns2:Value>
+                      </ns2:Tag>
+                      <ns2:Tag id="%s">
+                        <ns2:Value>Exploitable</ns2:Value>
+                      </ns2:Tag>
+                      <ns2:TagHistory>
+                        <ns2:Tag id="%s">
+                          <ns2:Value>Not an Issue</ns2:Value>
+                        </ns2:Tag>
+                        <ns2:Username>%s</ns2:Username>
+                      </ns2:TagHistory>
+                      <ns2:TagHistory>
+                        <ns2:Tag id="%s">
+                          <ns2:Value>Exploitable</ns2:Value>
+                        </ns2:Tag>
+                        <ns2:Username>analyst.user</ns2:Username>
+                      </ns2:TagHistory>
+                      <ns2:TagHistory>
+                        <ns2:Tag id="%s">
+                          <ns2:Value>Exploitable</ns2:Value>
+                        </ns2:Tag>
+                        <ns2:Username>%s</ns2:Username>
+                      </ns2:TagHistory>
+                    </ns2:Issue>
+                  </ns2:IssueList>
+                </ns2:Audit>
+                """.formatted(
+                Constants.ANALYSIS_TAG_ID, Constants.AUDITOR_STATUS_TAG_ID,
+                Constants.ANALYSIS_TAG_ID, Constants.USER_NAME,
+                Constants.ANALYSIS_TAG_ID,
+                Constants.AUDITOR_STATUS_TAG_ID, Constants.USER_NAME_LEGACY_FORTIFY_AVIATOR)));
+
+        Map<String, AuditIssue> issues = new AuditProcessor(fprHandle).processAuditXML();
+        Map<String, String> lastTagUsernames = issues.get(INSTANCE_ID).getLastTagUsernames();
+
+        assertEquals("analyst.user", lastTagUsernames.get(Constants.ANALYSIS_TAG_ID));
+        assertEquals(Constants.USER_NAME_LEGACY_FORTIFY_AVIATOR, lastTagUsernames.get(Constants.AUDITOR_STATUS_TAG_ID));
+    }
+
+    @Test
+    void missingUsernameIsStoredAsEmptyString() throws Exception {
+        fprHandle = new FprHandle(createTestFpr("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <ns2:Audit xmlns:ns2="xmlns://www.fortify.com/schema/audit" version="4.4">
+                  <ns2:IssueList>
+                    <ns2:Issue instanceId="ISSUE-1" revision="0">
+                      <ns2:TagHistory>
+                        <ns2:Tag id="%s">
+                          <ns2:Value>Exploitable</ns2:Value>
+                        </ns2:Tag>
+                      </ns2:TagHistory>
+                    </ns2:Issue>
+                  </ns2:IssueList>
+                </ns2:Audit>
+                """.formatted(Constants.ANALYSIS_TAG_ID)));
+
+        Map<String, AuditIssue> issues = new AuditProcessor(fprHandle).processAuditXML();
+
+        assertEquals("", issues.get(INSTANCE_ID).getLastTagUsernames().get(Constants.ANALYSIS_TAG_ID));
+    }
+
+    private Path createTestFpr(String auditXml) throws Exception {
+        Path fprPath = Files.createTempFile(tempDir, "audit-processor", ".fpr");
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(Files.newOutputStream(fprPath))) {
+            zipOutputStream.putNextEntry(new ZipEntry("audit.xml"));
+            zipOutputStream.write(auditXml.getBytes(StandardCharsets.UTF_8));
+            zipOutputStream.closeEntry();
+
+            zipOutputStream.putNextEntry(new ZipEntry("src-archive/index.xml"));
+            zipOutputStream.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?><index/>".getBytes(StandardCharsets.UTF_8));
+            zipOutputStream.closeEntry();
+        }
+        return fprPath;
+    }
+}

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/fpr/processor/RemediationProcessorTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/fpr/processor/RemediationProcessorTest.java
@@ -46,7 +46,9 @@ class RemediationProcessorTest {
         assertEquals(1, metric.totalRemediations());
         assertEquals(0, metric.appliedRemediations());
         assertEquals(1, metric.skippedRemediations());
-        assertEquals(Map.of("Source context matched multiple locations", 1), metric.skippedByReason());
+        assertEquals(Map.of(
+                "Source context matched multiple locations in file 'Example.java'; candidate lines: 1, 4", 1),
+                metric.skippedByReason());
         assertEquals(originalSource, Files.readString(sourceFile));
     }
 

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/fpr/processor/RemediationProcessorTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/fpr/processor/RemediationProcessorTest.java
@@ -47,7 +47,7 @@ class RemediationProcessorTest {
         assertEquals(0, metric.appliedRemediations());
         assertEquals(1, metric.skippedRemediations());
         assertEquals(Map.of(
-                "Source context matched multiple locations in file 'Example.java'; candidate lines: 1, 4", 1),
+          "Source context matched multiple locations", 1),
                 metric.skippedByReason());
         assertEquals(originalSource, Files.readString(sourceFile));
     }

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/fpr/processor/RemediationProcessorTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/fpr/processor/RemediationProcessorTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.aviator.fpr.processor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.fortify.cli.aviator.util.FprHandle;
+
+class RemediationProcessorTest {
+    private static final String REMEDIATIONS_NAMESPACE = "xmlns://www.fortify.com/schema/remediations";
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void skipsAmbiguousContextWithoutChangingSource() throws Exception {
+        String originalSource = "before\nTARGET\nafter\nbefore\nTARGET\nafter\n";
+        Path sourceFile = writeSourceFile(originalSource);
+        Path fprPath = createRemediationFpr(2, 2, 1, 1, "before\ntarget\nafter", "TARGET", "REPLACED");
+
+        RemediationProcessor.RemediationMetric metric;
+        try (FprHandle fprHandle = new FprHandle(fprPath)) {
+            metric = new RemediationProcessor(fprHandle, tempDir.toString()).processRemediationXML();
+        }
+
+        assertEquals(1, metric.totalRemediations());
+        assertEquals(0, metric.appliedRemediations());
+        assertEquals(1, metric.skippedRemediations());
+        assertEquals(Map.of("Source context matched multiple locations", 1), metric.skippedByReason());
+        assertEquals(originalSource, Files.readString(sourceFile));
+    }
+
+    @Test
+    void appliesRemediationWhenContextMatchesOnce() throws Exception {
+        Path sourceFile = writeSourceFile("before\nTARGET\nafter\n");
+        Path fprPath = createRemediationFpr(2, 2, 1, 1, "before\ntarget\nafter", "TARGET", "REPLACED");
+
+        RemediationProcessor.RemediationMetric metric;
+        try (FprHandle fprHandle = new FprHandle(fprPath)) {
+            metric = new RemediationProcessor(fprHandle, tempDir.toString()).processRemediationXML();
+        }
+
+        assertEquals(1, metric.appliedRemediations());
+        assertEquals(0, metric.skippedRemediations());
+        assertEquals("before\nREPLACED\nafter\n", Files.readString(sourceFile));
+    }
+
+    @Test
+    void appliesOriginalCodeAfterLeadingContextLines() throws Exception {
+        Path sourceFile = writeSourceFile("TARGET\nkeep\nTARGET\nafter\n");
+        Path fprPath = createRemediationFpr(3, 3, 2, 1, "TARGET\nkeep\nTARGET\nafter", "TARGET", "REPLACED");
+
+        RemediationProcessor.RemediationMetric metric;
+        try (FprHandle fprHandle = new FprHandle(fprPath)) {
+          metric = new RemediationProcessor(fprHandle, tempDir.toString()).processRemediationXML();
+        }
+
+        assertEquals(1, metric.appliedRemediations());
+        assertEquals("TARGET\nkeep\nREPLACED\nafter\n", Files.readString(sourceFile));
+    }
+
+      @Test
+      void appliesRemediationWhenContextStartsWithBlankLine() throws Exception {
+        Path sourceFile = writeSourceFile("header\n\nTARGET\nafter\n");
+        Path fprPath = createRemediationFpr(3, 3, 1, 1, "\nTARGET\nafter", "TARGET", "REPLACED");
+
+        RemediationProcessor.RemediationMetric metric;
+        try (FprHandle fprHandle = new FprHandle(fprPath)) {
+          metric = new RemediationProcessor(fprHandle, tempDir.toString()).processRemediationXML();
+        }
+
+        assertEquals(1, metric.appliedRemediations());
+        assertEquals("header\n\nREPLACED\nafter\n", Files.readString(sourceFile));
+      }
+
+    private Path writeSourceFile(String content) throws Exception {
+        Path sourceFile = tempDir.resolve("Example.java");
+        Files.writeString(sourceFile, content, StandardCharsets.UTF_8);
+        return sourceFile;
+    }
+
+    private Path createRemediationFpr(String context, String originalCode, String newCode) throws Exception {
+        return createRemediationFpr(2, 2, 1, 1, context, originalCode, newCode);
+    }
+
+    private Path createRemediationFpr(int lineFrom, int lineTo, int contextBefore, int contextAfter,
+            String context, String originalCode, String newCode) throws Exception {
+        Path fprPath = tempDir.resolve("remediation.fpr");
+        String remediationXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <r:Remediations xmlns:r="%s">
+                  <r:ProjectInfo>
+                    <r:Name>test</r:Name>
+                    <r:WriteDate>2026-08-26T00:00:00Z</r:WriteDate>
+                  </r:ProjectInfo>
+                  <r:RemediationList>
+                  <r:Remediation instanceId="issue-1">
+                    <r:AuditComment>test</r:AuditComment>
+                    <r:FileChanges>
+                      <r:Filename>Example.java</r:Filename>
+                      <r:Hash type="SHA-256">not-the-source-hash</r:Hash>
+                      <r:Change>
+                        <r:LineFrom>%d</r:LineFrom>
+                        <r:LineTo>%d</r:LineTo>
+                        <r:Context before="%d" after="%d">%s</r:Context>
+                        <r:OriginalCode>%s</r:OriginalCode>
+                        <r:NewCode>%s</r:NewCode>
+                      </r:Change>
+                    </r:FileChanges>
+                  </r:Remediation>
+                  </r:RemediationList>
+                </r:Remediations>
+                """.formatted(REMEDIATIONS_NAMESPACE, lineFrom, lineTo, contextBefore, contextAfter,
+                context, originalCode, newCode);
+
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(Files.newOutputStream(fprPath))) {
+            zipOutputStream.putNextEntry(new ZipEntry("remediations.xml"));
+            zipOutputStream.write(remediationXml.getBytes(StandardCharsets.UTF_8));
+            zipOutputStream.closeEntry();
+        }
+        return fprPath;
+    }
+}

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/util/FuzzyContextSearcherTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/util/FuzzyContextSearcherTest.java
@@ -82,4 +82,14 @@ class FuzzyContextSearcherTest {
 
         assertEquals(List.of(1), matches);
     }
+
+    @Test
+    void shouldMatchContextAcrossBlankSourceLines() throws Exception {
+        List<Integer> matches = FuzzyContextSearcher.fuzzySearchContextMatches(
+                List.of("header", "target", "", "", "after", "target", "", "after"),
+                List.of("target", "after"),
+                0);
+
+        assertEquals(List.of(1, 5), matches);
+    }
 }

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/util/FuzzyContextSearcherTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/util/FuzzyContextSearcherTest.java
@@ -13,6 +13,7 @@
 package com.fortify.cli.aviator.util;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
@@ -40,5 +41,45 @@ class FuzzyContextSearcherTest {
                 0);
 
         assertArrayEquals(new int[] {0, 3}, lineFromTo);
+    }
+
+    @Test
+    void shouldReturnAllMatchingContextStartLines() throws Exception {
+        List<Integer> matches = FuzzyContextSearcher.fuzzySearchContextMatches(
+                List.of("before", "target", "after", "target", "after"),
+                List.of("target", "after"),
+                0);
+
+        assertEquals(List.of(1, 3), matches);
+    }
+
+    @Test
+    void shouldReturnOneMatchingContextStartLine() throws Exception {
+        List<Integer> matches = FuzzyContextSearcher.fuzzySearchContextMatches(
+                List.of("before", "target", "after"),
+                List.of("target", "after"),
+                0);
+
+        assertEquals(List.of(1), matches);
+    }
+
+    @Test
+    void shouldReturnNoMatchingContextStartLines() throws Exception {
+        List<Integer> matches = FuzzyContextSearcher.fuzzySearchContextMatches(
+                List.of("before", "after"),
+                List.of("target", "after"),
+                0);
+
+        assertEquals(List.of(), matches);
+    }
+
+    @Test
+    void shouldKeepPhysicalStartWhenContextBeginsWithBlankLine() throws Exception {
+        List<Integer> matches = FuzzyContextSearcher.fuzzySearchContextMatches(
+                List.of("header", "", "target", "after"),
+                List.of("", "target", "after"),
+                0);
+
+        assertEquals(List.of(1), matches);
     }
 }

--- a/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/cli/cmd/AviatorSSCAuditCommand.java
+++ b/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/cli/cmd/AviatorSSCAuditCommand.java
@@ -80,6 +80,7 @@ public class AviatorSSCAuditCommand extends AbstractSSCJsonNodeOutputCommand imp
     @ArgGroup(exclusive = true, multiplicity = "0..1") private QuotaHandlingArgGroup quotaHandlingArgGroup = new QuotaHandlingArgGroup();
     @Option(names = {"--test-exceeding-quota"}) private boolean testExceedingQuota;
     @Option(names = {"--default-quota-fallback"}) private boolean defaultQuotaFallback;
+    @Option(names = {"--force-reaudit"}) private boolean forceReaudit;
     @Mixin private SourceEncodingsMixin sourceEncodingsMixin;
     private static final Logger LOG = LoggerFactory.getLogger(AviatorSSCAuditCommand.class);
     private Long checkedQuotaBefore;
@@ -102,7 +103,8 @@ public class AviatorSSCAuditCommand extends AbstractSSCJsonNodeOutputCommand imp
 
             refreshMetricsIfNeeded(unirest, av, logger);
 
-            long auditableIssueCount = AviatorSSCAuditHelper.getAuditableIssueCount(unirest, av, logger, isNoFilterSet(), getFilterSetTitleOrId(), folderNames);
+            long auditableIssueCount = AviatorSSCAuditHelper.getAuditableIssueCount(
+                    unirest, av, logger, isNoFilterSet(), getFilterSetTitleOrId(), folderNames, forceReaudit);
             if (auditableIssueCount == 0) {
                 logger.progress("Audit skipped - no auditable issues found matching the specified filters.");
                 ObjectNode result = AviatorSSCAuditHelper.buildResultNode(av, null, "SKIPPED");
@@ -110,7 +112,7 @@ public class AviatorSSCAuditCommand extends AbstractSSCJsonNodeOutputCommand imp
                 return result;
             }
 
-            JsonNode quotaResult = checkQuota(unirest, av, sessionDescriptor, auditableIssueCount, logger);
+            JsonNode quotaResult = checkQuota(unirest, av, sessionDescriptor, auditableIssueCount, logger, forceReaudit);
             if (quotaResult != null) {
                 return quotaResult;
             }
@@ -142,6 +144,10 @@ public class AviatorSSCAuditCommand extends AbstractSSCJsonNodeOutputCommand imp
         return noFilterSet;
     }
 
+    boolean isForceReaudit() {
+        return forceReaudit;
+    }
+
     private void refreshMetricsIfNeeded(UnirestInstance unirest, SSCAppVersionDescriptor av, AviatorLoggerImpl logger) {
         if (refreshOptions.isRefresh() && av.isRefreshRequired()) {
             logger.progress("Status: Metrics for application version %s:%s are out of date, starting refresh...", av.getApplicationName(), av.getVersionName());
@@ -167,7 +173,7 @@ public class AviatorSSCAuditCommand extends AbstractSSCJsonNodeOutputCommand imp
      */
     private JsonNode checkQuota(UnirestInstance unirest, SSCAppVersionDescriptor av,
             AviatorUserSessionDescriptor sessionDescriptor,
-            long auditableIssueCount, AviatorLoggerImpl logger) {
+            long auditableIssueCount, AviatorLoggerImpl logger, boolean forceReaudit) {
         if (!isSkipIfExceedingQuota() && !testExceedingQuota) {
             return null;
         }
@@ -194,7 +200,7 @@ public class AviatorSSCAuditCommand extends AbstractSSCJsonNodeOutputCommand imp
             return null;
         }
 
-        return evaluateQuota(unirest, av, effectiveAppName, auditableIssueCount, availableQuota, logger);
+        return evaluateQuota(unirest, av, effectiveAppName, auditableIssueCount, availableQuota, logger, forceReaudit);
     }
 
     /**
@@ -228,7 +234,7 @@ public class AviatorSSCAuditCommand extends AbstractSSCJsonNodeOutputCommand imp
      */
     private JsonNode evaluateQuota(UnirestInstance unirest, SSCAppVersionDescriptor av,
             String effectiveAppName, long auditableIssueCount, long availableQuota,
-            AviatorLoggerImpl logger) {
+            AviatorLoggerImpl logger, boolean forceReaudit) {
         if (availableQuota == AviatorSSCAuditHelper.QUOTA_UNKNOWN) {
             if (testExceedingQuota) {
                 ObjectNode result = AviatorSSCAuditHelper.buildResultNode(av, null, "QUOTA_UNKNOWN");
@@ -238,7 +244,7 @@ public class AviatorSSCAuditCommand extends AbstractSSCJsonNodeOutputCommand imp
             logger.progress("Warning: Could not retrieve quota for '%s', proceeding with audit.", effectiveAppName);
         } else if (availableQuota >= 0 && auditableIssueCount > availableQuota) {
             checkedQuotaBefore = availableQuota;
-            var topCategories = AviatorSSCAuditHelper.getTopUnauditedCategories(unirest, av, logger, 10);
+            var topCategories = AviatorSSCAuditHelper.getTopUnauditedCategories(unirest, av, logger, 10, forceReaudit);
             String detailedMessage = AviatorSSCAuditHelper.formatQuotaExceededMessage(
                 av, auditableIssueCount, availableQuota, topCategories);
             LOG.info(detailedMessage);
@@ -277,6 +283,7 @@ public class AviatorSSCAuditCommand extends AbstractSSCJsonNodeOutputCommand imp
                     .noFilterSet(isNoFilterSet())
                     .folderNames(folderNames)
                     .folderPriorityOrder(getFolderPriorityOrder())
+                    .forceReaudit(forceReaudit)
                     .sourceDecoder(sourceEncodingsMixin.getSourceDecoder())
                     .build());
         } catch (Exception e) {

--- a/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/cli/cmd/AviatorSSCAuditCommand.java
+++ b/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/cli/cmd/AviatorSSCAuditCommand.java
@@ -144,10 +144,6 @@ public class AviatorSSCAuditCommand extends AbstractSSCJsonNodeOutputCommand imp
         return noFilterSet;
     }
 
-    boolean isForceReaudit() {
-        return forceReaudit;
-    }
-
     private void refreshMetricsIfNeeded(UnirestInstance unirest, SSCAppVersionDescriptor av, AviatorLoggerImpl logger) {
         if (refreshOptions.isRefresh() && av.isRefreshRequired()) {
             logger.progress("Status: Metrics for application version %s:%s are out of date, starting refresh...", av.getApplicationName(), av.getVersionName());

--- a/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/cli/cmd/AviatorSSCAuditCommand.java
+++ b/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/cli/cmd/AviatorSSCAuditCommand.java
@@ -112,7 +112,7 @@ public class AviatorSSCAuditCommand extends AbstractSSCJsonNodeOutputCommand imp
                 return result;
             }
 
-            JsonNode quotaResult = checkQuota(unirest, av, sessionDescriptor, auditableIssueCount, logger, forceReaudit);
+            JsonNode quotaResult = checkQuota(unirest, av, sessionDescriptor, auditableIssueCount, logger);
             if (quotaResult != null) {
                 return quotaResult;
             }
@@ -173,7 +173,7 @@ public class AviatorSSCAuditCommand extends AbstractSSCJsonNodeOutputCommand imp
      */
     private JsonNode checkQuota(UnirestInstance unirest, SSCAppVersionDescriptor av,
             AviatorUserSessionDescriptor sessionDescriptor,
-            long auditableIssueCount, AviatorLoggerImpl logger, boolean forceReaudit) {
+            long auditableIssueCount, AviatorLoggerImpl logger) {
         if (!isSkipIfExceedingQuota() && !testExceedingQuota) {
             return null;
         }
@@ -200,7 +200,7 @@ public class AviatorSSCAuditCommand extends AbstractSSCJsonNodeOutputCommand imp
             return null;
         }
 
-        return evaluateQuota(unirest, av, effectiveAppName, auditableIssueCount, availableQuota, logger, forceReaudit);
+        return evaluateQuota(unirest, av, effectiveAppName, auditableIssueCount, availableQuota, logger);
     }
 
     /**
@@ -234,7 +234,7 @@ public class AviatorSSCAuditCommand extends AbstractSSCJsonNodeOutputCommand imp
      */
     private JsonNode evaluateQuota(UnirestInstance unirest, SSCAppVersionDescriptor av,
             String effectiveAppName, long auditableIssueCount, long availableQuota,
-            AviatorLoggerImpl logger, boolean forceReaudit) {
+            AviatorLoggerImpl logger) {
         if (availableQuota == AviatorSSCAuditHelper.QUOTA_UNKNOWN) {
             if (testExceedingQuota) {
                 ObjectNode result = AviatorSSCAuditHelper.buildResultNode(av, null, "QUOTA_UNKNOWN");

--- a/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/helper/AviatorSSCAuditHelper.java
+++ b/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/helper/AviatorSSCAuditHelper.java
@@ -216,10 +216,18 @@ public final class AviatorSSCAuditHelper {
      * Queries SSC to get the number of auditable issues for a given application version.
      */
     public static long getAuditableIssueCount(UnirestInstance unirest, SSCAppVersionDescriptor av, AviatorLoggerImpl logger, boolean noFilterSet, String filterSetTitleOrId, List<String> folderNames) {
+        return getAuditableIssueCount(unirest, av, logger, noFilterSet, filterSetTitleOrId, folderNames, false);
+    }
+
+    /**
+     * Queries SSC to get the number of issues eligible for the requested audit mode.
+     */
+    public static long getAuditableIssueCount(UnirestInstance unirest, SSCAppVersionDescriptor av, AviatorLoggerImpl logger,
+            boolean noFilterSet, String filterSetTitleOrId, List<String> folderNames, boolean forceReaudit) {
         logger.progress("Status: Checking for auditable issues...");
 
-        LOG.debug("Starting auditable issue count for SSC version {} (application='{}', version='{}') with pageLimit={}, noFilterSet={}",
-                av.getVersionId(), av.getApplicationName(), av.getVersionName(), PAGE_LIMIT, noFilterSet);
+        LOG.debug("Starting auditable issue count for SSC version {} (application='{}', version='{}') with pageLimit={}, noFilterSet={}, forceReaudit={}",
+            av.getVersionId(), av.getApplicationName(), av.getVersionName(), PAGE_LIMIT, noFilterSet, forceReaudit);
 
         String effectiveFilterSetTitleOrId = filterSetTitleOrId != null && !filterSetTitleOrId.isBlank()
                 ? filterSetTitleOrId
@@ -290,7 +298,7 @@ public final class AviatorSSCAuditHelper {
                 ArrayNode issues = (ArrayNode) response.get("data");
                 if (issues != null && !issues.isEmpty()) {
                     long auditableOnPage = JsonHelper.stream(issues)
-                            .filter(issue -> !isProcessedByAviator(issue))
+                            .filter(issue -> forceReaudit || !isProcessedByAviator(issue))
                             .count();
                     totalAuditableCount += auditableOnPage;
                     LOG.debug("Processed SSC issues page for version {}: pageStart={}, pageSize={}, auditableOnPage={}, cumulativeAuditableCount={}, totalFromServer={}",
@@ -434,9 +442,18 @@ public final class AviatorSSCAuditHelper {
     public static List<Map<String, Object>> getTopUnauditedCategories(
             UnirestInstance unirest, SSCAppVersionDescriptor av,
             AviatorLoggerImpl logger, int topN) {
+        return getTopUnauditedCategories(unirest, av, logger, topN, false);
+    }
+
+    /**
+     * Retrieves the top categories using the same Aviator-status scope as the audit preflight.
+     */
+    public static List<Map<String, Object>> getTopUnauditedCategories(
+            UnirestInstance unirest, SSCAppVersionDescriptor av,
+            AviatorLoggerImpl logger, int topN, boolean forceReaudit) {
 
         try {
-            return getTopUnauditedCategoriesInternal(unirest, av, logger, topN);
+            return getTopUnauditedCategoriesInternal(unirest, av, logger, topN, forceReaudit);
         } catch (Exception e) {
             LOG.warn("Failed to retrieve top unaudited categories for {}:{}: {}",
                 av.getApplicationName(), av.getVersionName(), e.getMessage());
@@ -447,7 +464,7 @@ public final class AviatorSSCAuditHelper {
 
     private static List<Map<String, Object>> getTopUnauditedCategoriesInternal(
             UnirestInstance unirest, SSCAppVersionDescriptor av,
-            AviatorLoggerImpl logger, int topN) {
+            AviatorLoggerImpl logger, int topN, boolean forceReaudit) {
 
         String versionId = av.getVersionId();
 
@@ -458,12 +475,14 @@ public final class AviatorSSCAuditHelper {
 
         // Resolve "Aviator status:Not Set" filter dynamically
         String aviatorStatusFilter = null;
-        try {
-            SSCIssueFilterHelper filterHelper = new SSCIssueFilterHelper(unirest, versionId);
-            aviatorStatusFilter = filterHelper.getFilter("Aviator status:Not Set");
-        } catch (FcliSimpleException e) {
-            // Tag doesn't exist on this version — all issues are unprocessed
-            LOG.debug("Aviator status tag not found for version {}. All issues considered unprocessed.", versionId);
+        if (!forceReaudit) {
+            try {
+                SSCIssueFilterHelper filterHelper = new SSCIssueFilterHelper(unirest, versionId);
+                aviatorStatusFilter = filterHelper.getFilter("Aviator status:Not Set");
+            } catch (FcliSimpleException e) {
+                // Tag doesn't exist on this version — all issues are unprocessed
+                LOG.debug("Aviator status tag not found for version {}. All issues considered unprocessed.", versionId);
+            }
         }
 
         // Call issueGroups API

--- a/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/helper/AviatorSSCAuditHelper.java
+++ b/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/helper/AviatorSSCAuditHelper.java
@@ -470,20 +470,10 @@ public final class AviatorSSCAuditHelper {
     }
 
     /**
-     * Returns the top N SAST categories ordered by truly-unaudited issue count (descending).
-     * Uses the SSC issueGroups API with:
-     *   - groupingtype = dynamically resolved "Category" GUID
-     *   - filter = dynamically resolved "Aviator status:Not Set" technical filter
-     * Each entry contains "categoryName" and "unauditedCount".
-     */
-    public static List<Map<String, Object>> getTopUnauditedCategories(
-            UnirestInstance unirest, SSCAppVersionDescriptor av,
-            AviatorLoggerImpl logger, int topN) {
-        return getTopUnauditedCategories(unirest, av, logger, topN, false);
-    }
-
-    /**
-     * Retrieves the top categories using the same Aviator-status scope as the audit preflight.
+     * Returns the top N SAST categories for the requested audit mode.
+     * Normal audit ranks by unaudited issues with Aviator status not set.
+     * Force re-audit ranks by visible issues, including Aviator-processed ones.
+     * Each entry contains "categoryName" and "unauditedCount" (eligible count for that mode).
      */
     public static List<Map<String, Object>> getTopUnauditedCategories(
             UnirestInstance unirest, SSCAppVersionDescriptor av,

--- a/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/helper/AviatorSSCAuditHelper.java
+++ b/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/helper/AviatorSSCAuditHelper.java
@@ -213,9 +213,9 @@ public final class AviatorSSCAuditHelper {
     }
 
     /**
-     * Queries SSC to get the number of issues eligible for the requested audit mode.
-     * Force re-audit counts previously processed Aviator issues even when SSC already
-     * marks them audited; human-audited issues Aviator never processed stay excluded.
+     * Coarse SSC download gate. Force re-audit counts Aviator-processed issues even when
+     * SSC marks them audited; suppressed issues and human-audited issues Aviator never
+     * processed stay excluded. Last TagHistory writer is applied later from the FPR.
      */
     public static long getAuditableIssueCount(UnirestInstance unirest, SSCAppVersionDescriptor av, AviatorLoggerImpl logger,
             boolean noFilterSet, String filterSetTitleOrId, List<String> folderNames, boolean forceReaudit) {
@@ -349,10 +349,13 @@ public final class AviatorSSCAuditHelper {
 
     /**
      * Force re-audit includes previously processed Aviator issues even when SSC
-     * already marks them audited. Human-audited issues that Aviator never processed
-     * stay out. Normal audit still excludes processed issues.
+     * already marks them audited. Suppressed issues and human-audited issues that
+     * Aviator never processed stay out. Normal audit still excludes processed issues.
      */
     private static boolean isEligibleForRequestedAudit(JsonNode issue, boolean forceReaudit) {
+        if (issue.path("suppressed").asBoolean(false)) {
+            return false;
+        }
         if (isProcessedByAviator(issue)) {
             return forceReaudit;
         }

--- a/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/helper/AviatorSSCAuditHelper.java
+++ b/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/helper/AviatorSSCAuditHelper.java
@@ -213,77 +213,75 @@ public final class AviatorSSCAuditHelper {
     }
 
     /**
-     * Queries SSC to get the number of auditable issues for a given application version.
-     */
-    public static long getAuditableIssueCount(UnirestInstance unirest, SSCAppVersionDescriptor av, AviatorLoggerImpl logger, boolean noFilterSet, String filterSetTitleOrId, List<String> folderNames) {
-        return getAuditableIssueCount(unirest, av, logger, noFilterSet, filterSetTitleOrId, folderNames, false);
-    }
-
-    /**
      * Queries SSC to get the number of issues eligible for the requested audit mode.
+     * Force re-audit counts previously processed Aviator issues even when SSC already
+     * marks them audited; human-audited issues Aviator never processed stay excluded.
      */
     public static long getAuditableIssueCount(UnirestInstance unirest, SSCAppVersionDescriptor av, AviatorLoggerImpl logger,
             boolean noFilterSet, String filterSetTitleOrId, List<String> folderNames, boolean forceReaudit) {
         logger.progress("Status: Checking for auditable issues...");
-
         LOG.debug("Starting auditable issue count for SSC version {} (application='{}', version='{}') with pageLimit={}, noFilterSet={}, forceReaudit={}",
             av.getVersionId(), av.getApplicationName(), av.getVersionName(), PAGE_LIMIT, noFilterSet, forceReaudit);
 
+        AuditableIssueCountQuery query = resolveAuditableIssueCountQuery(
+                unirest, av, logger, noFilterSet, filterSetTitleOrId, folderNames, forceReaudit);
+        return countEligibleIssues(query, logger);
+    }
+
+    private record AuditableIssueCountQuery(UnirestInstance unirest, SSCAppVersionDescriptor av, boolean noFilterSet,
+            String filterSetGuid, String folderFilter, boolean forceReaudit) {}
+
+    private static AuditableIssueCountQuery resolveAuditableIssueCountQuery(UnirestInstance unirest, SSCAppVersionDescriptor av,
+            AviatorLoggerImpl logger, boolean noFilterSet, String filterSetTitleOrId, List<String> folderNames,
+            boolean forceReaudit) {
         String effectiveFilterSetTitleOrId = filterSetTitleOrId != null && !filterSetTitleOrId.isBlank()
                 ? filterSetTitleOrId
                 : null;
         boolean effectiveNoFilterSet = noFilterSet && effectiveFilterSetTitleOrId == null;
+        SSCIssueFilterSetDescriptor filterSetDescriptor = resolveFilterSet(
+                unirest, av, logger, effectiveNoFilterSet, effectiveFilterSetTitleOrId);
+        String filterSetGuid = filterSetDescriptor != null ? filterSetDescriptor.getGuid() : null;
+        String folderFilter = resolveFolderFilter(logger, av, effectiveNoFilterSet, filterSetDescriptor, folderNames);
+        return new AuditableIssueCountQuery(unirest, av, effectiveNoFilterSet, filterSetGuid, folderFilter, forceReaudit);
+    }
 
-        // Apply filter set if specified
-        SSCIssueFilterSetDescriptor filterSetDescriptor = null;
-        String filterSetGuid = null;
-        if (!effectiveNoFilterSet) {
-            SSCIssueFilterSetHelper filterSetHelper = new SSCIssueFilterSetHelper(unirest, av.getVersionId());
-            filterSetDescriptor = filterSetHelper.getDescriptorByTitleOrId(effectiveFilterSetTitleOrId, false);
-            if (filterSetDescriptor != null) {
-                logger.progress("Status: Applying filter set '%s' for issue count check", filterSetDescriptor.getTitle());
-                filterSetGuid = filterSetDescriptor.getGuid();
-                LOG.debug("Applied SSC filter set '{}' with guid {} while counting auditable issues for version {}",
-                        filterSetDescriptor.getTitle(), filterSetGuid, av.getVersionId());
-            } else {
-                LOG.debug("No SSC filter set resolved from options while counting auditable issues for version {}",
-                        av.getVersionId());
-            }
+    private static SSCIssueFilterSetDescriptor resolveFilterSet(UnirestInstance unirest, SSCAppVersionDescriptor av,
+            AviatorLoggerImpl logger, boolean noFilterSet, String filterSetTitleOrId) {
+        if (noFilterSet) {
+            return null;
         }
-
-        // Apply folder filter if specified
-        String folderFilter = null;
-        if (folderNames != null && !folderNames.isEmpty()) {
-            folderFilter = getFolderFilter(effectiveNoFilterSet, filterSetDescriptor, folderNames);
-            logger.progress("Status: Applying folder filter for: %s", String.join(", ", folderNames));
-            LOG.debug("Applied folder filter '{}' for folders {} while counting auditable issues for version {}",
-                    folderFilter, folderNames, av.getVersionId());
+        SSCIssueFilterSetHelper filterSetHelper = new SSCIssueFilterSetHelper(unirest, av.getVersionId());
+        SSCIssueFilterSetDescriptor filterSetDescriptor = filterSetHelper.getDescriptorByTitleOrId(filterSetTitleOrId, false);
+        if (filterSetDescriptor != null) {
+            logger.progress("Status: Applying filter set '%s' for issue count check", filterSetDescriptor.getTitle());
+            LOG.debug("Applied SSC filter set '{}' with guid {} while counting auditable issues for version {}",
+                    filterSetDescriptor.getTitle(), filterSetDescriptor.getGuid(), av.getVersionId());
+        } else {
+            LOG.debug("No SSC filter set resolved from options while counting auditable issues for version {}",
+                    av.getVersionId());
         }
+        return filterSetDescriptor;
+    }
 
-        long totalAuditableCount = 0;
-        int start = 0;
-        long totalFromServer = -1;
+    private static String resolveFolderFilter(AviatorLoggerImpl logger, SSCAppVersionDescriptor av, boolean noFilterSet,
+            SSCIssueFilterSetDescriptor filterSetDescriptor, List<String> folderNames) {
+        if (folderNames == null || folderNames.isEmpty()) {
+            return null;
+        }
+        String folderFilter = getFolderFilter(noFilterSet, filterSetDescriptor, folderNames);
+        logger.progress("Status: Applying folder filter for: %s", String.join(", ", folderNames));
+        LOG.debug("Applied folder filter '{}' for folders {} while counting auditable issues for version {}",
+                folderFilter, folderNames, av.getVersionId());
+        return folderFilter;
+    }
 
+    private static long countEligibleIssues(AuditableIssueCountQuery query, AviatorLoggerImpl logger) {
         try {
+            long totalAuditableCount = 0;
+            int start = 0;
+            long totalFromServer = -1;
             do {
-                GetRequest request = unirest.get(SSCUrls.PROJECT_VERSION_ISSUES(av.getVersionId()))
-                        .queryString("limit", PAGE_LIMIT)
-                        .queryString("embed", "auditValues")
-                        .queryString("qm", "issues")
-                        .queryString("q", "audited:false")
-                        .queryString("start", start);
-                if (effectiveNoFilterSet) {
-                    request.queryString("showhidden", "true");
-                }
-                if (filterSetGuid != null) {
-                    request.queryString("filterset", filterSetGuid);
-                }
-                if (folderFilter != null) {
-                    request.queryString("filter", folderFilter);
-                }
-                LOG.debug("Requesting SSC issues page for version {} with start={} and limit={}",
-                        av.getVersionId(), start, PAGE_LIMIT);
-                JsonNode response = request.asObject(JsonNode.class).getBody();
+                JsonNode response = fetchAuditableIssuesPage(query, start);
                 if (response == null || !response.has("data")) {
                     LOG.warn("Invalid response received from issue check; proceeding with FPR download.");
                     logger.progress("WARN: Invalid response from issue check. Proceeding with FPR download.");
@@ -292,27 +290,23 @@ public final class AviatorSSCAuditHelper {
                 if (totalFromServer == -1) {
                     totalFromServer = response.get("count").asLong(0);
                     LOG.debug("SSC reported {} total issues matching the initial auditable count query for version {}",
-                            totalFromServer, av.getVersionId());
+                            totalFromServer, query.av().getVersionId());
                 }
-
                 ArrayNode issues = (ArrayNode) response.get("data");
-                if (issues != null && !issues.isEmpty()) {
-                    long auditableOnPage = JsonHelper.stream(issues)
-                            .filter(issue -> forceReaudit || !isProcessedByAviator(issue))
-                            .count();
-                    totalAuditableCount += auditableOnPage;
-                    LOG.debug("Processed SSC issues page for version {}: pageStart={}, pageSize={}, auditableOnPage={}, cumulativeAuditableCount={}, totalFromServer={}",
-                            av.getVersionId(), start, issues.size(), auditableOnPage, totalAuditableCount, totalFromServer);
-                    start += issues.size();
-                } else {
+                if (issues == null || issues.isEmpty()) {
                     LOG.debug("SSC returned no more issues for version {} at start={}; stopping pagination with cumulativeAuditableCount={} and totalFromServer={}",
-                            av.getVersionId(), start, totalAuditableCount, totalFromServer);
-                    break; // No more issues
+                            query.av().getVersionId(), start, totalAuditableCount, totalFromServer);
+                    break;
                 }
+                long auditableOnPage = countEligibleOnPage(issues, query.forceReaudit());
+                totalAuditableCount += auditableOnPage;
+                LOG.debug("Processed SSC issues page for version {}: pageStart={}, pageSize={}, auditableOnPage={}, cumulativeAuditableCount={}, totalFromServer={}",
+                        query.av().getVersionId(), start, issues.size(), auditableOnPage, totalAuditableCount, totalFromServer);
+                start += issues.size();
             } while (start < totalFromServer);
 
             LOG.debug("Completed auditable issue count for version {}: totalAuditableCount={}, totalFromServer={}",
-                    av.getVersionId(), totalAuditableCount, totalFromServer);
+                    query.av().getVersionId(), totalAuditableCount, totalFromServer);
             logger.progress("Status: Found %d auditable issues.", totalAuditableCount);
             return totalAuditableCount;
         } catch (UnexpectedHttpResponseException e) {
@@ -320,6 +314,49 @@ public final class AviatorSSCAuditHelper {
             logger.progress("WARN: Failed to retrieve issue count from SSC. Proceeding with FPR download as a fallback.");
             return -1;
         }
+    }
+
+    private static JsonNode fetchAuditableIssuesPage(AuditableIssueCountQuery query, int start) {
+        GetRequest request = query.unirest().get(SSCUrls.PROJECT_VERSION_ISSUES(query.av().getVersionId()))
+                .queryString("limit", PAGE_LIMIT)
+                .queryString("embed", "auditValues")
+                .queryString("qm", "issues")
+                .queryString("start", start);
+        // Normal audit only needs unaudited issues. Force re-audit must also
+        // retrieve Aviator-processed issues, which SSC marks audited after Analysis is set.
+        if (!query.forceReaudit()) {
+            request.queryString("q", "audited:false");
+        }
+        if (query.noFilterSet()) {
+            request.queryString("showhidden", "true");
+        }
+        if (query.filterSetGuid() != null) {
+            request.queryString("filterset", query.filterSetGuid());
+        }
+        if (query.folderFilter() != null) {
+            request.queryString("filter", query.folderFilter());
+        }
+        LOG.debug("Requesting SSC issues page for version {} with start={} and limit={}",
+                query.av().getVersionId(), start, PAGE_LIMIT);
+        return request.asObject(JsonNode.class).getBody();
+    }
+
+    private static long countEligibleOnPage(ArrayNode issues, boolean forceReaudit) {
+        return JsonHelper.stream(issues)
+                .filter(issue -> isEligibleForRequestedAudit(issue, forceReaudit))
+                .count();
+    }
+
+    /**
+     * Force re-audit includes previously processed Aviator issues even when SSC
+     * already marks them audited. Human-audited issues that Aviator never processed
+     * stay out. Normal audit still excludes processed issues.
+     */
+    private static boolean isEligibleForRequestedAudit(JsonNode issue, boolean forceReaudit) {
+        if (isProcessedByAviator(issue)) {
+            return forceReaudit;
+        }
+        return !issue.path("audited").asBoolean(false);
     }
 
     /**
@@ -498,20 +535,22 @@ public final class AviatorSSCAuditHelper {
         JsonNode response = request.asObject(JsonNode.class).getBody();
         ArrayNode groups = (ArrayNode) response.get("data");
 
-        // Calculate truly-unaudited count per category and sort descending
+        // Rank categories by issues eligible for the requested audit mode.
         List<Map<String, Object>> categories = new ArrayList<>();
         if (groups != null) {
             for (JsonNode group : groups) {
                 String name = group.path("id").asText("Unknown");
                 long visibleCount = group.path("visibleCount").asLong(0);
                 long auditedCount = group.path("auditedCount").asLong(0);
-                long unaudited = visibleCount - auditedCount;
-                if (unaudited > 0) {
+                // Force re-audit sends Aviator-processed (already audited) issues, so
+                // visible count is the quota-relevant size for the category.
+                long eligibleCount = forceReaudit ? visibleCount : visibleCount - auditedCount;
+                if (eligibleCount > 0) {
                     Map<String, Object> entry = new LinkedHashMap<>();
                     entry.put("categoryName", name);
                     entry.put("totalIssues", visibleCount);
                     entry.put("auditedIssues", auditedCount);
-                    entry.put("unauditedCount", unaudited);
+                    entry.put("unauditedCount", eligibleCount);
                     categories.add(entry);
                 }
             }

--- a/fcli-core/fcli-aviator/src/main/resources/com/fortify/cli/aviator/i18n/AviatorMessages.properties
+++ b/fcli-core/fcli-aviator/src/main/resources/com/fortify/cli/aviator/i18n/AviatorMessages.properties
@@ -128,6 +128,7 @@ fcli.aviator.ssc.audit.folder = Filter issues by a comma-separated list of speci
 fcli.aviator.ssc.audit.skip-if-exceeding-quota = Skip audit if the number of open issues exceeds the available Fortify Remediation Aviator quota. When skipped, a summary with top unaudited categories is shown.
 fcli.aviator.ssc.audit.test-exceeding-quota = Check whether the number of open issues exceeds the available Fortify Remediation Aviator quota and report the result without performing an audit.
 fcli.aviator.ssc.audit.default-quota-fallback = (Internal) When the Fortify Aviator application does not exist, use the tenant default quota instead of reporting app not found. Used by bulk audit.
+fcli.aviator.ssc.audit.force-reaudit = Re-audit issues previously processed by Aviator, while preserving suppressed and manually triaged issues.
 fcli.aviator.ssc.audit.folder-priority-order = Custom priority order for folder-based filtering when quota is exceeded (comma-separated, highest priority first). Example: Critical,High,Medium,Low. If not specified, uses default priority order.
 fcli.aviator.source-encodings = Comma-separated source encoding candidates to try in order when decoding source files. Use FPR to try the source encoding recorded in audit.fvdl. When writing remediated files, the accepted encoding is used. Default value: ${DEFAULT-VALUE}.
 fcli.aviator.ssc.audit.refresh = By default, this command will refresh the  source application version's metrics when copying from it. \

--- a/fcli-core/fcli-aviator/src/test/java/com/fortify/cli/aviator/ssc/cli/cmd/AviatorSSCAuditCommandTest.java
+++ b/fcli-core/fcli-aviator/src/test/java/com/fortify/cli/aviator/ssc/cli/cmd/AviatorSSCAuditCommandTest.java
@@ -53,6 +53,12 @@ class AviatorSSCAuditCommandTest {
     }
 
     @Test
+    void testAllowsForceReauditOption() {
+        var cmd = parse("--force-reaudit");
+        assertTrue(cmd.isForceReaudit());
+    }
+
+    @Test
     void reportsDecodeSkippedIssuesAsNotSubmitted() {
         ObjectNode result = JsonHelper.getObjectMapper().createObjectNode();
         result.set("operation", JsonHelper.getObjectMapper().createObjectNode());

--- a/fcli-core/fcli-aviator/src/test/java/com/fortify/cli/aviator/ssc/cli/cmd/AviatorSSCAuditCommandTest.java
+++ b/fcli-core/fcli-aviator/src/test/java/com/fortify/cli/aviator/ssc/cli/cmd/AviatorSSCAuditCommandTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;
@@ -53,9 +54,11 @@ class AviatorSSCAuditCommandTest {
     }
 
     @Test
-    void testAllowsForceReauditOption() {
+    void testAllowsForceReauditOption() throws Exception {
         var cmd = parse("--force-reaudit");
-        assertTrue(cmd.isForceReaudit());
+        Field field = AviatorSSCAuditCommand.class.getDeclaredField("forceReaudit");
+        field.setAccessible(true);
+        assertTrue((boolean) field.get(cmd));
     }
 
     @Test

--- a/fcli-core/fcli-aviator/src/test/java/com/fortify/cli/aviator/ssc/helper/AviatorSSCAuditHelperTest.java
+++ b/fcli-core/fcli-aviator/src/test/java/com/fortify/cli/aviator/ssc/helper/AviatorSSCAuditHelperTest.java
@@ -82,6 +82,15 @@ class AviatorSSCAuditHelperTest {
     }
 
     @Test
+    void forceReauditPreflightExcludesSuppressedAviatorIssues() throws Exception {
+        try (var server = new TestSscServer(processedIssue(), suppressedProcessedIssue());
+                var unirest = newUnirest(server)) {
+            assertEquals(1, AviatorSSCAuditHelper.getAuditableIssueCount(
+                    unirest, appVersion(), logger(), true, null, null, true));
+        }
+    }
+
+    @Test
     void forceReauditCategoryBreakdownIncludesFullyAuditedCategories() throws Exception {
         try (var server = new TestSscServer(processedIssue());
                 var unirest = newUnirest(server)) {
@@ -135,6 +144,12 @@ class AviatorSSCAuditHelperTest {
         ObjectNode issue = JsonHelper.getObjectMapper().createObjectNode();
         issue.put("audited", true);
         issue.putObject("_embed").putArray("auditValues");
+        return issue;
+    }
+
+    private static ObjectNode suppressedProcessedIssue() {
+        ObjectNode issue = processedIssue();
+        issue.put("suppressed", true);
         return issue;
     }
 

--- a/fcli-core/fcli-aviator/src/test/java/com/fortify/cli/aviator/ssc/helper/AviatorSSCAuditHelperTest.java
+++ b/fcli-core/fcli-aviator/src/test/java/com/fortify/cli/aviator/ssc/helper/AviatorSSCAuditHelperTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.aviator.ssc.helper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fortify.cli.aviator.config.AviatorLoggerImpl;
+import com.fortify.cli.common.json.JsonHelper;
+import com.fortify.cli.common.progress.helper.IProgressWriter;
+import com.fortify.cli.common.rest.unirest.UnirestHelper;
+import com.fortify.cli.common.rest.unirest.config.UnirestJsonHeaderConfigurer;
+import com.fortify.cli.ssc.appversion.helper.SSCAppVersionDescriptor;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+import kong.unirest.UnirestInstance;
+
+class AviatorSSCAuditHelperTest {
+
+    @Test
+    void excludesPreviouslyProcessedIssuesFromNormalPreflightCount() throws Exception {
+        try (var server = new TestSscServer(processedIssue(), unprocessedIssue());
+                var unirest = newUnirest(server)) {
+            assertEquals(1, AviatorSSCAuditHelper.getAuditableIssueCount(
+                    unirest, appVersion(), logger(), true, null, null));
+            assertTrue(server.getLastIssueQuery().contains("q=audited:false"));
+        }
+    }
+
+    @Test
+    void forceReauditPreflightIncludesPreviouslyProcessedIssues() throws Exception {
+        try (var server = new TestSscServer(processedIssue(), unprocessedIssue());
+                var unirest = newUnirest(server)) {
+            assertEquals(2, AviatorSSCAuditHelper.getAuditableIssueCount(
+                    unirest, appVersion(), logger(), true, null, null, true));
+            assertTrue(server.getLastIssueQuery().contains("q=audited:false"));
+        }
+    }
+
+    @Test
+    void forceReauditPreflightDoesNotSkipAnAllProcessedApplicationVersion() throws Exception {
+        try (var server = new TestSscServer(processedIssue());
+                var unirest = newUnirest(server)) {
+            assertEquals(1, AviatorSSCAuditHelper.getAuditableIssueCount(
+                    unirest, appVersion(), logger(), true, null, null, true));
+            assertTrue(server.getLastIssueQuery().contains("q=audited:false"));
+        }
+    }
+
+    @Test
+    void forceReauditCategoryBreakdownDoesNotApplyAviatorStatusFilter() throws Exception {
+        try (var server = new TestSscServer(processedIssue());
+                var unirest = newUnirest(server)) {
+            List<Map<String, Object>> categories = AviatorSSCAuditHelper.getTopUnauditedCategories(
+                    unirest, appVersion(), logger(), 10, true);
+
+            assertEquals(1, categories.size());
+            assertEquals("Category A", categories.get(0).get("categoryName"));
+            assertEquals(1, server.getSelectorSetRequestCount());
+        }
+    }
+
+    private static SSCAppVersionDescriptor appVersion() {
+        var descriptor = new SSCAppVersionDescriptor();
+        descriptor.setVersionId("42");
+        descriptor.setApplicationName("TestApp");
+        descriptor.setVersionName("1.0");
+        return descriptor;
+    }
+
+    private static AviatorLoggerImpl logger() {
+        return new AviatorLoggerImpl(new NoOpProgressWriter());
+    }
+
+    private static UnirestInstance newUnirest(TestSscServer server) {
+        return UnirestHelper.createUnirestInstance(unirest -> {
+            UnirestJsonHeaderConfigurer.configure(unirest);
+            unirest.config().defaultBaseUrl(server.getBaseUrl());
+        });
+    }
+
+    private static ObjectNode processedIssue() {
+        ObjectNode issue = JsonHelper.getObjectMapper().createObjectNode();
+        ArrayNode auditValues = issue.putObject("_embed").putArray("auditValues");
+        auditValues.addObject()
+                .put("customTagGuid", AviatorSSCTagDefs.AVIATOR_STATUS_TAG.getGuid())
+                .put("customTagIndex", 0);
+        return issue;
+    }
+
+    private static ObjectNode unprocessedIssue() {
+        ObjectNode issue = JsonHelper.getObjectMapper().createObjectNode();
+        issue.putObject("_embed").putArray("auditValues");
+        return issue;
+    }
+
+    private static final class TestSscServer implements AutoCloseable {
+        private final HttpServer server;
+        private final ArrayNode issues = JsonHelper.getObjectMapper().createArrayNode();
+        private int selectorSetRequestCount;
+        private String lastIssueQuery = "";
+
+        private TestSscServer(ObjectNode... issueNodes) throws IOException {
+            for (ObjectNode issue : issueNodes) {
+                issues.add(issue);
+            }
+            server = HttpServer.create(new InetSocketAddress(0), 0);
+            server.createContext("/api/v1/projectVersions/42/issues", this::handleIssues);
+            server.createContext("/api/v1/projectVersions/42/issueSelectorSet", this::handleSelectorSet);
+            server.createContext("/api/v1/projectVersions/42/issueGroups", this::handleIssueGroups);
+            server.start();
+        }
+
+        private String getBaseUrl() {
+            return "http://localhost:" + server.getAddress().getPort();
+        }
+
+        private void handleIssues(HttpExchange exchange) throws IOException {
+            lastIssueQuery = URLDecoder.decode(exchange.getRequestURI().getRawQuery(), StandardCharsets.UTF_8);
+            byte[] response = JsonHelper.getObjectMapper().createObjectNode()
+                    .put("count", issues.size())
+                    .set("data", issues)
+                    .toString()
+                    .getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, response.length);
+            try (var outputStream = exchange.getResponseBody()) {
+                outputStream.write(response);
+            }
+        }
+
+        private void handleSelectorSet(HttpExchange exchange) throws IOException {
+            selectorSetRequestCount++;
+            ObjectNode data = JsonHelper.getObjectMapper().createObjectNode();
+            data.putArray("filterBySet");
+            data.putArray("groupBySet").addObject()
+                    .put("guid", "category-guid")
+                    .put("displayName", "Category");
+            writeJson(exchange, JsonHelper.getObjectMapper().createObjectNode().set("data", data));
+        }
+
+        private void handleIssueGroups(HttpExchange exchange) throws IOException {
+            ObjectNode group = JsonHelper.getObjectMapper().createObjectNode()
+                    .put("id", "Category A")
+                    .put("visibleCount", 1)
+                    .put("auditedCount", 0);
+            ArrayNode data = JsonHelper.getObjectMapper().createArrayNode().add(group);
+            writeJson(exchange, JsonHelper.getObjectMapper().createObjectNode().set("data", data));
+        }
+
+        private void writeJson(HttpExchange exchange, ObjectNode responseNode) throws IOException {
+            byte[] response = responseNode.toString().getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, response.length);
+            try (var outputStream = exchange.getResponseBody()) {
+                outputStream.write(response);
+            }
+        }
+
+        private String getLastIssueQuery() {
+            return lastIssueQuery;
+        }
+
+        private int getSelectorSetRequestCount() {
+            return selectorSetRequestCount;
+        }
+
+        @Override
+        public void close() {
+            server.stop(0);
+        }
+    }
+
+    private static final class NoOpProgressWriter implements IProgressWriter {
+        @Override public boolean isMultiLineSupported() { return false; }
+        @Override public void writeProgress(String message, Object... args) {}
+        @Override public void writeInfo(String message, Object... args) {}
+        @Override public void writeInfoWithException(String message, Throwable cause, Object... args) {}
+        @Override public void writeWarning(String message, Object... args) {}
+        @Override public void writeWarningWithException(String message, Throwable cause, Object... args) {}
+        @Override public void clearProgress() {}
+        @Override public void close() {}
+        @Override public String type() { return "test"; }
+    }
+}

--- a/fcli-core/fcli-aviator/src/test/java/com/fortify/cli/aviator/ssc/helper/AviatorSSCAuditHelperTest.java
+++ b/fcli-core/fcli-aviator/src/test/java/com/fortify/cli/aviator/ssc/helper/AviatorSSCAuditHelperTest.java
@@ -13,6 +13,7 @@
 package com.fortify.cli.aviator.ssc.helper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -24,6 +25,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fortify.cli.aviator.config.AviatorLoggerImpl;
@@ -44,7 +46,7 @@ class AviatorSSCAuditHelperTest {
         try (var server = new TestSscServer(processedIssue(), unprocessedIssue());
                 var unirest = newUnirest(server)) {
             assertEquals(1, AviatorSSCAuditHelper.getAuditableIssueCount(
-                    unirest, appVersion(), logger(), true, null, null));
+                    unirest, appVersion(), logger(), true, null, null, false));
             assertTrue(server.getLastIssueQuery().contains("q=audited:false"));
         }
     }
@@ -55,7 +57,7 @@ class AviatorSSCAuditHelperTest {
                 var unirest = newUnirest(server)) {
             assertEquals(2, AviatorSSCAuditHelper.getAuditableIssueCount(
                     unirest, appVersion(), logger(), true, null, null, true));
-            assertTrue(server.getLastIssueQuery().contains("q=audited:false"));
+            assertFalse(server.getLastIssueQuery().contains("q=audited:false"));
         }
     }
 
@@ -65,12 +67,22 @@ class AviatorSSCAuditHelperTest {
                 var unirest = newUnirest(server)) {
             assertEquals(1, AviatorSSCAuditHelper.getAuditableIssueCount(
                     unirest, appVersion(), logger(), true, null, null, true));
-            assertTrue(server.getLastIssueQuery().contains("q=audited:false"));
+            assertFalse(server.getLastIssueQuery().contains("q=audited:false"));
         }
     }
 
     @Test
-    void forceReauditCategoryBreakdownDoesNotApplyAviatorStatusFilter() throws Exception {
+    void forceReauditPreflightExcludesHumanAuditedIssuesThatAviatorNeverProcessed() throws Exception {
+        try (var server = new TestSscServer(processedIssue(), unprocessedIssue(), humanAuditedIssue());
+                var unirest = newUnirest(server)) {
+            assertEquals(2, AviatorSSCAuditHelper.getAuditableIssueCount(
+                    unirest, appVersion(), logger(), true, null, null, true));
+            assertFalse(server.getLastIssueQuery().contains("q=audited:false"));
+        }
+    }
+
+    @Test
+    void forceReauditCategoryBreakdownIncludesFullyAuditedCategories() throws Exception {
         try (var server = new TestSscServer(processedIssue());
                 var unirest = newUnirest(server)) {
             List<Map<String, Object>> categories = AviatorSSCAuditHelper.getTopUnauditedCategories(
@@ -78,6 +90,7 @@ class AviatorSSCAuditHelperTest {
 
             assertEquals(1, categories.size());
             assertEquals("Category A", categories.get(0).get("categoryName"));
+            assertEquals(1L, categories.get(0).get("unauditedCount"));
             assertEquals(1, server.getSelectorSetRequestCount());
         }
     }
@@ -103,6 +116,7 @@ class AviatorSSCAuditHelperTest {
 
     private static ObjectNode processedIssue() {
         ObjectNode issue = JsonHelper.getObjectMapper().createObjectNode();
+        issue.put("audited", true);
         ArrayNode auditValues = issue.putObject("_embed").putArray("auditValues");
         auditValues.addObject()
                 .put("customTagGuid", AviatorSSCTagDefs.AVIATOR_STATUS_TAG.getGuid())
@@ -112,6 +126,14 @@ class AviatorSSCAuditHelperTest {
 
     private static ObjectNode unprocessedIssue() {
         ObjectNode issue = JsonHelper.getObjectMapper().createObjectNode();
+        issue.put("audited", false);
+        issue.putObject("_embed").putArray("auditValues");
+        return issue;
+    }
+
+    private static ObjectNode humanAuditedIssue() {
+        ObjectNode issue = JsonHelper.getObjectMapper().createObjectNode();
+        issue.put("audited", true);
         issue.putObject("_embed").putArray("auditValues");
         return issue;
     }
@@ -139,9 +161,17 @@ class AviatorSSCAuditHelperTest {
 
         private void handleIssues(HttpExchange exchange) throws IOException {
             lastIssueQuery = URLDecoder.decode(exchange.getRequestURI().getRawQuery(), StandardCharsets.UTF_8);
+            ArrayNode matchingIssues = JsonHelper.getObjectMapper().createArrayNode();
+            boolean unauditedOnly = lastIssueQuery.contains("q=audited:false");
+            for (JsonNode issue : issues) {
+                if (unauditedOnly && issue.path("audited").asBoolean(false)) {
+                    continue;
+                }
+                matchingIssues.add(issue);
+            }
             byte[] response = JsonHelper.getObjectMapper().createObjectNode()
-                    .put("count", issues.size())
-                    .set("data", issues)
+                    .put("count", matchingIssues.size())
+                    .set("data", matchingIssues)
                     .toString()
                     .getBytes(StandardCharsets.UTF_8);
             exchange.getResponseHeaders().set("Content-Type", "application/json");
@@ -165,7 +195,7 @@ class AviatorSSCAuditHelperTest {
             ObjectNode group = JsonHelper.getObjectMapper().createObjectNode()
                     .put("id", "Category A")
                     .put("visibleCount", 1)
-                    .put("auditedCount", 0);
+                    .put("auditedCount", 1);
             ArrayNode data = JsonHelper.getObjectMapper().createArrayNode().add(group);
             writeJson(exchange, JsonHelper.getObjectMapper().createObjectNode().set("data", data));
         }


### PR DESCRIPTION
> **NOTE: This PR merges into dev/v3.x**

Adds `--force-reaudit` to `fcli aviator ssc audit` so issues Aviator already processed can be sent again.

**Behavior**
- Re-includes Aviator-processed issues, including ones SSC already marks audited (Analysis tag set).
- Never overwrites suppressed issues or human triage.
- Human vs Aviator is the last `audit.xml` `TagHistory` username on result tags (Analysis, Auditor Status, FoD, filter-template Analysis id, `--tag-mapping` GUID). Not “any Auditor Status value.”
- Aviator usernames: `Fortify Remediation Aviator`, `Fortify Aviator`, `Core SAST Aviator`.
- Custom `--tag-mapping` onto Auditor Status does not make force-reaudit a no-op when Aviator wrote that tag.
- Output message for source context matching multiple location
```text
> java -jar '.\fcli.jar' aviator ssc apply-remediations --source-dir C:\Users\cdatla\Desktop\test\repos\aviatordemo\src\main\ --av gold_test:1.6 --latest 
Skipping remediation 7239ED25696B7CA174B0E77C5E35F7C8: Source context matched multiple locations in file 'java/com/fortify/aviator_fod_demo/HomeController.java'; candidate lines: 60, 66
Skipping remediation 8F7000582F24B8B678135EF2F8A10CA2: Source context matched multiple locations in file 'java/com/fortify/aviator_fod_demo/HomeController.java'; candidate lines: 61, 67
Skipping remediation 7239ED25696B7CA174B0E77C5E35F7C7: Source context matched multiple locations in file 'java/com/fortify/aviator_fod_demo/HomeController.java'; candidate lines: 60, 66
Skipping remediation C8FF8DC0AFB73405944FC6DA37C73E39: Original code not found for file 'java/com/fortify/aviator_fod_demo/HomeController.java'; file may have changed or remediation may overlap a previous change
Skipping remediation 8F7000582F24B8B678135EF2F8A10CA4: Source context matched multiple locations in file 'java/com/fortify/aviator_fod_demo/HomeController.java'; candidate lines: 60, 66
Skipping remediation 8F7000582F24B8B678135EF2F8A10CA3: Original code not found for file 'java/com/fortify/aviator_fod_demo/HomeController.java'; file may have changed or remediation may overlap a previous change
Skipping remediation 7239ED25696B7CA174B0E77C5E35F7C9: Source context matched multiple locations in file 'java/com/fortify/aviator_fod_demo/HomeController.java'; candidate lines: 59, 65
---
appVersionId: 137
artifactId: 3222
artifactsProcessed: 1
artifactsSkipped: 0
totalRemediation: 7
appliedRemediation: 0
skippedRemediation: 7
skippedReasons: "Source context matched multiple locations=5, Original code not found=2"
skippedByReason:
  Source context matched multiple locations: 5
  Original code not found: 2
modifiedFiles: []
__action__: No-Remediation-Applied
```

**Preflight**
- Drops `q=audited:false` under `--force-reaudit`; otherwise Analysis-tagged Aviator issues skip the whole AV.
- Also excludes suppressed issues.
- SSC issue list has no TagHistory usernames, so last-writer identity is applied when the FPR is parsed.

**Tests:** `IssueAuditorTest`, `AuditProcessorLastTagUsernamesTest`, `AviatorSSCAuditHelperTest`.

Commit:
```
feat: `fcli aviator ssc audit`: Add `--force-reaudit` to re-audit Aviator-processed issues without overwriting human triage
fix: `fcli aviator ssc apply-remediations`: Skip remediations when source context matches multiple locations
```