### PR TITLE
Fix DAST audit eligibility and server tier handling

### DIFF
--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/DastAuditDecisionMapper.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/DastAuditDecisionMapper.java
@@ -12,10 +12,9 @@
  */
 package com.fortify.cli.aviator.audit;
 
-import java.util.Locale;
-
 import com.fortify.cli.aviator.audit.model.AuditResponse;
 import com.fortify.cli.aviator.audit.model.AuditResult;
+import com.fortify.cli.aviator.audit.model.AuditTier;
 import com.fortify.cli.aviator.grpc.DastAuditResult;
 import com.fortify.cli.aviator.util.Constants;
 
@@ -28,28 +27,22 @@ public final class DastAuditDecisionMapper {
     public static AuditResponse toAuditResponse(DastAuditResult result) {
         if (!(result instanceof DastAuditResult.Success success)) {
             return AuditResponse.builder()
-            .issueId(result.issueId())
-            .status(result.status())
-            .statusMessage(result.statusMessage())
+                .issueId(result.issueId())
+                .status(result.status())
+                .statusMessage(result.statusMessage())
                 .build();
         }
 
-        String confidence = normalizedConfidence(success.confidence());
+        AuditTier tier = success.tier();
+        boolean tierOne = tier == AuditTier.GOLD;
         String tagValue;
         String prediction;
-        String tier;
         if (success.truePositive()) {
             tagValue = Constants.EXPLOITABLE;
-            prediction = Constants.AVIATOR_REMEDIATION_REQUIRED;
-            tier = "GOLD";
-        } else if ("HIGH".equals(confidence)) {
-            tagValue = Constants.NOT_AN_ISSUE;
-            prediction = Constants.AVIATOR_NOT_AN_ISSUE;
-            tier = "GOLD";
+            prediction = tierOne ? Constants.AVIATOR_REMEDIATION_REQUIRED : Constants.AVIATOR_LIKELY_TP;
         } else {
             tagValue = Constants.NOT_AN_ISSUE;
-            prediction = Constants.AVIATOR_LIKELY_FP;
-            tier = "SILVER";
+            prediction = tierOne ? Constants.AVIATOR_NOT_AN_ISSUE : Constants.AVIATOR_LIKELY_FP;
         }
 
         String comment = success.finalComment() != null && !success.finalComment().isBlank()
@@ -58,19 +51,11 @@ public final class DastAuditDecisionMapper {
         return AuditResponse.builder()
             .issueId(success.issueId())
             .status("SUCCESS")
-            .tier(tier)
+            .tier(tier.name())
             .aviatorPredictionTag(prediction)
             .isAviatorProcessed(true)
             .auditResult(AuditResult.builder().tagValue(tagValue).comment(comment).build())
             .build();
     }
 
-    private static String normalizedConfidence(String confidence) {
-        if (confidence == null) return "LOW";
-        String normalized = confidence.toUpperCase(Locale.ROOT);
-        return switch (normalized) {
-            case "HIGH", "MEDIUM", "LOW" -> normalized;
-            default -> "LOW";
-        };
-    }
 }

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/DastAuditFPR.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/DastAuditFPR.java
@@ -236,7 +236,7 @@ public final class DastAuditFPR {
     }
 
     private static boolean isSuppressedFalsePositive(AuditResponse response, TagMappingConfig tagMappingConfig) {
-        boolean tierOne = AuditTier.GOLD.name().equals(response.getTier());
+        boolean tierOne = AuditTier.fromServerValue(response.getTier()) == AuditTier.GOLD;
         return Boolean.TRUE.equals(tagMappingConfig.getResult(
             tierOne, TagMappingConfig.ResultType.FP).getSuppress());
     }

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/DastAuditFPR.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/DastAuditFPR.java
@@ -24,7 +24,9 @@ import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fortify.cli.aviator._common.exception.AviatorTechnicalException;
 import com.fortify.cli.aviator.audit.model.AuditResponse;
+import com.fortify.cli.aviator.audit.model.AuditTier;
 import com.fortify.cli.aviator.config.TagMappingConfig;
 import com.fortify.cli.aviator.dast.DastSession;
 import com.fortify.cli.aviator.dast.StreamingWebInspectParser;
@@ -53,12 +55,12 @@ public final class DastAuditFPR {
             int missingId,
             int duplicate,
             int suppressed,
-            int alreadyProcessed) {
+            int alreadyProcessed,
+            int humanAudited) {
         private static class EligibilityResultBuilder {
-            private List<DastAuditWorkItem> workItems;
+            private List<DastAuditWorkItem> workItems = new ArrayList<>();
 
             private EligibilityResultBuilder addWorkItem(DastAuditWorkItem workItem) {
-                if (workItems == null) workItems = new ArrayList<>();
                 workItems.add(workItem);
                 return this;
             }
@@ -80,6 +82,11 @@ public final class DastAuditFPR {
 
             private EligibilityResultBuilder incrementAlreadyProcessed() {
                 alreadyProcessed++;
+                return this;
+            }
+
+            private EligibilityResultBuilder incrementHumanAudited() {
+                humanAudited++;
                 return this;
             }
         }
@@ -114,16 +121,24 @@ public final class DastAuditFPR {
         int totalReported = sessions.stream().mapToInt(session -> session.getIssues().size()).sum();
         int locallySkipped = totalReported - workItems.size();
         LOG.info("DAST audit eligibility: reported={}, eligible={}, skipped={} "
-                + "(missingId={}, duplicate={}, suppressed={}, alreadyProcessed={})",
+                + "(missingId={}, duplicate={}, suppressed={}, alreadyProcessed={}, humanAudited={})",
             totalReported, workItems.size(), locallySkipped, eligibility.missingId(),
-            eligibility.duplicate(), eligibility.suppressed(), eligibility.alreadyProcessed());
+            eligibility.duplicate(), eligibility.suppressed(), eligibility.alreadyProcessed(),
+            eligibility.humanAudited());
 
         if (workItems.isEmpty()) {
             LOG.info("DAST audit skipped because no eligible findings remain");
             return emptyResult(totalReported, locallySkipped);
         }
 
-        DastAuditStreamResult streamResult = streamRunner.run(config, workItems, totalReported).join();
+        CompletableFuture<DastAuditStreamResult> streamFuture = streamRunner.run(config, workItems, totalReported);
+        if (streamFuture == null) {
+            throw new AviatorTechnicalException("DAST audit stream did not return a completion future");
+        }
+        DastAuditStreamResult streamResult = streamFuture.join();
+        if (streamResult == null) {
+            throw new AviatorTechnicalException("DAST audit stream completed without a result");
+        }
         ResponseSummary summary = summarizeResponses(streamResult, workItems, tagMappingConfig);
         var updatedFile = summary.successfulResponses().isEmpty()
             ? null
@@ -221,7 +236,7 @@ public final class DastAuditFPR {
     }
 
     private static boolean isSuppressedFalsePositive(AuditResponse response, TagMappingConfig tagMappingConfig) {
-        boolean tierOne = "GOLD".equalsIgnoreCase(response.getTier());
+        boolean tierOne = AuditTier.GOLD.name().equals(response.getTier());
         return Boolean.TRUE.equals(tagMappingConfig.getResult(
             tierOne, TagMappingConfig.ResultType.FP).getSuppress());
     }
@@ -255,6 +270,11 @@ public final class DastAuditFPR {
                     LOG.debug("Skipping DAST issue {} because it is already processed by Aviator", issueId);
                     continue;
                 }
+                if (auditIssue != null && isHumanAudited(auditIssue)) {
+                    result.incrementHumanAudited();
+                    LOG.debug("Skipping DAST issue {} because it is already audited by a human", issueId);
+                    continue;
+                }
                 result.addWorkItem(new DastAuditWorkItem(session, issue));
             }
         }
@@ -262,8 +282,30 @@ public final class DastAuditFPR {
     }
 
     private static boolean isProcessedByAviator(AuditIssue auditIssue) {
-        return Constants.PROCESSED_BY_AVIATOR.equalsIgnoreCase(
-            auditIssue.getTags().get(Constants.AVIATOR_STATUS_TAG_ID));
+        Map<String, String> tags = getTags(auditIssue);
+        return Constants.PROCESSED_BY_AVIATOR.equalsIgnoreCase(tags.get(Constants.AVIATOR_STATUS_TAG_ID))
+            || tags.containsKey(Constants.AVIATOR_EXPECTED_OUTCOME_TAG_ID);
+    }
+
+    private static boolean isHumanAudited(AuditIssue auditIssue) {
+        Map<String, String> tags = getTags(auditIssue);
+        return isAuditDecision(tags.get(Constants.AUDITOR_STATUS_TAG_ID))
+            || isAuditDecision(tags.get(Constants.FOD_TAG_ID))
+            || isAnalysisDecision(tags.get(Constants.ANALYSIS_TAG_ID));
+    }
+
+    private static Map<String, String> getTags(AuditIssue auditIssue) {
+        return auditIssue.getTags() == null ? Map.of() : auditIssue.getTags();
+    }
+
+    private static boolean isAuditDecision(String value) {
+        return value != null && !value.isBlank()
+            && !Constants.PENDING_REVIEW.equalsIgnoreCase(value)
+            && !"Pending Review".equalsIgnoreCase(value);
+    }
+
+    private static boolean isAnalysisDecision(String value) {
+        return isAuditDecision(value) && !"Not Set".equalsIgnoreCase(value);
     }
 
     private static DastAuditFprResult emptyResult(int totalReported, int skipped) {

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/model/AuditTier.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/audit/model/AuditTier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021-2026 Open Text.
+ *
+ * The only warranties for products and services of Open Text
+ * and its affiliates and licensors ("Open Text") are as may
+ * be set forth in the express warranty statements accompanying
+ * such products and services. Nothing herein should be construed
+ * as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained
+ * herein. The information contained herein is subject to change
+ * without notice.
+ */
+package com.fortify.cli.aviator.audit.model;
+
+/** Supported Aviator audit decision tiers. */
+public enum AuditTier {
+    GOLD,
+    SILVER;
+
+    /**
+     * Parses a server-provided tier, defaulting unknown values to the conservative tier.
+     *
+     * @param value server-provided tier value
+     * @return parsed tier, or {@link #SILVER} when missing or unknown
+     */
+    public static AuditTier fromServerValue(String value) {
+        return GOLD.name().equalsIgnoreCase(value) ? GOLD : SILVER;
+    }
+}

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/AuditProcessor.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/AuditProcessor.java
@@ -843,7 +843,7 @@ public class AuditProcessor {
 
     private TagMappingConfig.Result getDastResultConfig(AuditResponse response,
             TagMappingConfig tagMappingConfig) {
-        boolean tierOne = AuditTier.GOLD.name().equals(response.getTier());
+        boolean tierOne = AuditTier.fromServerValue(response.getTier()) == AuditTier.GOLD;
         String tagValue = response.getAuditResult().getTagValue();
         if (Constants.NOT_AN_ISSUE.equalsIgnoreCase(tagValue)) {
             return tagMappingConfig.getResult(tierOne, TagMappingConfig.ResultType.FP);

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/AuditProcessor.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/fpr/processor/AuditProcessor.java
@@ -56,6 +56,7 @@ import org.xml.sax.SAXException;
 
 import com.fortify.cli.aviator._common.exception.AviatorTechnicalException;
 import com.fortify.cli.aviator.audit.model.AuditResponse;
+import com.fortify.cli.aviator.audit.model.AuditTier;
 import com.fortify.cli.aviator.config.TagMappingConfig;
 import com.fortify.cli.aviator.fpr.model.AuditIssue;
 import com.fortify.cli.aviator.fpr.model.FPRInfo;
@@ -842,7 +843,7 @@ public class AuditProcessor {
 
     private TagMappingConfig.Result getDastResultConfig(AuditResponse response,
             TagMappingConfig tagMappingConfig) {
-        boolean tierOne = "GOLD".equalsIgnoreCase(response.getTier());
+        boolean tierOne = AuditTier.GOLD.name().equals(response.getTier());
         String tagValue = response.getAuditResult().getTagValue();
         if (Constants.NOT_AN_ISSUE.equalsIgnoreCase(tagValue)) {
             return tagMappingConfig.getResult(tierOne, TagMappingConfig.ResultType.FP);

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/grpc/DastAuditResponseMapper.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/grpc/DastAuditResponseMapper.java
@@ -13,6 +13,7 @@
 package com.fortify.cli.aviator.grpc;
 
 import com.fortify.aviator.dastaudit.DastAuditResponse;
+import com.fortify.cli.aviator.audit.model.AuditTier;
 
 /**
  * Maps a DAST audit response to the issue associated with its request ID.
@@ -61,7 +62,7 @@ final class DastAuditResponseMapper {
             .remediationAdvice(decision.getRemediationAdvice())
             .finalComment(decision.getFinalComment())
             .tagValue(decision.getTagValue())
-            .tier(decision.getTier())
+            .tier(AuditTier.fromServerValue(decision.getTier()))
             .build();
     }
 }

--- a/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/grpc/DastAuditResult.java
+++ b/fcli-core/fcli-aviator-common/src/main/java/com/fortify/cli/aviator/grpc/DastAuditResult.java
@@ -12,6 +12,8 @@
  */
 package com.fortify.cli.aviator.grpc;
 
+import com.fortify.cli.aviator.audit.model.AuditTier;
+
 import lombok.Builder;
 
 /** Domain representation of one terminal DAST audit response. */
@@ -29,8 +31,12 @@ public sealed interface DastAuditResult permits DastAuditResult.Success, DastAud
         String remediationAdvice,
         String finalComment,
         String tagValue,
-        String tier
+        AuditTier tier
     ) implements DastAuditResult {
+        public Success {
+            tier = tier == null ? AuditTier.SILVER : tier;
+        }
+
         @Override
         public String status() {
             return "SUCCESS";

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/audit/DastAuditDecisionMapperTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/audit/DastAuditDecisionMapperTest.java
@@ -16,29 +16,30 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
+import com.fortify.cli.aviator.audit.model.AuditTier;
 import com.fortify.cli.aviator.grpc.DastAuditResult;
 import com.fortify.cli.aviator.util.Constants;
 
 class DastAuditDecisionMapperTest {
     @Test
-    void unknownConfidenceFalsePositiveRemainsUnsuppressed() {
+    void serverGoldTierControlsFalsePositiveMappingRegardlessOfConfidence() {
         var result = DastAuditResult.Success.builder()
             .issueId("DAST-1")
             .confidence("UNKNOWN")
             .reasoning("reason")
             .finalComment("comment")
             .tagValue("bad")
-            .tier("GOLD")
+            .tier(AuditTier.GOLD)
             .build();
 
         var response = DastAuditDecisionMapper.toAuditResponse(result);
 
-        assertEquals("SILVER", response.getTier());
-        assertEquals(Constants.AVIATOR_LIKELY_FP, response.getAviatorPredictionTag());
+        assertEquals("GOLD", response.getTier());
+        assertEquals(Constants.AVIATOR_NOT_AN_ISSUE, response.getAviatorPredictionTag());
     }
 
     @Test
-    void highConfidenceFalsePositiveIsSuppressible() {
+    void missingServerTierDefaultsToSilverRegardlessOfConfidence() {
         var result = DastAuditResult.Success.builder()
             .issueId("DAST-1")
             .confidence("HIGH")
@@ -48,7 +49,34 @@ class DastAuditDecisionMapperTest {
 
         var response = DastAuditDecisionMapper.toAuditResponse(result);
 
-        assertEquals("GOLD", response.getTier());
-        assertEquals(Constants.AVIATOR_NOT_AN_ISSUE, response.getAviatorPredictionTag());
+        assertEquals("SILVER", response.getTier());
+        assertEquals(Constants.AVIATOR_LIKELY_FP, response.getAviatorPredictionTag());
+    }
+
+    @Test
+    void missingDomainTierDefaultsToSilver() {
+        var result = DastAuditResult.Success.builder()
+            .issueId("DAST-1")
+            .build();
+
+        var response = DastAuditDecisionMapper.toAuditResponse(result);
+
+        assertEquals("SILVER", response.getTier());
+        assertEquals(Constants.AVIATOR_LIKELY_FP, response.getAviatorPredictionTag());
+    }
+
+    @Test
+    void serverSilverTierControlsTruePositivePrediction() {
+        var result = DastAuditResult.Success.builder()
+            .issueId("DAST-1")
+            .truePositive(true)
+            .confidence("HIGH")
+            .tier(AuditTier.SILVER)
+            .build();
+
+        var response = DastAuditDecisionMapper.toAuditResponse(result);
+
+        assertEquals("SILVER", response.getTier());
+        assertEquals(Constants.AVIATOR_LIKELY_TP, response.getAviatorPredictionTag());
     }
 }

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/audit/DastAuditFPRTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/audit/DastAuditFPRTest.java
@@ -14,6 +14,7 @@ package com.fortify.cli.aviator.audit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
@@ -29,6 +30,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import com.fortify.cli.aviator._common.config.AviatorConfigManager;
+import com.fortify.cli.aviator._common.exception.AviatorTechnicalException;
+import com.fortify.cli.aviator.audit.model.AuditTier;
 import com.fortify.cli.aviator.config.TagMappingConfig;
 import com.fortify.cli.aviator.grpc.DastAuditResult;
 import com.fortify.cli.aviator.grpc.DastAuditStreamConfig;
@@ -48,7 +51,7 @@ class DastAuditFPRTest {
         try (FprHandle handle = new FprHandle(fpr)) {
             result = DastAuditFPR.audit(handle, config, defaultTagMapping(), (ignoredConfig, items, total) ->
                 CompletableFuture.completedFuture(DastAuditStreamResult.builder()
-                    .results(List.of(successResult(false, "HIGH")))
+                    .results(List.of(successResult(false, "HIGH", AuditTier.GOLD)))
                     .reservedQuota(1)
                     .build()));
         }
@@ -88,7 +91,7 @@ class DastAuditFPRTest {
                 ResourceUtil.loadYamlFile(tagMapping.toFile(), TagMappingConfig.class),
                 (ignoredConfig, items, total) ->
                 CompletableFuture.completedFuture(DastAuditStreamResult.builder()
-                    .results(List.of(successResult(false, "MEDIUM")))
+                    .results(List.of(successResult(false, "MEDIUM", AuditTier.SILVER)))
                     .reservedQuota(1)
                     .build()));
         }
@@ -118,7 +121,7 @@ class DastAuditFPRTest {
         try (FprHandle handle = new FprHandle(fpr)) {
             DastAuditFPR.audit(handle, config, defaultTagMapping(), (ignoredConfig, items, total) ->
                 CompletableFuture.completedFuture(DastAuditStreamResult.builder()
-                    .results(List.of(successResult(true, "HIGH")))
+                    .results(List.of(successResult(true, "HIGH", AuditTier.GOLD)))
                     .reservedQuota(1)
                     .build()));
         }
@@ -148,11 +151,87 @@ class DastAuditFPRTest {
         }
     }
 
-    private DastAuditResult.Success successResult(boolean truePositive, String confidence) {
+    @Test
+    void excludesSuppressedAviatorProcessedAndHumanAuditedFindings() throws Exception {
+        Path fpr = createEligibilityFpr();
+
+        try (FprHandle handle = new FprHandle(fpr)) {
+            DastAuditFprResult result = DastAuditFPR.audit(
+                handle, streamConfig(), defaultTagMapping(), (ignoredConfig, items, total) -> {
+                    assertEquals(List.of("DAST-5"), items.stream().map(item -> item.issue().getId()).toList());
+                    return CompletableFuture.completedFuture(DastAuditStreamResult.builder()
+                        .results(List.of(successResult("DAST-5", true, "HIGH", AuditTier.GOLD)))
+                        .reservedQuota(1)
+                        .build());
+                });
+
+            assertEquals(5, result.totalReported());
+            assertEquals(1, result.submitted());
+            assertEquals(4, result.skipped());
+        }
+    }
+
+    @Test
+    void allExcludedFindingsReturnSkippedWithoutStartingStream() throws Exception {
+        Path fpr = createFpr();
+        try (FileSystem zip = FileSystems.newFileSystem(fpr)) {
+            Files.writeString(zip.getPath("/audit.xml"), """
+                <Audit xmlns="xmlns://www.fortify.com/schema/audit"><IssueList>
+                  <Issue instanceId="DAST-1" revision="0" suppressed="true"/>
+                </IssueList></Audit>
+                """);
+        }
+
+        try (FprHandle handle = new FprHandle(fpr)) {
+            DastAuditFprResult result = DastAuditFPR.audit(
+                handle, streamConfig(), defaultTagMapping(), (ignoredConfig, items, total) -> {
+                    throw new AssertionError("Stream must not start when all findings are excluded");
+                });
+
+            assertEquals(DastAuditFprStatus.SKIPPED, result.status());
+            assertEquals(1, result.totalReported());
+            assertEquals(1, result.skipped());
+            assertEquals(0, result.submitted());
+        }
+    }
+
+    @Test
+    void missingStreamFutureProducesTechnicalError() throws Exception {
+        Path fpr = createFpr();
+
+        try (FprHandle handle = new FprHandle(fpr)) {
+            AviatorTechnicalException exception = assertThrows(AviatorTechnicalException.class,
+                () -> DastAuditFPR.audit(handle, streamConfig(), defaultTagMapping(),
+                    (ignoredConfig, items, total) -> null));
+
+            assertEquals("DAST audit stream did not return a completion future", exception.getMessage());
+        }
+    }
+
+    @Test
+    void missingStreamResultProducesTechnicalError() throws Exception {
+        Path fpr = createFpr();
+
+        try (FprHandle handle = new FprHandle(fpr)) {
+            AviatorTechnicalException exception = assertThrows(AviatorTechnicalException.class,
+                () -> DastAuditFPR.audit(handle, streamConfig(), defaultTagMapping(),
+                    (ignoredConfig, items, total) -> CompletableFuture.completedFuture(null)));
+
+            assertEquals("DAST audit stream completed without a result", exception.getMessage());
+        }
+    }
+
+    private DastAuditResult.Success successResult(boolean truePositive, String confidence, AuditTier tier) {
+        return successResult("DAST-1", truePositive, confidence, tier);
+    }
+
+    private DastAuditResult.Success successResult(
+            String issueId, boolean truePositive, String confidence, AuditTier tier) {
         return DastAuditResult.Success.builder()
-            .issueId("DAST-1")
+            .issueId(issueId)
             .truePositive(truePositive)
             .confidence(confidence)
+            .tier(tier)
             .reasoning("reason")
             .finalComment("comment")
             .build();
@@ -178,6 +257,36 @@ class DastAuditFPRTest {
                 <WebInspectScan><Session requestId="REQ-1"><URL>https://example.test</URL><Issues>
                 <Issue id="DAST-1"><Name>SQL Injection</Name><Severity>4</Severity></Issue>
                 </Issues></Session></WebInspectScan>
+                """, StandardCharsets.UTF_8);
+        }
+        return fpr;
+    }
+
+    private Path createEligibilityFpr() throws Exception {
+        Path fpr = tempDir.resolve("dast-eligibility.fpr");
+        try (FileSystem zip = FileSystems.newFileSystem(fpr, Map.of("create", "true"))) {
+            Files.writeString(zip.getPath("/webinspect.xml"), """
+                <WebInspectScan><Session requestId="REQ-1"><URL>https://example.test</URL><Issues>
+                <Issue id="DAST-1"><Name>Suppressed</Name><Severity>4</Severity></Issue>
+                <Issue id="DAST-2"><Name>Aviator status</Name><Severity>4</Severity></Issue>
+                <Issue id="DAST-3"><Name>Legacy Aviator outcome</Name><Severity>4</Severity></Issue>
+                <Issue id="DAST-4"><Name>Human audited</Name><Severity>4</Severity></Issue>
+                <Issue id="DAST-5"><Name>Eligible</Name><Severity>4</Severity></Issue>
+                </Issues></Session></WebInspectScan>
+                """, StandardCharsets.UTF_8);
+            Files.writeString(zip.getPath("/audit.xml"), """
+                <Audit xmlns="xmlns://www.fortify.com/schema/audit"><IssueList>
+                    <Issue instanceId="DAST-1" revision="0" suppressed="true"/>
+                    <Issue instanceId="DAST-2" revision="0" suppressed="false">
+                        <Tag id="FB7B0462-2C2E-46D9-811A-DCC1F3C83051"><Value>PROCESSED_BY_AVIATOR</Value></Tag>
+                    </Issue>
+                    <Issue instanceId="DAST-3" revision="0" suppressed="false">
+                        <Tag id="013cc66f-8651-4e39-bacb-beb918c5ef65"><Value>Not an Issue</Value></Tag>
+                    </Issue>
+                    <Issue instanceId="DAST-4" revision="0" suppressed="false">
+                        <Tag id="ACB05E55-E74D-468C-8501-52E1FDC27D71"><Value>Exploitable</Value></Tag>
+                    </Issue>
+                </IssueList></Audit>
                 """, StandardCharsets.UTF_8);
         }
         return fpr;

--- a/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/grpc/DastAuditResponseMapperTest.java
+++ b/fcli-core/fcli-aviator-common/src/test/java/com/fortify/cli/aviator/grpc/DastAuditResponseMapperTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import com.fortify.aviator.dastaudit.DastAuditDecision;
 import com.fortify.aviator.dastaudit.DastAuditResponse;
+import com.fortify.cli.aviator.audit.model.AuditTier;
 
 class DastAuditResponseMapperTest {
     @Test
@@ -36,6 +37,13 @@ class DastAuditResponseMapperTest {
         assertEquals("DAST-1", result.issueId());
         assertEquals("SUCCESS", result.status());
         assertEquals(true, success.truePositive());
+        assertEquals(AuditTier.SILVER, success.tier());
+    }
+
+    @Test
+    void parsesKnownTierAndDefaultsUnknownTierToSilver() {
+        assertEquals(AuditTier.GOLD, mapTier("gold"));
+        assertEquals(AuditTier.SILVER, mapTier("BRONZE"));
     }
 
     @Test
@@ -67,5 +75,14 @@ class DastAuditResponseMapperTest {
         assertInstanceOf(DastAuditResult.Skipped.class, result);
         assertEquals("SKIPPED", result.status());
         assertEquals("Quota exceeded", result.statusMessage());
+    }
+
+    private AuditTier mapTier(String tier) {
+        var response = DastAuditResponse.newBuilder()
+            .setDastIssueId("DAST-1")
+            .setStatus("SUCCESS")
+            .setDecision(DastAuditDecision.newBuilder().setTier(tier))
+            .build();
+        return ((DastAuditResult.Success) DastAuditResponseMapper.map(response, "DAST-1")).tier();
     }
 }

--- a/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/cli/cmd/AviatorSSCDastAuditCommand.java
+++ b/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/cli/cmd/AviatorSSCDastAuditCommand.java
@@ -12,8 +12,6 @@
  */
 package com.fortify.cli.aviator.ssc.cli.cmd;
 
-import static com.fortify.cli.ssc.artifact.helper.SSCArtifactHelper.getLatestDASTArtifact;
-
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -52,7 +50,6 @@ import com.fortify.cli.ssc.appversion.cli.mixin.SSCAppVersionRefreshOptions;
 import com.fortify.cli.ssc.appversion.cli.mixin.SSCAppVersionResolverMixin;
 import com.fortify.cli.ssc.appversion.helper.SSCAppVersionDescriptor;
 import com.fortify.cli.ssc.appversion.helper.SSCAppVersionHelper;
-import com.fortify.cli.ssc.artifact.helper.SSCArtifactDescriptor;
 import com.fortify.cli.ssc.system_state.helper.SSCJobDescriptor;
 import com.fortify.cli.ssc.system_state.helper.SSCJobHelper;
 
@@ -87,9 +84,8 @@ public class AviatorSSCDastAuditCommand extends AbstractSSCJsonNodeOutputCommand
 
             refreshMetricsIfNeeded(unirest, appVersion, logger);
 
-            SSCArtifactDescriptor artifact = getLatestDASTArtifact(unirest, appVersion.getVersionId());
-            downloadedFpr = AviatorSSCFprTransferHelper.downloadArtifactFpr(
-                unirest, artifact, logger, progressWriter);
+            downloadedFpr = AviatorSSCFprTransferHelper.downloadCurrentStateFpr(
+                unirest, appVersion, logger, progressWriter);
 
             DastAuditFprResult result = auditFpr(
                 downloadedFpr, appVersion, session, logger, tagMappingConfig);

--- a/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/helper/AviatorSSCFprTransferHelper.java
+++ b/fcli-core/fcli-aviator/src/main/java/com/fortify/cli/aviator/ssc/helper/AviatorSSCFprTransferHelper.java
@@ -28,22 +28,42 @@ import com.fortify.cli.ssc.artifact.helper.SSCArtifactDescriptor;
 import kong.unirest.UnirestInstance;
 
 /**
- * Shared SSC transfer operations for artifact-specific DAST FPR workflows.
+ * Shared SSC transfer operations for DAST FPR workflows.
  */
 public final class AviatorSSCFprTransferHelper {
     private AviatorSSCFprTransferHelper() {}
+
+    public static Path downloadCurrentStateFpr(
+            UnirestInstance unirest,
+            SSCAppVersionDescriptor appVersion,
+            IAviatorLogger logger,
+            IProgressWriter progressWriter) throws IOException {
+        logger.progress("Status: Downloading current FPR state from SSC for app version %s:%s (id=%s)",
+            appVersion.getApplicationName(), appVersion.getVersionName(), appVersion.getVersionId());
+        return downloadFpr(unirest, "aviator_" + appVersion.getVersionId() + "_",
+            SSCUrls.DOWNLOAD_CURRENT_FPR(appVersion.getVersionId(), true), progressWriter);
+    }
 
     public static Path downloadArtifactFpr(
             UnirestInstance unirest,
             SSCArtifactDescriptor artifact,
             IAviatorLogger logger,
             IProgressWriter progressWriter) throws IOException {
-        Path fprPath = Files.createTempFile("aviator_" + artifact.getId() + "_", ".fpr");
+        logger.progress("Status: Downloading FPR from SSC (artifact id=%s)", artifact.getId());
+        return downloadFpr(unirest, "aviator_" + artifact.getId() + "_",
+            SSCUrls.DOWNLOAD_ARTIFACT(artifact.getId(), true), progressWriter);
+    }
+
+    private static Path downloadFpr(
+            UnirestInstance unirest,
+            String filePrefix,
+            String downloadUrl,
+            IProgressWriter progressWriter) throws IOException {
+        Path fprPath = Files.createTempFile(filePrefix, ".fpr");
         try {
-            logger.progress("Status: Downloading FPR from SSC (artifact id=%s)", artifact.getId());
             SSCFileTransferHelper.download(
                 unirest,
-                SSCUrls.DOWNLOAD_ARTIFACT(artifact.getId(), true),
+                downloadUrl,
                 fprPath.toFile(),
                 SSCFileTransferHelper.ISSCAddDownloadTokenFunction.ROUTEPARAM_DOWNLOADTOKEN,
                 progressWriter);

--- a/fcli-core/fcli-aviator/src/main/resources/com/fortify/cli/aviator/i18n/AviatorMessages.properties
+++ b/fcli-core/fcli-aviator/src/main/resources/com/fortify/cli/aviator/i18n/AviatorMessages.properties
@@ -179,7 +179,7 @@ fcli.ssc.appversion.create.refresh-timeout = Time-out for refreshing application
   5m (5 minutes), 1h (1 hour). Default value: ${DEFAULT-VALUE}
 
 fcli.aviator.ssc.audit-dast.usage.header = Audit DAST findings in an SSC application version using Fortify Aviator.
-fcli.aviator.ssc.audit-dast.usage.description = Downloads the latest DAST FPR from SSC, audits eligible WebInspect findings, \
+fcli.aviator.ssc.audit-dast.usage.description = Downloads the current application version FPR from SSC, audits eligible WebInspect findings, \
   writes decisions to audit.xml, and uploads the changed DAST FPR. This command requires an active Fortify Aviator user session.
 fcli.aviator.ssc.audit-dast.app = Fortify Aviator application name to associate with the DAST audit. \
   If omitted, the SSC application name is used.


### PR DESCRIPTION
## Summary

- Download the current SSC FPR state before DAST auditing.
- Exclude suppressed, human-audited, and Aviator-processed findings before quota submission.
- Skip stream initialization when no eligible findings remain.
- Introduce `AuditTier` for typed `GOLD`/`SILVER` handling.
- Default missing or unknown server tiers to `SILVER`.
- Harden null stream future/result handling.
- Consolidate temporary FPR download and cleanup logic.