### PR TITLE
Fix NPE during forced re-audit when audit metadata is missing

### DIFF
--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/IssueAuditor.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/IssueAuditor.java
@@ -323,6 +323,9 @@ public class IssueAuditor {
     }
 
     private boolean isResultTagSet(AuditIssue auditIssue, String tagId) {
+        if (auditIssue == null) {
+            return false;
+        }
         Map<String, String> tags = auditIssue.getTags();
         return tags != null && !StringUtil.isPendingReviewValue(tags.get(tagId));
     }


### PR DESCRIPTION


## Description

Fixes a `NullPointerException` in the SAST audit flow when:

- `--force-reaudit` is enabled.
- An FVDL vulnerability has no matching issue entry in `audit.xml`.

In this case, `isAviatorWork()` passed a null `AuditIssue` to `isResultTagSet()`, which dereferenced it while checking result tags.

The updated logic treats a missing audit entry as having no result tag. The vulnerability is therefore considered unaudited and remains eligible for processing.

## Changes

- Added a null guard to `isResultTagSet()`.
