### PR TITLE
fix: Support role names and IDs for SSC local user management

### DIFF
--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/cli/cmd/SSCUserCreateLocalCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/cli/cmd/SSCUserCreateLocalCommand.java
@@ -21,6 +21,8 @@ import com.fortify.cli.common.cli.util.CommandGroup;
 import com.fortify.cli.common.output.cli.mixin.OutputHelperMixins;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCJsonNodeOutputCommand;
 import com.fortify.cli.ssc._common.rest.ssc.SSCUrls;
+import com.fortify.cli.ssc.access_control.helper.SSCRoleDescriptor;
+import com.fortify.cli.ssc.access_control.helper.SSCRoleHelper;
 import com.fortify.cli.ssc.access_control.helper.SSCUserCreateRequest;
 
 import kong.unirest.UnirestInstance;
@@ -65,7 +67,13 @@ public class SSCUserCreateLocalCommand extends AbstractSSCJsonNodeOutputCommand 
                 .requirePasswordChange(requirePwChange)
                 .suspended(suspend)
                 .build();
-        userCreateRequest.addRoles(roles);
+        // Resolve each role name/ID to its actual ID
+        ArrayList<String> resolvedRoles = new ArrayList<>();
+        for (String roleNameOrId : roles) {
+            SSCRoleDescriptor descriptor = SSCRoleHelper.getRoleDescriptor(unirest, roleNameOrId, "id");
+            resolvedRoles.add(descriptor.getRoleId());
+        }
+        userCreateRequest.addRoles(resolvedRoles);
         ObjectNode body = objectMapper.valueToTree(userCreateRequest);
         
         return unirest.post(SSCUrls.LOCAL_USERS)

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/cli/cmd/SSCUserUpdateLocalCommand.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/access_control/cli/cmd/SSCUserUpdateLocalCommand.java
@@ -26,6 +26,8 @@ import com.fortify.cli.common.output.transform.IActionCommandResultSupplier;
 import com.fortify.cli.ssc._common.output.cli.cmd.AbstractSSCJsonNodeOutputCommand;
 import com.fortify.cli.ssc._common.rest.ssc.SSCUrls;
 import com.fortify.cli.ssc.access_control.cli.mixin.SSCUserResolverMixin;
+import com.fortify.cli.ssc.access_control.helper.SSCRoleDescriptor;
+import com.fortify.cli.ssc.access_control.helper.SSCRoleHelper;
 
 import kong.unirest.UnirestInstance;
 import lombok.Getter;
@@ -65,7 +67,7 @@ public class SSCUserUpdateLocalCommand extends AbstractSSCJsonNodeOutputCommand 
         String userId = resolveUserId(unirest);
         ObjectNode userData = getLocalUser(unirest, userId);
         setUserAttributes(userData);
-        setUserRoles(userData);
+        setUserRoles(unirest, userData);
         return unirest.put(SSCUrls.LOCAL_USER(userId))
                 .body(userData)
                 .asObject(JsonNode.class).getBody();
@@ -95,35 +97,40 @@ public class SSCUserUpdateLocalCommand extends AbstractSSCJsonNodeOutputCommand 
         if (suspend != null) { userData.put("suspended", suspend); }
     }
 
-    private void setUserRoles(ObjectNode userData) {
+    private void setUserRoles(UnirestInstance unirest, ObjectNode userData) {
         if (roles != null) {
             ArrayNode rolesArray = userData.putArray("roles");
-            for (String roleId : roles) {
+            for (String roleNameOrId : roles) {
+                String roleId = resolveRoleId(unirest, roleNameOrId);
                 rolesArray.addObject().put("id", roleId);
             }
         }
         if (addRoles != null) {
-            addRolesToUser(userData);
+            addRolesToUser(unirest, userData);
         }
         if (rmRoles != null) {
-            removeRolesFromUser(userData);
+            removeRolesFromUser(unirest, userData);
         }
     }
 
-    private void addRolesToUser(ObjectNode userData) {
+    private void addRolesToUser(UnirestInstance unirest, ObjectNode userData) {
         ArrayNode existingRoles = getOrCreateRolesArray(userData);
         Set<String> existingRoleIds = collectRoleIds(existingRoles);
-        for (String roleId : addRoles) {
+        for (String roleNameOrId : addRoles) {
+            String roleId = resolveRoleId(unirest, roleNameOrId);
             if (!existingRoleIds.contains(roleId)) {
                 existingRoles.addObject().put("id", roleId);
             }
         }
     }
 
-    private void removeRolesFromUser(ObjectNode userData) {
+    private void removeRolesFromUser(UnirestInstance unirest, ObjectNode userData) {
         ArrayNode existingRoles = (ArrayNode) userData.get("roles");
         if (existingRoles == null) { return; }
-        Set<String> idsToRemove = new HashSet<>(rmRoles);
+        Set<String> idsToRemove = new HashSet<>();
+        for (String roleNameOrId : rmRoles) {
+            idsToRemove.add(resolveRoleId(unirest, roleNameOrId));
+        }
         ArrayNode filteredRoles = userData.putArray("roles");
         for (JsonNode role : existingRoles) {
             if (!idsToRemove.contains(role.get("id").asText())) {
@@ -143,6 +150,11 @@ public class SSCUserUpdateLocalCommand extends AbstractSSCJsonNodeOutputCommand 
             ids.add(role.get("id").asText());
         }
         return ids;
+    }
+
+    private String resolveRoleId(UnirestInstance unirest, String roleNameOrId) {
+        SSCRoleDescriptor descriptor = SSCRoleHelper.getRoleDescriptor(unirest, roleNameOrId, "id");
+        return descriptor.getRoleId();
     }
 
     @Override


### PR DESCRIPTION
This PR fixes SSC local user creation and update operations to support roles specified either by role ID or role name.

Previously, commands such as `fcli ssc ac create-local-user` and `ssc ac update-local-user` would fail when a role name was provided, even though the CLI help indicated that both role names and IDs were supported. The underlying SSC API accepts only role IDs, causing requests with role names to be rejected.

**Changes:**
- Added support for resolving role names to their corresponding SSC role IDs before invoking the SSC API.
- Continued support for directly specifying role IDs.
- Improved consistency between command behavior and the documented option help.

This change ensures the implementation matches the documented behaviour and provides a more user-friendly experience by allowing users to specify roles using either format.